### PR TITLE
Apply clang format to all cpp and h files

### DIFF
--- a/include/backend/estimator.h
+++ b/include/backend/estimator.h
@@ -2,6 +2,7 @@
 #define ESTIMATOR_H
 
 #include <ceres/ceres.h>
+
 #include <Eigen/Dense>
 #include <fstream>
 #include <iomanip>
@@ -23,66 +24,67 @@ namespace backend {
 
 class Estimator {
 public:
-    Estimator();
+  Estimator();
 
-    void setParameter();
+  void setParameter();
 
-    void processIMU(double dt, const Eigen::Vector3d& linear_acceleration, const Eigen::Vector3d& angular_velocity);
-    void processImage(const ImageData& image, double timestamp);
+  void processIMU(double dt, const Eigen::Vector3d& linear_acceleration,
+                  const Eigen::Vector3d& angular_velocity);
+  void processImage(const ImageData& image, double timestamp);
 
-    Matrix3d r_ic_;
-    Vector3d t_ic_;
+  Matrix3d r_ic_;
+  Vector3d t_ic_;
 
-    SlidingWindow sliding_window_;
+  SlidingWindow sliding_window_;
 
-    SolverFlag solver_flag_;
-    MarginalizationFlag marginalization_flag_;
+  SolverFlag solver_flag_;
+  MarginalizationFlag marginalization_flag_;
 
-    std::vector<Eigen::Vector3d> getSlidingWindowMapPoints() const;
+  std::vector<Eigen::Vector3d> getSlidingWindowMapPoints() const;
 
-    mutable std::mutex estimator_mutex_;
+  mutable std::mutex estimator_mutex_;
 
 private:
-    void clearState();
+  void clearState();
 
-    void slideWindow();
-    void slideWindowNewGeneralFrame();
-    void slideWindowOldKeyframe();
+  void slideWindow();
+  void slideWindowNewGeneralFrame();
+  void slideWindowOldKeyframe();
 
-    void solveOdometry();
+  void solveOdometry();
 
-    void cleanupOldImageFrames(double timestamp);
-    void cleanupPreIntegration(ImageFrame& frame);
+  void cleanupOldImageFrames(double timestamp);
+  void cleanupPreIntegration(ImageFrame& frame);
 
-    void propagateIMUState(int frame_index, double dt, const Vector3d& linear_acceleration,
-                           const Vector3d& angular_velocity);
-    void storeLastPoseInSlidingWindow();
+  void propagateIMUState(int frame_index, double dt, const Vector3d& linear_acceleration,
+                         const Vector3d& angular_velocity);
+  void storeLastPoseInSlidingWindow();
 
-    bool first_imu_;
-    bool failure_occur_;
+  bool first_imu_;
+  bool failure_occur_;
 
-    double initial_timestamp_;
-    Vector3d prev_acc_, prev_gyro_;
-    int frame_count_;
+  double initial_timestamp_;
+  Vector3d prev_acc_, prev_gyro_;
+  int frame_count_;
 
-    Vector3d g_;
+  Vector3d g_;
 
-    backend::factor::IntegrationBase* tmp_pre_integration_;
+  backend::factor::IntegrationBase* tmp_pre_integration_;
 
-    std::map<double, ImageFrame> all_image_frame_;
+  std::map<double, ImageFrame> all_image_frame_;
 
-    FeatureManager feature_manager_;
-    MotionEstimator motion_estimator_;
+  FeatureManager feature_manager_;
+  MotionEstimator motion_estimator_;
 
-    Matrix3d last_R_end_;
-    Vector3d last_P_end_;
+  Matrix3d last_R_end_;
+  Vector3d last_P_end_;
 
-    // Core components
-    Optimizer optimizer_;
-    FailureDetector failure_detector_;
-    Initializer initializer_;
+  // Core components
+  Optimizer optimizer_;
+  FailureDetector failure_detector_;
+  Initializer initializer_;
 };
 
-} // namespace backend
+}  // namespace backend
 
 #endif  // ESTIMATOR_H

--- a/include/backend/factor/imu_factor.h
+++ b/include/backend/factor/imu_factor.h
@@ -1,137 +1,148 @@
 #ifndef IMU_FACTOR_H
 #define IMU_FACTOR_H
 
+#include <ceres/ceres.h>
+
 #include <eigen3/Eigen/Dense>
 #include <iostream>
 
-#include "utility/utility.h"
-#include "utility/config.h"
 #include "integration_base.h"
-
-#include <ceres/ceres.h>
+#include "utility/config.h"
+#include "utility/utility.h"
 
 namespace backend {
 namespace factor {
 
 class IMUFactor : public ceres::SizedCostFunction<15, 7, 9, 7, 9> {
-  public:
-    IMUFactor() = delete;
-    IMUFactor(IntegrationBase *_pre_integration) : pre_integration(_pre_integration) {}
-    virtual bool Evaluate(double const *const *parameters, double *residuals, double **jacobians) const {
-        Eigen::Vector3d Pi(parameters[0][0], parameters[0][1], parameters[0][2]);
-        Eigen::Quaterniond Qi(parameters[0][6], parameters[0][3], parameters[0][4], parameters[0][5]);
+public:
+  IMUFactor() = delete;
+  IMUFactor(IntegrationBase *_pre_integration) : pre_integration(_pre_integration) {}
+  virtual bool Evaluate(double const *const *parameters, double *residuals,
+                        double **jacobians) const {
+    Eigen::Vector3d Pi(parameters[0][0], parameters[0][1], parameters[0][2]);
+    Eigen::Quaterniond Qi(parameters[0][6], parameters[0][3], parameters[0][4], parameters[0][5]);
 
-        Eigen::Vector3d Vi(parameters[1][0], parameters[1][1], parameters[1][2]);
-        Eigen::Vector3d Bai(parameters[1][3], parameters[1][4], parameters[1][5]);
-        Eigen::Vector3d Bgi(parameters[1][6], parameters[1][7], parameters[1][8]);
+    Eigen::Vector3d Vi(parameters[1][0], parameters[1][1], parameters[1][2]);
+    Eigen::Vector3d Bai(parameters[1][3], parameters[1][4], parameters[1][5]);
+    Eigen::Vector3d Bgi(parameters[1][6], parameters[1][7], parameters[1][8]);
 
-        Eigen::Vector3d Pj(parameters[2][0], parameters[2][1], parameters[2][2]);
-        Eigen::Quaterniond Qj(parameters[2][6], parameters[2][3], parameters[2][4], parameters[2][5]);
+    Eigen::Vector3d Pj(parameters[2][0], parameters[2][1], parameters[2][2]);
+    Eigen::Quaterniond Qj(parameters[2][6], parameters[2][3], parameters[2][4], parameters[2][5]);
 
-        Eigen::Vector3d Vj(parameters[3][0], parameters[3][1], parameters[3][2]);
-        Eigen::Vector3d Baj(parameters[3][3], parameters[3][4], parameters[3][5]);
-        Eigen::Vector3d Bgj(parameters[3][6], parameters[3][7], parameters[3][8]);
+    Eigen::Vector3d Vj(parameters[3][0], parameters[3][1], parameters[3][2]);
+    Eigen::Vector3d Baj(parameters[3][3], parameters[3][4], parameters[3][5]);
+    Eigen::Vector3d Bgj(parameters[3][6], parameters[3][7], parameters[3][8]);
 
-        Eigen::Map<Eigen::Matrix<double, 15, 1>> residual(residuals);
-        residual = pre_integration->evaluate(Pi, Qi, Vi, Bai, Bgi, Pj, Qj, Vj, Baj, Bgj);
+    Eigen::Map<Eigen::Matrix<double, 15, 1>> residual(residuals);
+    residual = pre_integration->evaluate(Pi, Qi, Vi, Bai, Bgi, Pj, Qj, Vj, Baj, Bgj);
 
-        Eigen::Matrix<double, 15, 15> sqrt_info =
-            Eigen::LLT<Eigen::Matrix<double, 15, 15>>(pre_integration->covariance.inverse()).matrixL().transpose();
+    Eigen::Matrix<double, 15, 15> sqrt_info =
+        Eigen::LLT<Eigen::Matrix<double, 15, 15>>(pre_integration->covariance.inverse())
+            .matrixL()
+            .transpose();
 
-        residual = sqrt_info * residual;
+    residual = sqrt_info * residual;
 
-        if (jacobians) {
-            double sum_dt = pre_integration->sum_dt;
-            Eigen::Matrix3d dp_dba = pre_integration->jacobian.template block<3, 3>(O_P, O_BA);
-            Eigen::Matrix3d dp_dbg = pre_integration->jacobian.template block<3, 3>(O_P, O_BG);
+    if (jacobians) {
+      double sum_dt = pre_integration->sum_dt;
+      Eigen::Matrix3d dp_dba = pre_integration->jacobian.template block<3, 3>(O_P, O_BA);
+      Eigen::Matrix3d dp_dbg = pre_integration->jacobian.template block<3, 3>(O_P, O_BG);
 
-            Eigen::Matrix3d dq_dbg = pre_integration->jacobian.template block<3, 3>(O_R, O_BG);
+      Eigen::Matrix3d dq_dbg = pre_integration->jacobian.template block<3, 3>(O_R, O_BG);
 
-            Eigen::Matrix3d dv_dba = pre_integration->jacobian.template block<3, 3>(O_V, O_BA);
-            Eigen::Matrix3d dv_dbg = pre_integration->jacobian.template block<3, 3>(O_V, O_BG);
+      Eigen::Matrix3d dv_dba = pre_integration->jacobian.template block<3, 3>(O_V, O_BA);
+      Eigen::Matrix3d dv_dbg = pre_integration->jacobian.template block<3, 3>(O_V, O_BG);
 
-            if (pre_integration->jacobian.maxCoeff() > 1e8 || pre_integration->jacobian.minCoeff() < -1e8) {
-                std::cout << "numerical unstable in preintegration" << std::endl;
-            }
+      if (pre_integration->jacobian.maxCoeff() > 1e8 ||
+          pre_integration->jacobian.minCoeff() < -1e8) {
+        std::cout << "numerical unstable in preintegration" << std::endl;
+      }
 
-            if (jacobians[0]) {
-                Eigen::Map<Eigen::Matrix<double, 15, 7, Eigen::RowMajor>> jacobian_pose_i(jacobians[0]);
-                jacobian_pose_i.setZero();
+      if (jacobians[0]) {
+        Eigen::Map<Eigen::Matrix<double, 15, 7, Eigen::RowMajor>> jacobian_pose_i(jacobians[0]);
+        jacobian_pose_i.setZero();
 
-                jacobian_pose_i.block<3, 3>(O_P, O_P) = -Qi.inverse().toRotationMatrix();
-                jacobian_pose_i.block<3, 3>(O_P, O_R) =
-                    Utility::skewSymmetric(Qi.inverse() * (0.5 * g_config.estimator.g * sum_dt * sum_dt + Pj - Pi - Vi * sum_dt));
+        jacobian_pose_i.block<3, 3>(O_P, O_P) = -Qi.inverse().toRotationMatrix();
+        jacobian_pose_i.block<3, 3>(O_P, O_R) = Utility::skewSymmetric(
+            Qi.inverse() * (0.5 * g_config.estimator.g * sum_dt * sum_dt + Pj - Pi - Vi * sum_dt));
 
-                Eigen::Quaterniond corrected_delta_q =
-                    pre_integration->delta_q * Utility::deltaQ(dq_dbg * (Bgi - pre_integration->linearized_bg));
-                jacobian_pose_i.block<3, 3>(O_R, O_R) =
-                    -(Utility::Qleft(Qj.inverse() * Qi) * Utility::Qright(corrected_delta_q)).bottomRightCorner<3, 3>();
+        Eigen::Quaterniond corrected_delta_q =
+            pre_integration->delta_q *
+            Utility::deltaQ(dq_dbg * (Bgi - pre_integration->linearized_bg));
+        jacobian_pose_i.block<3, 3>(O_R, O_R) =
+            -(Utility::Qleft(Qj.inverse() * Qi) * Utility::Qright(corrected_delta_q))
+                 .bottomRightCorner<3, 3>();
 
-                jacobian_pose_i.block<3, 3>(O_V, O_R) = Utility::skewSymmetric(Qi.inverse() * (g_config.estimator.g * sum_dt + Vj - Vi));
+        jacobian_pose_i.block<3, 3>(O_V, O_R) =
+            Utility::skewSymmetric(Qi.inverse() * (g_config.estimator.g * sum_dt + Vj - Vi));
 
-                jacobian_pose_i = sqrt_info * jacobian_pose_i;
+        jacobian_pose_i = sqrt_info * jacobian_pose_i;
 
-                if (jacobian_pose_i.maxCoeff() > 1e8 || jacobian_pose_i.minCoeff() < -1e8) {
-                    std::cout << "numerical unstable in preintegration" << std::endl;
-                }
-            }
-            if (jacobians[1]) {
-                Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor>> jacobian_speedbias_i(jacobians[1]);
-                jacobian_speedbias_i.setZero();
-                jacobian_speedbias_i.block<3, 3>(O_P, O_V - O_V) = -Qi.inverse().toRotationMatrix() * sum_dt;
-                jacobian_speedbias_i.block<3, 3>(O_P, O_BA - O_V) = -dp_dba;
-                jacobian_speedbias_i.block<3, 3>(O_P, O_BG - O_V) = -dp_dbg;
-
-                jacobian_speedbias_i.block<3, 3>(O_R, O_BG - O_V) =
-                    -Utility::Qleft(Qj.inverse() * Qi * pre_integration->delta_q).bottomRightCorner<3, 3>() * dq_dbg;
-
-                jacobian_speedbias_i.block<3, 3>(O_V, O_V - O_V) = -Qi.inverse().toRotationMatrix();
-                jacobian_speedbias_i.block<3, 3>(O_V, O_BA - O_V) = -dv_dba;
-                jacobian_speedbias_i.block<3, 3>(O_V, O_BG - O_V) = -dv_dbg;
-
-                jacobian_speedbias_i.block<3, 3>(O_BA, O_BA - O_V) = -Eigen::Matrix3d::Identity();
-
-                jacobian_speedbias_i.block<3, 3>(O_BG, O_BG - O_V) = -Eigen::Matrix3d::Identity();
-
-                jacobian_speedbias_i = sqrt_info * jacobian_speedbias_i;
-
-            }
-            if (jacobians[2]) {
-                Eigen::Map<Eigen::Matrix<double, 15, 7, Eigen::RowMajor>> jacobian_pose_j(jacobians[2]);
-                jacobian_pose_j.setZero();
-
-                jacobian_pose_j.block<3, 3>(O_P, O_P) = Qi.inverse().toRotationMatrix();
-
-                Eigen::Quaterniond corrected_delta_q =
-                    pre_integration->delta_q * Utility::deltaQ(dq_dbg * (Bgi - pre_integration->linearized_bg));
-                jacobian_pose_j.block<3, 3>(O_R, O_R) =
-                    Utility::Qleft(corrected_delta_q.inverse() * Qi.inverse() * Qj).bottomRightCorner<3, 3>();
-
-                jacobian_pose_j = sqrt_info * jacobian_pose_j;
-
-            }
-            if (jacobians[3]) {
-                Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor>> jacobian_speedbias_j(jacobians[3]);
-                jacobian_speedbias_j.setZero();
-
-                jacobian_speedbias_j.block<3, 3>(O_V, O_V - O_V) = Qi.inverse().toRotationMatrix();
-
-                jacobian_speedbias_j.block<3, 3>(O_BA, O_BA - O_V) = Eigen::Matrix3d::Identity();
-
-                jacobian_speedbias_j.block<3, 3>(O_BG, O_BG - O_V) = Eigen::Matrix3d::Identity();
-
-                jacobian_speedbias_j = sqrt_info * jacobian_speedbias_j;
-
-            }
+        if (jacobian_pose_i.maxCoeff() > 1e8 || jacobian_pose_i.minCoeff() < -1e8) {
+          std::cout << "numerical unstable in preintegration" << std::endl;
         }
+      }
+      if (jacobians[1]) {
+        Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor>> jacobian_speedbias_i(
+            jacobians[1]);
+        jacobian_speedbias_i.setZero();
+        jacobian_speedbias_i.block<3, 3>(O_P, O_V - O_V) =
+            -Qi.inverse().toRotationMatrix() * sum_dt;
+        jacobian_speedbias_i.block<3, 3>(O_P, O_BA - O_V) = -dp_dba;
+        jacobian_speedbias_i.block<3, 3>(O_P, O_BG - O_V) = -dp_dbg;
 
-        return true;
+        jacobian_speedbias_i.block<3, 3>(O_R, O_BG - O_V) =
+            -Utility::Qleft(Qj.inverse() * Qi * pre_integration->delta_q)
+                 .bottomRightCorner<3, 3>() *
+            dq_dbg;
+
+        jacobian_speedbias_i.block<3, 3>(O_V, O_V - O_V) = -Qi.inverse().toRotationMatrix();
+        jacobian_speedbias_i.block<3, 3>(O_V, O_BA - O_V) = -dv_dba;
+        jacobian_speedbias_i.block<3, 3>(O_V, O_BG - O_V) = -dv_dbg;
+
+        jacobian_speedbias_i.block<3, 3>(O_BA, O_BA - O_V) = -Eigen::Matrix3d::Identity();
+
+        jacobian_speedbias_i.block<3, 3>(O_BG, O_BG - O_V) = -Eigen::Matrix3d::Identity();
+
+        jacobian_speedbias_i = sqrt_info * jacobian_speedbias_i;
+      }
+      if (jacobians[2]) {
+        Eigen::Map<Eigen::Matrix<double, 15, 7, Eigen::RowMajor>> jacobian_pose_j(jacobians[2]);
+        jacobian_pose_j.setZero();
+
+        jacobian_pose_j.block<3, 3>(O_P, O_P) = Qi.inverse().toRotationMatrix();
+
+        Eigen::Quaterniond corrected_delta_q =
+            pre_integration->delta_q *
+            Utility::deltaQ(dq_dbg * (Bgi - pre_integration->linearized_bg));
+        jacobian_pose_j.block<3, 3>(O_R, O_R) =
+            Utility::Qleft(corrected_delta_q.inverse() * Qi.inverse() * Qj)
+                .bottomRightCorner<3, 3>();
+
+        jacobian_pose_j = sqrt_info * jacobian_pose_j;
+      }
+      if (jacobians[3]) {
+        Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor>> jacobian_speedbias_j(
+            jacobians[3]);
+        jacobian_speedbias_j.setZero();
+
+        jacobian_speedbias_j.block<3, 3>(O_V, O_V - O_V) = Qi.inverse().toRotationMatrix();
+
+        jacobian_speedbias_j.block<3, 3>(O_BA, O_BA - O_V) = Eigen::Matrix3d::Identity();
+
+        jacobian_speedbias_j.block<3, 3>(O_BG, O_BG - O_V) = Eigen::Matrix3d::Identity();
+
+        jacobian_speedbias_j = sqrt_info * jacobian_speedbias_j;
+      }
     }
 
-    IntegrationBase *pre_integration;
+    return true;
+  }
+
+  IntegrationBase *pre_integration;
 };
 
-} // namespace factor
-} // namespace backend
+}  // namespace factor
+}  // namespace backend
 
-#endif // IMU_FACTOR_H
+#endif  // IMU_FACTOR_H

--- a/include/backend/factor/integration_base.h
+++ b/include/backend/factor/integration_base.h
@@ -4,8 +4,8 @@
 #include <eigen3/Eigen/Dense>
 #include <iostream>
 
-#include "utility/utility.h"
 #include "utility/config.h"
+#include "utility/utility.h"
 
 using namespace Eigen;
 using namespace utility;
@@ -14,197 +14,218 @@ namespace backend {
 namespace factor {
 
 class IntegrationBase {
-  public:
-    IntegrationBase() = delete;
-    IntegrationBase(const Eigen::Vector3d &_acc_0, const Eigen::Vector3d &_gyr_0, const Eigen::Vector3d &_linearized_ba,
-                    const Eigen::Vector3d &_linearized_bg)
-        : acc_0{_acc_0}, gyr_0{_gyr_0}, linearized_acc{_acc_0}, linearized_gyr{_gyr_0}, linearized_ba{_linearized_ba},
-          linearized_bg{_linearized_bg}, jacobian{Eigen::Matrix<double, 15, 15>::Identity()},
-          covariance{Eigen::Matrix<double, 15, 15>::Zero()}, sum_dt{0.0}, delta_p{Eigen::Vector3d::Zero()},
-          delta_q{Eigen::Quaterniond::Identity()}, delta_v{Eigen::Vector3d::Zero()}
+public:
+  IntegrationBase() = delete;
+  IntegrationBase(const Eigen::Vector3d &_acc_0, const Eigen::Vector3d &_gyr_0,
+                  const Eigen::Vector3d &_linearized_ba, const Eigen::Vector3d &_linearized_bg)
+      : acc_0{_acc_0},
+        gyr_0{_gyr_0},
+        linearized_acc{_acc_0},
+        linearized_gyr{_gyr_0},
+        linearized_ba{_linearized_ba},
+        linearized_bg{_linearized_bg},
+        jacobian{Eigen::Matrix<double, 15, 15>::Identity()},
+        covariance{Eigen::Matrix<double, 15, 15>::Zero()},
+        sum_dt{0.0},
+        delta_p{Eigen::Vector3d::Zero()},
+        delta_q{Eigen::Quaterniond::Identity()},
+        delta_v{Eigen::Vector3d::Zero()}
 
-    {
-        noise = Eigen::Matrix<double, 18, 18>::Zero();
-        noise.block<3, 3>(0, 0) = (g_config.estimator.acc_n * g_config.estimator.acc_n) * Eigen::Matrix3d::Identity();
-        noise.block<3, 3>(3, 3) = (g_config.estimator.gyr_n * g_config.estimator.gyr_n) * Eigen::Matrix3d::Identity();
-        noise.block<3, 3>(6, 6) = (g_config.estimator.acc_n * g_config.estimator.acc_n) * Eigen::Matrix3d::Identity();
-        noise.block<3, 3>(9, 9) = (g_config.estimator.gyr_n * g_config.estimator.gyr_n) * Eigen::Matrix3d::Identity();
-        noise.block<3, 3>(12, 12) = (g_config.estimator.acc_w * g_config.estimator.acc_w) * Eigen::Matrix3d::Identity();
-        noise.block<3, 3>(15, 15) = (g_config.estimator.gyr_w * g_config.estimator.gyr_w) * Eigen::Matrix3d::Identity();
+  {
+    noise = Eigen::Matrix<double, 18, 18>::Zero();
+    noise.block<3, 3>(0, 0) =
+        (g_config.estimator.acc_n * g_config.estimator.acc_n) * Eigen::Matrix3d::Identity();
+    noise.block<3, 3>(3, 3) =
+        (g_config.estimator.gyr_n * g_config.estimator.gyr_n) * Eigen::Matrix3d::Identity();
+    noise.block<3, 3>(6, 6) =
+        (g_config.estimator.acc_n * g_config.estimator.acc_n) * Eigen::Matrix3d::Identity();
+    noise.block<3, 3>(9, 9) =
+        (g_config.estimator.gyr_n * g_config.estimator.gyr_n) * Eigen::Matrix3d::Identity();
+    noise.block<3, 3>(12, 12) =
+        (g_config.estimator.acc_w * g_config.estimator.acc_w) * Eigen::Matrix3d::Identity();
+    noise.block<3, 3>(15, 15) =
+        (g_config.estimator.gyr_w * g_config.estimator.gyr_w) * Eigen::Matrix3d::Identity();
+  }
+
+  void push_back(double dt, const Eigen::Vector3d &acc, const Eigen::Vector3d &gyr) {
+    dt_buf.push_back(dt);
+    acc_buf.push_back(acc);
+    gyr_buf.push_back(gyr);
+    propagate(dt, acc, gyr);
+  }
+
+  void repropagate(const Eigen::Vector3d &_linearized_ba, const Eigen::Vector3d &_linearized_bg) {
+    sum_dt = 0.0;
+    acc_0 = linearized_acc;
+    gyr_0 = linearized_gyr;
+    delta_p.setZero();
+    delta_q.setIdentity();
+    delta_v.setZero();
+    linearized_ba = _linearized_ba;
+    linearized_bg = _linearized_bg;
+    jacobian.setIdentity();
+    covariance.setZero();
+    for (int i = 0; i < static_cast<int>(dt_buf.size()); i++)
+      propagate(dt_buf[i], acc_buf[i], gyr_buf[i]);
+  }
+
+  void midPointIntegration(double _dt, const Eigen::Vector3d &_acc_0, const Eigen::Vector3d &_gyr_0,
+                           const Eigen::Vector3d &_acc_1, const Eigen::Vector3d &_gyr_1,
+                           const Eigen::Vector3d &delta_p, const Eigen::Quaterniond &delta_q,
+                           const Eigen::Vector3d &delta_v, const Eigen::Vector3d &linearized_ba,
+                           const Eigen::Vector3d &linearized_bg, Eigen::Vector3d &result_delta_p,
+                           Eigen::Quaterniond &result_delta_q, Eigen::Vector3d &result_delta_v,
+                           Eigen::Vector3d &result_linearized_ba,
+                           Eigen::Vector3d &result_linearized_bg, bool update_jacobian) {
+    // ROS_INFO("midpoint integration");
+    Vector3d un_acc_0 = delta_q * (_acc_0 - linearized_ba);
+    Vector3d un_gyr = 0.5 * (_gyr_0 + _gyr_1) - linearized_bg;
+    result_delta_q =
+        delta_q * Quaterniond(1, un_gyr(0) * _dt / 2, un_gyr(1) * _dt / 2, un_gyr(2) * _dt / 2);
+    Vector3d un_acc_1 = result_delta_q * (_acc_1 - linearized_ba);
+    Vector3d un_acc = 0.5 * (un_acc_0 + un_acc_1);
+    result_delta_p = delta_p + delta_v * _dt + 0.5 * un_acc * _dt * _dt;
+    result_delta_v = delta_v + un_acc * _dt;
+    result_linearized_ba = linearized_ba;
+    result_linearized_bg = linearized_bg;
+
+    if (update_jacobian) {
+      Vector3d w_x = 0.5 * (_gyr_0 + _gyr_1) - linearized_bg;
+      Vector3d a_0_x = _acc_0 - linearized_ba;
+      Vector3d a_1_x = _acc_1 - linearized_ba;
+      Matrix3d R_w_x, R_a_0_x, R_a_1_x;
+
+      R_w_x << 0, -w_x(2), w_x(1), w_x(2), 0, -w_x(0), -w_x(1), w_x(0), 0;
+      R_a_0_x << 0, -a_0_x(2), a_0_x(1), a_0_x(2), 0, -a_0_x(0), -a_0_x(1), a_0_x(0), 0;
+      R_a_1_x << 0, -a_1_x(2), a_1_x(1), a_1_x(2), 0, -a_1_x(0), -a_1_x(1), a_1_x(0), 0;
+
+      MatrixXd F = MatrixXd::Zero(15, 15);
+      F.block<3, 3>(0, 0) = Matrix3d::Identity();
+      F.block<3, 3>(0, 3) = -0.25 * delta_q.toRotationMatrix() * R_a_0_x * _dt * _dt +
+                            -0.25 * result_delta_q.toRotationMatrix() * R_a_1_x *
+                                (Matrix3d::Identity() - R_w_x * _dt) * _dt * _dt;
+      F.block<3, 3>(0, 6) = MatrixXd::Identity(3, 3) * _dt;
+      F.block<3, 3>(0, 9) =
+          -0.25 * (delta_q.toRotationMatrix() + result_delta_q.toRotationMatrix()) * _dt * _dt;
+      F.block<3, 3>(0, 12) = -0.25 * result_delta_q.toRotationMatrix() * R_a_1_x * _dt * _dt * -_dt;
+      F.block<3, 3>(3, 3) = Matrix3d::Identity() - R_w_x * _dt;
+      F.block<3, 3>(3, 12) = -1.0 * MatrixXd::Identity(3, 3) * _dt;
+      F.block<3, 3>(6, 3) = -0.5 * delta_q.toRotationMatrix() * R_a_0_x * _dt +
+                            -0.5 * result_delta_q.toRotationMatrix() * R_a_1_x *
+                                (Matrix3d::Identity() - R_w_x * _dt) * _dt;
+      F.block<3, 3>(6, 6) = Matrix3d::Identity();
+      F.block<3, 3>(6, 9) =
+          -0.5 * (delta_q.toRotationMatrix() + result_delta_q.toRotationMatrix()) * _dt;
+      F.block<3, 3>(6, 12) = -0.5 * result_delta_q.toRotationMatrix() * R_a_1_x * _dt * -_dt;
+      F.block<3, 3>(9, 9) = Matrix3d::Identity();
+      F.block<3, 3>(12, 12) = Matrix3d::Identity();
+      // cout<<"A"<<endl<<A<<endl;
+
+      MatrixXd V = MatrixXd::Zero(15, 18);
+      V.block<3, 3>(0, 0) = 0.25 * delta_q.toRotationMatrix() * _dt * _dt;
+      V.block<3, 3>(0, 3) =
+          0.25 * -result_delta_q.toRotationMatrix() * R_a_1_x * _dt * _dt * 0.5 * _dt;
+      V.block<3, 3>(0, 6) = 0.25 * result_delta_q.toRotationMatrix() * _dt * _dt;
+      V.block<3, 3>(0, 9) = V.block<3, 3>(0, 3);
+      V.block<3, 3>(3, 3) = 0.5 * MatrixXd::Identity(3, 3) * _dt;
+      V.block<3, 3>(3, 9) = 0.5 * MatrixXd::Identity(3, 3) * _dt;
+      V.block<3, 3>(6, 0) = 0.5 * delta_q.toRotationMatrix() * _dt;
+      V.block<3, 3>(6, 3) = 0.5 * -result_delta_q.toRotationMatrix() * R_a_1_x * _dt * 0.5 * _dt;
+      V.block<3, 3>(6, 6) = 0.5 * result_delta_q.toRotationMatrix() * _dt;
+      V.block<3, 3>(6, 9) = V.block<3, 3>(6, 3);
+      V.block<3, 3>(9, 12) = MatrixXd::Identity(3, 3) * _dt;
+      V.block<3, 3>(12, 15) = MatrixXd::Identity(3, 3) * _dt;
+
+      // step_jacobian = F;
+      // step_V = V;
+      jacobian = F * jacobian;
+      covariance = F * covariance * F.transpose() + V * noise * V.transpose();
     }
+  }
 
-    void push_back(double dt, const Eigen::Vector3d &acc, const Eigen::Vector3d &gyr) {
-        dt_buf.push_back(dt);
-        acc_buf.push_back(acc);
-        gyr_buf.push_back(gyr);
-        propagate(dt, acc, gyr);
-    }
+  void propagate(double _dt, const Eigen::Vector3d &_acc_1, const Eigen::Vector3d &_gyr_1) {
+    dt = _dt;
+    acc_1 = _acc_1;
+    gyr_1 = _gyr_1;
+    Vector3d result_delta_p;
+    Quaterniond result_delta_q;
+    Vector3d result_delta_v;
+    Vector3d result_linearized_ba;
+    Vector3d result_linearized_bg;
 
-    void repropagate(const Eigen::Vector3d &_linearized_ba, const Eigen::Vector3d &_linearized_bg) {
-        sum_dt = 0.0;
-        acc_0 = linearized_acc;
-        gyr_0 = linearized_gyr;
-        delta_p.setZero();
-        delta_q.setIdentity();
-        delta_v.setZero();
-        linearized_ba = _linearized_ba;
-        linearized_bg = _linearized_bg;
-        jacobian.setIdentity();
-        covariance.setZero();
-        for (int i = 0; i < static_cast<int>(dt_buf.size()); i++)
-            propagate(dt_buf[i], acc_buf[i], gyr_buf[i]);
-    }
+    midPointIntegration(_dt, acc_0, gyr_0, _acc_1, _gyr_1, delta_p, delta_q, delta_v, linearized_ba,
+                        linearized_bg, result_delta_p, result_delta_q, result_delta_v,
+                        result_linearized_ba, result_linearized_bg, 1);
 
-    void midPointIntegration(double _dt, const Eigen::Vector3d &_acc_0, const Eigen::Vector3d &_gyr_0,
-                             const Eigen::Vector3d &_acc_1, const Eigen::Vector3d &_gyr_1,
-                             const Eigen::Vector3d &delta_p, const Eigen::Quaterniond &delta_q,
-                             const Eigen::Vector3d &delta_v, const Eigen::Vector3d &linearized_ba,
-                             const Eigen::Vector3d &linearized_bg, Eigen::Vector3d &result_delta_p,
-                             Eigen::Quaterniond &result_delta_q, Eigen::Vector3d &result_delta_v,
-                             Eigen::Vector3d &result_linearized_ba, Eigen::Vector3d &result_linearized_bg,
-                             bool update_jacobian) {
-        // ROS_INFO("midpoint integration");
-        Vector3d un_acc_0 = delta_q * (_acc_0 - linearized_ba);
-        Vector3d un_gyr = 0.5 * (_gyr_0 + _gyr_1) - linearized_bg;
-        result_delta_q = delta_q * Quaterniond(1, un_gyr(0) * _dt / 2, un_gyr(1) * _dt / 2, un_gyr(2) * _dt / 2);
-        Vector3d un_acc_1 = result_delta_q * (_acc_1 - linearized_ba);
-        Vector3d un_acc = 0.5 * (un_acc_0 + un_acc_1);
-        result_delta_p = delta_p + delta_v * _dt + 0.5 * un_acc * _dt * _dt;
-        result_delta_v = delta_v + un_acc * _dt;
-        result_linearized_ba = linearized_ba;
-        result_linearized_bg = linearized_bg;
+    // checkJacobian(_dt, acc_0, gyr_0, acc_1, gyr_1, delta_p, delta_q, delta_v,
+    //                    linearized_ba, linearized_bg);
+    delta_p = result_delta_p;
+    delta_q = result_delta_q;
+    delta_v = result_delta_v;
+    linearized_ba = result_linearized_ba;
+    linearized_bg = result_linearized_bg;
+    delta_q.normalize();
+    sum_dt += dt;
+    acc_0 = acc_1;
+    gyr_0 = gyr_1;
+  }
 
-        if (update_jacobian) {
-            Vector3d w_x = 0.5 * (_gyr_0 + _gyr_1) - linearized_bg;
-            Vector3d a_0_x = _acc_0 - linearized_ba;
-            Vector3d a_1_x = _acc_1 - linearized_ba;
-            Matrix3d R_w_x, R_a_0_x, R_a_1_x;
+  Eigen::Matrix<double, 15, 1> evaluate(const Eigen::Vector3d &Pi, const Eigen::Quaterniond &Qi,
+                                        const Eigen::Vector3d &Vi, const Eigen::Vector3d &Bai,
+                                        const Eigen::Vector3d &Bgi, const Eigen::Vector3d &Pj,
+                                        const Eigen::Quaterniond &Qj, const Eigen::Vector3d &Vj,
+                                        const Eigen::Vector3d &Baj, const Eigen::Vector3d &Bgj) {
+    Eigen::Matrix<double, 15, 1> residuals;
 
-            R_w_x << 0, -w_x(2), w_x(1), w_x(2), 0, -w_x(0), -w_x(1), w_x(0), 0;
-            R_a_0_x << 0, -a_0_x(2), a_0_x(1), a_0_x(2), 0, -a_0_x(0), -a_0_x(1), a_0_x(0), 0;
-            R_a_1_x << 0, -a_1_x(2), a_1_x(1), a_1_x(2), 0, -a_1_x(0), -a_1_x(1), a_1_x(0), 0;
+    Eigen::Matrix3d dp_dba = jacobian.block<3, 3>(O_P, O_BA);
+    Eigen::Matrix3d dp_dbg = jacobian.block<3, 3>(O_P, O_BG);
 
-            MatrixXd F = MatrixXd::Zero(15, 15);
-            F.block<3, 3>(0, 0) = Matrix3d::Identity();
-            F.block<3, 3>(0, 3) =
-                -0.25 * delta_q.toRotationMatrix() * R_a_0_x * _dt * _dt +
-                -0.25 * result_delta_q.toRotationMatrix() * R_a_1_x * (Matrix3d::Identity() - R_w_x * _dt) * _dt * _dt;
-            F.block<3, 3>(0, 6) = MatrixXd::Identity(3, 3) * _dt;
-            F.block<3, 3>(0, 9) = -0.25 * (delta_q.toRotationMatrix() + result_delta_q.toRotationMatrix()) * _dt * _dt;
-            F.block<3, 3>(0, 12) = -0.25 * result_delta_q.toRotationMatrix() * R_a_1_x * _dt * _dt * -_dt;
-            F.block<3, 3>(3, 3) = Matrix3d::Identity() - R_w_x * _dt;
-            F.block<3, 3>(3, 12) = -1.0 * MatrixXd::Identity(3, 3) * _dt;
-            F.block<3, 3>(6, 3) =
-                -0.5 * delta_q.toRotationMatrix() * R_a_0_x * _dt +
-                -0.5 * result_delta_q.toRotationMatrix() * R_a_1_x * (Matrix3d::Identity() - R_w_x * _dt) * _dt;
-            F.block<3, 3>(6, 6) = Matrix3d::Identity();
-            F.block<3, 3>(6, 9) = -0.5 * (delta_q.toRotationMatrix() + result_delta_q.toRotationMatrix()) * _dt;
-            F.block<3, 3>(6, 12) = -0.5 * result_delta_q.toRotationMatrix() * R_a_1_x * _dt * -_dt;
-            F.block<3, 3>(9, 9) = Matrix3d::Identity();
-            F.block<3, 3>(12, 12) = Matrix3d::Identity();
-            // cout<<"A"<<endl<<A<<endl;
+    Eigen::Matrix3d dq_dbg = jacobian.block<3, 3>(O_R, O_BG);
 
-            MatrixXd V = MatrixXd::Zero(15, 18);
-            V.block<3, 3>(0, 0) = 0.25 * delta_q.toRotationMatrix() * _dt * _dt;
-            V.block<3, 3>(0, 3) = 0.25 * -result_delta_q.toRotationMatrix() * R_a_1_x * _dt * _dt * 0.5 * _dt;
-            V.block<3, 3>(0, 6) = 0.25 * result_delta_q.toRotationMatrix() * _dt * _dt;
-            V.block<3, 3>(0, 9) = V.block<3, 3>(0, 3);
-            V.block<3, 3>(3, 3) = 0.5 * MatrixXd::Identity(3, 3) * _dt;
-            V.block<3, 3>(3, 9) = 0.5 * MatrixXd::Identity(3, 3) * _dt;
-            V.block<3, 3>(6, 0) = 0.5 * delta_q.toRotationMatrix() * _dt;
-            V.block<3, 3>(6, 3) = 0.5 * -result_delta_q.toRotationMatrix() * R_a_1_x * _dt * 0.5 * _dt;
-            V.block<3, 3>(6, 6) = 0.5 * result_delta_q.toRotationMatrix() * _dt;
-            V.block<3, 3>(6, 9) = V.block<3, 3>(6, 3);
-            V.block<3, 3>(9, 12) = MatrixXd::Identity(3, 3) * _dt;
-            V.block<3, 3>(12, 15) = MatrixXd::Identity(3, 3) * _dt;
+    Eigen::Matrix3d dv_dba = jacobian.block<3, 3>(O_V, O_BA);
+    Eigen::Matrix3d dv_dbg = jacobian.block<3, 3>(O_V, O_BG);
 
-            // step_jacobian = F;
-            // step_V = V;
-            jacobian = F * jacobian;
-            covariance = F * covariance * F.transpose() + V * noise * V.transpose();
-        }
-    }
+    Eigen::Vector3d dba = Bai - linearized_ba;
+    Eigen::Vector3d dbg = Bgi - linearized_bg;
 
-    void propagate(double _dt, const Eigen::Vector3d &_acc_1, const Eigen::Vector3d &_gyr_1) {
-        dt = _dt;
-        acc_1 = _acc_1;
-        gyr_1 = _gyr_1;
-        Vector3d result_delta_p;
-        Quaterniond result_delta_q;
-        Vector3d result_delta_v;
-        Vector3d result_linearized_ba;
-        Vector3d result_linearized_bg;
+    Eigen::Quaterniond corrected_delta_q = delta_q * Utility::deltaQ(dq_dbg * dbg);
+    Eigen::Vector3d corrected_delta_v = delta_v + dv_dba * dba + dv_dbg * dbg;
+    Eigen::Vector3d corrected_delta_p = delta_p + dp_dba * dba + dp_dbg * dbg;
 
-        midPointIntegration(_dt, acc_0, gyr_0, _acc_1, _gyr_1, delta_p, delta_q, delta_v, linearized_ba, linearized_bg,
-                            result_delta_p, result_delta_q, result_delta_v, result_linearized_ba, result_linearized_bg,
-                            1);
+    residuals.block<3, 1>(O_P, 0) =
+        Qi.inverse() * (0.5 * g_config.estimator.g * sum_dt * sum_dt + Pj - Pi - Vi * sum_dt) -
+        corrected_delta_p;
+    residuals.block<3, 1>(O_R, 0) = 2 * (corrected_delta_q.inverse() * (Qi.inverse() * Qj)).vec();
+    residuals.block<3, 1>(O_V, 0) =
+        Qi.inverse() * (g_config.estimator.g * sum_dt + Vj - Vi) - corrected_delta_v;
+    residuals.block<3, 1>(O_BA, 0) = Baj - Bai;
+    residuals.block<3, 1>(O_BG, 0) = Bgj - Bgi;
+    return residuals;
+  }
 
-        // checkJacobian(_dt, acc_0, gyr_0, acc_1, gyr_1, delta_p, delta_q, delta_v,
-        //                    linearized_ba, linearized_bg);
-        delta_p = result_delta_p;
-        delta_q = result_delta_q;
-        delta_v = result_delta_v;
-        linearized_ba = result_linearized_ba;
-        linearized_bg = result_linearized_bg;
-        delta_q.normalize();
-        sum_dt += dt;
-        acc_0 = acc_1;
-        gyr_0 = gyr_1;
-    }
+  double dt;
+  Eigen::Vector3d acc_0, gyr_0;
+  Eigen::Vector3d acc_1, gyr_1;
 
-    Eigen::Matrix<double, 15, 1> evaluate(const Eigen::Vector3d &Pi, const Eigen::Quaterniond &Qi,
-                                          const Eigen::Vector3d &Vi, const Eigen::Vector3d &Bai,
-                                          const Eigen::Vector3d &Bgi, const Eigen::Vector3d &Pj,
-                                          const Eigen::Quaterniond &Qj, const Eigen::Vector3d &Vj,
-                                          const Eigen::Vector3d &Baj, const Eigen::Vector3d &Bgj) {
-        Eigen::Matrix<double, 15, 1> residuals;
+  const Eigen::Vector3d linearized_acc, linearized_gyr;
+  Eigen::Vector3d linearized_ba, linearized_bg;
 
-        Eigen::Matrix3d dp_dba = jacobian.block<3, 3>(O_P, O_BA);
-        Eigen::Matrix3d dp_dbg = jacobian.block<3, 3>(O_P, O_BG);
+  Eigen::Matrix<double, 15, 15> jacobian, covariance;
+  Eigen::Matrix<double, 15, 15> step_jacobian;
+  Eigen::Matrix<double, 15, 18> step_V;
+  Eigen::Matrix<double, 18, 18> noise;
 
-        Eigen::Matrix3d dq_dbg = jacobian.block<3, 3>(O_R, O_BG);
+  double sum_dt;
+  Eigen::Vector3d delta_p;
+  Eigen::Quaterniond delta_q;
+  Eigen::Vector3d delta_v;
 
-        Eigen::Matrix3d dv_dba = jacobian.block<3, 3>(O_V, O_BA);
-        Eigen::Matrix3d dv_dbg = jacobian.block<3, 3>(O_V, O_BG);
-
-        Eigen::Vector3d dba = Bai - linearized_ba;
-        Eigen::Vector3d dbg = Bgi - linearized_bg;
-
-        Eigen::Quaterniond corrected_delta_q = delta_q * Utility::deltaQ(dq_dbg * dbg);
-        Eigen::Vector3d corrected_delta_v = delta_v + dv_dba * dba + dv_dbg * dbg;
-        Eigen::Vector3d corrected_delta_p = delta_p + dp_dba * dba + dp_dbg * dbg;
-
-        residuals.block<3, 1>(O_P, 0) = Qi.inverse() * (0.5 * g_config.estimator.g * sum_dt * sum_dt + Pj - Pi - Vi * sum_dt) - corrected_delta_p;
-        residuals.block<3, 1>(O_R, 0) = 2 * (corrected_delta_q.inverse() * (Qi.inverse() * Qj)).vec();
-        residuals.block<3, 1>(O_V, 0) = Qi.inverse() * (g_config.estimator.g * sum_dt + Vj - Vi) - corrected_delta_v;
-        residuals.block<3, 1>(O_BA, 0) = Baj - Bai;
-        residuals.block<3, 1>(O_BG, 0) = Bgj - Bgi;
-        return residuals;
-    }
-
-    double dt;
-    Eigen::Vector3d acc_0, gyr_0;
-    Eigen::Vector3d acc_1, gyr_1;
-
-    const Eigen::Vector3d linearized_acc, linearized_gyr;
-    Eigen::Vector3d linearized_ba, linearized_bg;
-
-    Eigen::Matrix<double, 15, 15> jacobian, covariance;
-    Eigen::Matrix<double, 15, 15> step_jacobian;
-    Eigen::Matrix<double, 15, 18> step_V;
-    Eigen::Matrix<double, 18, 18> noise;
-
-    double sum_dt;
-    Eigen::Vector3d delta_p;
-    Eigen::Quaterniond delta_q;
-    Eigen::Vector3d delta_v;
-
-    std::vector<double> dt_buf;
-    std::vector<Eigen::Vector3d> acc_buf;
-    std::vector<Eigen::Vector3d> gyr_buf;
+  std::vector<double> dt_buf;
+  std::vector<Eigen::Vector3d> acc_buf;
+  std::vector<Eigen::Vector3d> gyr_buf;
 };
 
-} // namespace factor
-} // namespace backend
+}  // namespace factor
+}  // namespace backend
 
-#endif // INTEGRATION_BASE_H
+#endif  // INTEGRATION_BASE_H

--- a/include/backend/factor/marginalization_factor.h
+++ b/include/backend/factor/marginalization_factor.h
@@ -2,8 +2,9 @@
 #define MARGINALIZATION_FACTOR_H
 
 #include <ceres/ceres.h>
-#include <cstdlib>
 #include <pthread.h>
+
+#include <cstdlib>
 #include <unordered_map>
 
 #include "utility/utility.h"
@@ -14,70 +15,71 @@ namespace backend {
 namespace factor {
 
 struct ResidualBlockInfo {
-    ResidualBlockInfo(ceres::CostFunction *_cost_function, ceres::LossFunction *_loss_function,
-                      std::vector<double *> _parameter_blocks, std::vector<int> _drop_set)
-        : cost_function(_cost_function), loss_function(_loss_function), parameter_blocks(_parameter_blocks),
-          drop_set(_drop_set) {}
+  ResidualBlockInfo(ceres::CostFunction *_cost_function, ceres::LossFunction *_loss_function,
+                    std::vector<double *> _parameter_blocks, std::vector<int> _drop_set)
+      : cost_function(_cost_function),
+        loss_function(_loss_function),
+        parameter_blocks(_parameter_blocks),
+        drop_set(_drop_set) {}
 
-    void Evaluate();
+  void Evaluate();
 
-    ceres::CostFunction *cost_function;
-    ceres::LossFunction *loss_function;
-    std::vector<double *> parameter_blocks;
-    std::vector<int> drop_set;
+  ceres::CostFunction *cost_function;
+  ceres::LossFunction *loss_function;
+  std::vector<double *> parameter_blocks;
+  std::vector<int> drop_set;
 
-    double **raw_jacobians;
-    std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> jacobians;
-    Eigen::VectorXd residuals;
+  double **raw_jacobians;
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> jacobians;
+  Eigen::VectorXd residuals;
 
-    int localSize(int size) {
-        return size == 7 ? 6 : size;
-    }
+  int localSize(int size) { return size == 7 ? 6 : size; }
 };
 
 struct ThreadsStruct {
-    std::vector<ResidualBlockInfo *> sub_factors;
-    Eigen::MatrixXd A;
-    Eigen::VectorXd b;
-    std::unordered_map<long, int> parameter_block_size; // global size
-    std::unordered_map<long, int> parameter_block_idx;  // local size
+  std::vector<ResidualBlockInfo *> sub_factors;
+  Eigen::MatrixXd A;
+  Eigen::VectorXd b;
+  std::unordered_map<long, int> parameter_block_size;  // global size
+  std::unordered_map<long, int> parameter_block_idx;   // local size
 };
 
 class MarginalizationInfo {
-  public:
-    ~MarginalizationInfo();
-    int localSize(int size) const;
-    int globalSize(int size) const;
-    void addResidualBlockInfo(ResidualBlockInfo *residual_block_info);
-    void preMarginalize();
-    void marginalize();
-    std::vector<double *> getParameterBlocks(std::unordered_map<long, double *> &addr_shift);
+public:
+  ~MarginalizationInfo();
+  int localSize(int size) const;
+  int globalSize(int size) const;
+  void addResidualBlockInfo(ResidualBlockInfo *residual_block_info);
+  void preMarginalize();
+  void marginalize();
+  std::vector<double *> getParameterBlocks(std::unordered_map<long, double *> &addr_shift);
 
-    std::vector<ResidualBlockInfo *> factors;
-    int m, n;
-    std::unordered_map<long, int> parameter_block_size; // global size
-    int sum_block_size;
-    std::unordered_map<long, int> parameter_block_idx; // local size
-    std::unordered_map<long, double *> parameter_block_data;
+  std::vector<ResidualBlockInfo *> factors;
+  int m, n;
+  std::unordered_map<long, int> parameter_block_size;  // global size
+  int sum_block_size;
+  std::unordered_map<long, int> parameter_block_idx;  // local size
+  std::unordered_map<long, double *> parameter_block_data;
 
-    std::vector<int> keep_block_size; // global size
-    std::vector<int> keep_block_idx;  // local size
-    std::vector<double *> keep_block_data;
+  std::vector<int> keep_block_size;  // global size
+  std::vector<int> keep_block_idx;   // local size
+  std::vector<double *> keep_block_data;
 
-    Eigen::MatrixXd linearized_jacobians;
-    Eigen::VectorXd linearized_residuals;
-    const double eps = 1e-8;
+  Eigen::MatrixXd linearized_jacobians;
+  Eigen::VectorXd linearized_residuals;
+  const double eps = 1e-8;
 };
 
 class MarginalizationFactor : public ceres::CostFunction {
-  public:
-    MarginalizationFactor(MarginalizationInfo *_marginalization_info);
-    virtual bool Evaluate(double const *const *parameters, double *residuals, double **jacobians) const;
+public:
+  MarginalizationFactor(MarginalizationInfo *_marginalization_info);
+  virtual bool Evaluate(double const *const *parameters, double *residuals,
+                        double **jacobians) const;
 
-    MarginalizationInfo *marginalization_info;
+  MarginalizationInfo *marginalization_info;
 };
 
-} // namespace factor
-} // namespace backend
+}  // namespace factor
+}  // namespace backend
 
 #endif

--- a/include/backend/factor/pose_local_parameterization.h
+++ b/include/backend/factor/pose_local_parameterization.h
@@ -1,25 +1,23 @@
 #ifndef POSE_LOCAL_PARAMETERIZATION_H
 #define POSE_LOCAL_PARAMETERIZATION_H
 
-#include "utility/utility.h"
 #include <ceres/ceres.h>
+
 #include <eigen3/Eigen/Dense>
+
+#include "utility/utility.h"
 
 namespace backend {
 namespace factor {
 
 class PoseLocalParameterization : public ceres::LocalParameterization {
-    virtual bool Plus(const double *x, const double *delta, double *x_plus_delta) const;
-    virtual bool ComputeJacobian(const double *x, double *jacobian) const;
-    virtual int GlobalSize() const {
-        return 7;
-    };
-    virtual int LocalSize() const {
-        return 6;
-    };
+  virtual bool Plus(const double *x, const double *delta, double *x_plus_delta) const;
+  virtual bool ComputeJacobian(const double *x, double *jacobian) const;
+  virtual int GlobalSize() const { return 7; };
+  virtual int LocalSize() const { return 6; };
 };
 
-} // namespace factor
-} // namespace backend
+}  // namespace factor
+}  // namespace backend
 
 #endif

--- a/include/backend/factor/projection_factor.h
+++ b/include/backend/factor/projection_factor.h
@@ -1,26 +1,29 @@
 #ifndef PROJECTION_FACTOR_H
 #define PROJECTION_FACTOR_H
 
-#include "utility/utility.h"
-#include <Eigen/Dense>
 #include <ceres/ceres.h>
+
+#include <Eigen/Dense>
+
+#include "utility/utility.h"
 
 namespace backend {
 namespace factor {
 
 class ProjectionFactor : public ceres::SizedCostFunction<2, 7, 7, 7, 1> {
-  public:
-    ProjectionFactor(const Eigen::Vector3d &_pts_i, const Eigen::Vector3d &_pts_j);
-    virtual bool Evaluate(double const *const *parameters, double *residuals, double **jacobians) const;
-    void check(double **parameters);
+public:
+  ProjectionFactor(const Eigen::Vector3d &_pts_i, const Eigen::Vector3d &_pts_j);
+  virtual bool Evaluate(double const *const *parameters, double *residuals,
+                        double **jacobians) const;
+  void check(double **parameters);
 
-    Eigen::Vector3d pts_i, pts_j;
-    Eigen::Matrix<double, 2, 3> tangent_base;
-    static Eigen::Matrix2d sqrt_info;
-    static double sum_t;
+  Eigen::Vector3d pts_i, pts_j;
+  Eigen::Matrix<double, 2, 3> tangent_base;
+  static Eigen::Matrix2d sqrt_info;
+  static double sum_t;
 };
 
-} // namespace factor
-} // namespace backend
+}  // namespace factor
+}  // namespace backend
 
-#endif // PROJECTION_FACTOR_H
+#endif  // PROJECTION_FACTOR_H

--- a/include/backend/optimizer.h
+++ b/include/backend/optimizer.h
@@ -1,78 +1,78 @@
 #ifndef OPTIMIZER_H
 #define OPTIMIZER_H
 
-#include <iostream>
-#include <Eigen/Dense>
 #include <ceres/ceres.h>
 
+#include <Eigen/Dense>
+#include <iostream>
+
+#include "backend/factor/imu_factor.h"
 #include "backend/factor/integration_base.h"
 #include "backend/factor/marginalization_factor.h"
-#include "backend/factor/imu_factor.h"
 #include "backend/factor/pose_local_parameterization.h"
 #include "backend/factor/projection_factor.h"
 #include "backend/sliding_window.h"
-#include "frontend/feature_manager.h"
 #include "common/common_types.h"
+#include "frontend/feature_manager.h"
 #include "utility/config.h"
-
 
 namespace backend {
 
 class Optimizer {
 public:
-    Optimizer(SlidingWindow* sliding_window, FeatureManager* feature_manager);
-    ~Optimizer();
+  Optimizer(SlidingWindow* sliding_window, FeatureManager* feature_manager);
+  ~Optimizer();
 
-    // Main optimization interface
-    void optimize(MarginalizationFlag marginalization_flag);
-    
-    // Setter for extrinsic parameters
-    void setExtrinsicParameters(const Vector3d& t_ic, const Matrix3d& r_ic);
+  // Main optimization interface
+  void optimize(MarginalizationFlag marginalization_flag);
 
-    // Getter for extrinsic parameters
-    Vector3d getTic() const { return t_ic_; }
-    Matrix3d getRic() const { return r_ic_; }
+  // Setter for extrinsic parameters
+  void setExtrinsicParameters(const Vector3d& t_ic, const Matrix3d& r_ic);
+
+  // Getter for extrinsic parameters
+  Vector3d getTic() const { return t_ic_; }
+  Matrix3d getRic() const { return r_ic_; }
 
 private:
-    // Optimization setup
-    ceres::LossFunction* setupOptimizationProblem(ceres::Problem& problem);
-    void addMarginalizationFactor(ceres::Problem& problem);
-    void addIMUFactors(ceres::Problem& problem);
-    int addFeatureFactors(ceres::Problem& problem, ceres::LossFunction* loss_function);
-    void solveCeresProblem(ceres::Problem& problem);
-    
-    // Marginalization methods
-    void marginalizeOldKeyframe();
-    void marginalizeNewGeneralFrame();
-    void addFeatureFactorsForMarginalization(factor::MarginalizationInfo* marginalization_info);
-    void addIMUFactorForMarginalization(factor::MarginalizationInfo* marginalization_info);
-    void performMarginalizationForOldKeyframe(factor::MarginalizationInfo* marginalization_info);
-    void performMarginalizationForNewGeneralFrame(factor::MarginalizationInfo* marginalization_info);
-    void handleMarginalization(MarginalizationFlag marginalization_flag);
+  // Optimization setup
+  ceres::LossFunction* setupOptimizationProblem(ceres::Problem& problem);
+  void addMarginalizationFactor(ceres::Problem& problem);
+  void addIMUFactors(ceres::Problem& problem);
+  int addFeatureFactors(ceres::Problem& problem, ceres::LossFunction* loss_function);
+  void solveCeresProblem(ceres::Problem& problem);
 
-    // Parameter management
-    void prepareOptimizationParameters();
-    void applyOptimizationResults();
+  // Marginalization methods
+  void marginalizeOldKeyframe();
+  void marginalizeNewGeneralFrame();
+  void addFeatureFactorsForMarginalization(factor::MarginalizationInfo* marginalization_info);
+  void addIMUFactorForMarginalization(factor::MarginalizationInfo* marginalization_info);
+  void performMarginalizationForOldKeyframe(factor::MarginalizationInfo* marginalization_info);
+  void performMarginalizationForNewGeneralFrame(factor::MarginalizationInfo* marginalization_info);
+  void handleMarginalization(MarginalizationFlag marginalization_flag);
 
-    // Member variables
-    SlidingWindow* sliding_window_;
-    FeatureManager* feature_manager_;
-    
-    // Extrinsic parameters
-    Vector3d t_ic_;
-    Matrix3d r_ic_;
-    
-    // Optimization parameters
-    double para_Pose[WINDOW_SIZE + 1][SIZE_POSE];
-    double para_SpeedAndBiases[WINDOW_SIZE + 1][SIZE_SPEEDANDBIAS];
-    double para_Feature[NUM_OF_FEATURES][SIZE_FEATURE];
-    double para_Ex_Pose[SIZE_POSE];
-    
-    // Marginalization info
-    factor::MarginalizationInfo *last_marginalization_info_;
-    std::vector<double *> last_marginalization_parameter_blocks_;
+  // Parameter management
+  void prepareOptimizationParameters();
+  void applyOptimizationResults();
+
+  // Member variables
+  SlidingWindow* sliding_window_;
+  FeatureManager* feature_manager_;
+
+  // Extrinsic parameters
+  Vector3d t_ic_;
+  Matrix3d r_ic_;
+
+  // Optimization parameters
+  double para_Pose[WINDOW_SIZE + 1][SIZE_POSE];
+  double para_SpeedAndBiases[WINDOW_SIZE + 1][SIZE_SPEEDANDBIAS];
+  double para_Feature[NUM_OF_FEATURES][SIZE_FEATURE];
+  double para_Ex_Pose[SIZE_POSE];
+
+  // Marginalization info
+  factor::MarginalizationInfo* last_marginalization_info_;
+  std::vector<double*> last_marginalization_parameter_blocks_;
 };
 
-} // namespace backend
+}  // namespace backend
 
-#endif // OPTIMIZER_H 
+#endif  // OPTIMIZER_H

--- a/include/backend/sliding_window copy.h
+++ b/include/backend/sliding_window copy.h
@@ -5,79 +5,73 @@
 
 #include "frame.h"
 
-
 class SlidingWindow {
 public:
-    SlidingWindow() 
-    {
-        clearSlidingWindow();
-    }
+  SlidingWindow() { clearSlidingWindow(); }
 
-    void clearSlidingWindow();
+  void clearSlidingWindow();
 
-    Frame& operator[](int index) {
-        return sliding_window[index];
-    }
+  Frame& operator[](int index) { return sliding_window[index]; }
 
-    const Frame& operator[](int index) const {
-        return sliding_window[index];
-    }
+  const Frame& operator[](int index) const { return sliding_window[index]; }
 
-    void clearBuffer(int32_t index) {
-        sliding_window[index].dt_buf.clear();
-        sliding_window[index].linear_acceleration_buf.clear();
-        sliding_window[index].angular_velocity_buf.clear();
-    }
+  void clearBuffer(int32_t index) {
+    sliding_window[index].dt_buf.clear();
+    sliding_window[index].linear_acceleration_buf.clear();
+    sliding_window[index].angular_velocity_buf.clear();
+  }
 
-    void copyFrame(int32_t index, int32_t other_index) {
-        sliding_window[index].timestamp = sliding_window[other_index].timestamp;
-        sliding_window[index].R = sliding_window[other_index].R;
-        sliding_window[index].P = sliding_window[other_index].P;
-        sliding_window[index].V = sliding_window[other_index].V;
-        sliding_window[index].Ba = sliding_window[other_index].Ba;
-        sliding_window[index].Bg = sliding_window[other_index].Bg;
-    }
+  void copyFrame(int32_t index, int32_t other_index) {
+    sliding_window[index].timestamp = sliding_window[other_index].timestamp;
+    sliding_window[index].R = sliding_window[other_index].R;
+    sliding_window[index].P = sliding_window[other_index].P;
+    sliding_window[index].V = sliding_window[other_index].V;
+    sliding_window[index].Ba = sliding_window[other_index].Ba;
+    sliding_window[index].Bg = sliding_window[other_index].Bg;
+  }
 
-    void swapFrame(int32_t index, int32_t other_index) {
-        std::swap(sliding_window[index].timestamp, sliding_window[other_index].timestamp);
-        std::swap(sliding_window[index].R, sliding_window[other_index].R);
-        std::swap(sliding_window[index].P, sliding_window[other_index].P);
-        std::swap(sliding_window[index].V, sliding_window[other_index].V);
-        std::swap(sliding_window[index].Ba, sliding_window[other_index].Ba);
-        std::swap(sliding_window[index].Bg, sliding_window[other_index].Bg);
-        std::swap(sliding_window[index].pre_integration, sliding_window[other_index].pre_integration);
-    }
+  void swapFrame(int32_t index, int32_t other_index) {
+    std::swap(sliding_window[index].timestamp, sliding_window[other_index].timestamp);
+    std::swap(sliding_window[index].R, sliding_window[other_index].R);
+    std::swap(sliding_window[index].P, sliding_window[other_index].P);
+    std::swap(sliding_window[index].V, sliding_window[other_index].V);
+    std::swap(sliding_window[index].Ba, sliding_window[other_index].Ba);
+    std::swap(sliding_window[index].Bg, sliding_window[other_index].Bg);
+    std::swap(sliding_window[index].pre_integration, sliding_window[other_index].pre_integration);
+  }
 
-    void swapBuffer(int32_t index, int32_t other_index) {
-        std::swap(sliding_window[index].dt_buf, sliding_window[other_index].dt_buf);
-        std::swap(sliding_window[index].linear_acceleration_buf, sliding_window[other_index].linear_acceleration_buf);
-        std::swap(sliding_window[index].angular_velocity_buf, sliding_window[other_index].angular_velocity_buf);
-    }
+  void swapBuffer(int32_t index, int32_t other_index) {
+    std::swap(sliding_window[index].dt_buf, sliding_window[other_index].dt_buf);
+    std::swap(sliding_window[index].linear_acceleration_buf,
+              sliding_window[other_index].linear_acceleration_buf);
+    std::swap(sliding_window[index].angular_velocity_buf,
+              sliding_window[other_index].angular_velocity_buf);
+  }
 
-    void pushBackBuffer(int32_t index, double dt, const Eigen::Vector3d& linear_acceleration, const Eigen::Vector3d& angular_velocity) {
-        sliding_window[index].dt_buf.push_back(dt);
-        sliding_window[index].linear_acceleration_buf.push_back(linear_acceleration);
-        sliding_window[index].angular_velocity_buf.push_back(angular_velocity);
-    }
+  void pushBackBuffer(int32_t index, double dt, const Eigen::Vector3d& linear_acceleration,
+                      const Eigen::Vector3d& angular_velocity) {
+    sliding_window[index].dt_buf.push_back(dt);
+    sliding_window[index].linear_acceleration_buf.push_back(linear_acceleration);
+    sliding_window[index].angular_velocity_buf.push_back(angular_velocity);
+  }
 
-    void pushBackPreintegration(int32_t index, double dt, const Eigen::Vector3d& linear_acceleration, const Eigen::Vector3d& angular_velocity) {
-        sliding_window[index].pre_integration->push_back(dt, linear_acceleration, angular_velocity);
-    }
+  void pushBackPreintegration(int32_t index, double dt, const Eigen::Vector3d& linear_acceleration,
+                              const Eigen::Vector3d& angular_velocity) {
+    sliding_window[index].pre_integration->push_back(dt, linear_acceleration, angular_velocity);
+  }
 
-    void createNewPreintegration(int32_t index, const Eigen::Vector3d& linear_acceleration, const Eigen::Vector3d& angular_velocity) {
-        delete sliding_window[index].pre_integration;
-        sliding_window[index].pre_integration = new IntegrationBase(linear_acceleration, angular_velocity, sliding_window[index].Ba, sliding_window[index].Bg);
-    }
+  void createNewPreintegration(int32_t index, const Eigen::Vector3d& linear_acceleration,
+                               const Eigen::Vector3d& angular_velocity) {
+    delete sliding_window[index].pre_integration;
+    sliding_window[index].pre_integration = new IntegrationBase(
+        linear_acceleration, angular_velocity, sliding_window[index].Ba, sliding_window[index].Bg);
+  }
 
-    const Frame& front() const {
-        return sliding_window[0];
-    }
+  const Frame& front() const { return sliding_window[0]; }
 
-    const Frame& back() const {
-        return sliding_window[WINDOW_SIZE];
-    }
+  const Frame& back() const { return sliding_window[WINDOW_SIZE]; }
 
 private:
-    std::array<Frame, WINDOW_SIZE + 1> sliding_window;
+  std::array<Frame, WINDOW_SIZE + 1> sliding_window;
 };
 #endif

--- a/include/backend/sliding_window.h
+++ b/include/backend/sliding_window.h
@@ -3,90 +3,80 @@
 
 #include <Eigen/Dense>
 
-#include "common/frame.h"
 #include "backend/factor/integration_base.h"
+#include "common/frame.h"
 #include "utility/config.h"
-
-
 
 namespace backend {
 
 class SlidingWindow {
 public:
-    SlidingWindow() {
-        clearSlidingWindow();
-    }
+  SlidingWindow() { clearSlidingWindow(); }
 
-    void clearSlidingWindow();
+  void clearSlidingWindow();
 
-    Frame& operator[](int index) {
-        return sliding_window[index];
-    }
+  Frame& operator[](int index) { return sliding_window[index]; }
 
-    const Frame& operator[](int index) const {
-        return sliding_window[index];
-    }
+  const Frame& operator[](int index) const { return sliding_window[index]; }
 
-    void clearBuffer(int32_t index) {
-        sliding_window[index].dt_buf.clear();
-        sliding_window[index].linear_acceleration_buf.clear();
-        sliding_window[index].angular_velocity_buf.clear();
-    }
+  void clearBuffer(int32_t index) {
+    sliding_window[index].dt_buf.clear();
+    sliding_window[index].linear_acceleration_buf.clear();
+    sliding_window[index].angular_velocity_buf.clear();
+  }
 
-    void copyFrame(int32_t index, int32_t other_index) {
-        sliding_window[index].timestamp = sliding_window[other_index].timestamp;
-        sliding_window[index].R = sliding_window[other_index].R;
-        sliding_window[index].P = sliding_window[other_index].P;
-        sliding_window[index].V = sliding_window[other_index].V;
-        sliding_window[index].Ba = sliding_window[other_index].Ba;
-        sliding_window[index].Bg = sliding_window[other_index].Bg;
-    }
+  void copyFrame(int32_t index, int32_t other_index) {
+    sliding_window[index].timestamp = sliding_window[other_index].timestamp;
+    sliding_window[index].R = sliding_window[other_index].R;
+    sliding_window[index].P = sliding_window[other_index].P;
+    sliding_window[index].V = sliding_window[other_index].V;
+    sliding_window[index].Ba = sliding_window[other_index].Ba;
+    sliding_window[index].Bg = sliding_window[other_index].Bg;
+  }
 
-    void swapFrame(int32_t index, int32_t other_index) {
-        std::swap(sliding_window[index].timestamp, sliding_window[other_index].timestamp);
-        std::swap(sliding_window[index].R, sliding_window[other_index].R);
-        std::swap(sliding_window[index].P, sliding_window[other_index].P);
-        std::swap(sliding_window[index].V, sliding_window[other_index].V);
-        std::swap(sliding_window[index].Ba, sliding_window[other_index].Ba);
-        std::swap(sliding_window[index].Bg, sliding_window[other_index].Bg);
-        std::swap(sliding_window[index].pre_integration, sliding_window[other_index].pre_integration);
-    }
+  void swapFrame(int32_t index, int32_t other_index) {
+    std::swap(sliding_window[index].timestamp, sliding_window[other_index].timestamp);
+    std::swap(sliding_window[index].R, sliding_window[other_index].R);
+    std::swap(sliding_window[index].P, sliding_window[other_index].P);
+    std::swap(sliding_window[index].V, sliding_window[other_index].V);
+    std::swap(sliding_window[index].Ba, sliding_window[other_index].Ba);
+    std::swap(sliding_window[index].Bg, sliding_window[other_index].Bg);
+    std::swap(sliding_window[index].pre_integration, sliding_window[other_index].pre_integration);
+  }
 
-    void swapBuffer(int32_t index, int32_t other_index) {
-        std::swap(sliding_window[index].dt_buf, sliding_window[other_index].dt_buf);
-        std::swap(sliding_window[index].linear_acceleration_buf, sliding_window[other_index].linear_acceleration_buf);
-        std::swap(sliding_window[index].angular_velocity_buf, sliding_window[other_index].angular_velocity_buf);
-    }
+  void swapBuffer(int32_t index, int32_t other_index) {
+    std::swap(sliding_window[index].dt_buf, sliding_window[other_index].dt_buf);
+    std::swap(sliding_window[index].linear_acceleration_buf,
+              sliding_window[other_index].linear_acceleration_buf);
+    std::swap(sliding_window[index].angular_velocity_buf,
+              sliding_window[other_index].angular_velocity_buf);
+  }
 
-    void pushBackBuffer(int32_t index, double dt, const Eigen::Vector3d& linear_acceleration,
-                        const Eigen::Vector3d& angular_velocity) {
-        sliding_window[index].dt_buf.push_back(dt);
-        sliding_window[index].linear_acceleration_buf.push_back(linear_acceleration);
-        sliding_window[index].angular_velocity_buf.push_back(angular_velocity);
-    }
+  void pushBackBuffer(int32_t index, double dt, const Eigen::Vector3d& linear_acceleration,
+                      const Eigen::Vector3d& angular_velocity) {
+    sliding_window[index].dt_buf.push_back(dt);
+    sliding_window[index].linear_acceleration_buf.push_back(linear_acceleration);
+    sliding_window[index].angular_velocity_buf.push_back(angular_velocity);
+  }
 
-    void pushBackPreintegration(int32_t index, double dt, const Eigen::Vector3d& linear_acceleration,
-                                const Eigen::Vector3d& angular_velocity) {
-        sliding_window[index].pre_integration->push_back(dt, linear_acceleration, angular_velocity);
-    }
+  void pushBackPreintegration(int32_t index, double dt, const Eigen::Vector3d& linear_acceleration,
+                              const Eigen::Vector3d& angular_velocity) {
+    sliding_window[index].pre_integration->push_back(dt, linear_acceleration, angular_velocity);
+  }
 
-    void createNewPreintegration(int32_t index, const Eigen::Vector3d& linear_acceleration,
-                                 const Eigen::Vector3d& angular_velocity) {
-        delete sliding_window[index].pre_integration;
-        sliding_window[index].pre_integration = new backend::factor::IntegrationBase(linear_acceleration, angular_velocity,
-                                                                     sliding_window[index].Ba, sliding_window[index].Bg);
-    }
+  void createNewPreintegration(int32_t index, const Eigen::Vector3d& linear_acceleration,
+                               const Eigen::Vector3d& angular_velocity) {
+    delete sliding_window[index].pre_integration;
+    sliding_window[index].pre_integration = new backend::factor::IntegrationBase(
+        linear_acceleration, angular_velocity, sliding_window[index].Ba, sliding_window[index].Bg);
+  }
 
-    const Frame& front() const {
-        return sliding_window[0];
-    }
+  const Frame& front() const { return sliding_window[0]; }
 
-    const Frame& back() const {
-        return sliding_window[WINDOW_SIZE];
-    }
+  const Frame& back() const { return sliding_window[WINDOW_SIZE]; }
 
 private:
-    std::array<Frame, WINDOW_SIZE + 1> sliding_window;
+  std::array<Frame, WINDOW_SIZE + 1> sliding_window;
 };
 
 }  // namespace backend

--- a/include/common/common_types.h
+++ b/include/common/common_types.h
@@ -4,4 +4,4 @@
 enum SolverFlag { INITIAL = 0, NON_LINEAR = 1 };
 enum MarginalizationFlag { MARGIN_OLD_KEYFRAME = 0, MARGIN_NEW_GENERAL_FRAME = 1 };
 
-#endif // COMMON_TYPES_H 
+#endif  // COMMON_TYPES_H

--- a/include/common/frame.h
+++ b/include/common/frame.h
@@ -7,21 +7,21 @@
 
 class Frame {
 public:
-    Frame() = default;
+  Frame() = default;
 
-    void clear();
+  void clear();
 
 public:
-    double timestamp;
-    Eigen::Matrix3d R;
-    Eigen::Vector3d P;
-    Eigen::Vector3d V;
-    Eigen::Vector3d Ba;
-    Eigen::Vector3d Bg;
-    backend::factor::IntegrationBase *pre_integration;
+  double timestamp;
+  Eigen::Matrix3d R;
+  Eigen::Vector3d P;
+  Eigen::Vector3d V;
+  Eigen::Vector3d Ba;
+  Eigen::Vector3d Bg;
+  backend::factor::IntegrationBase *pre_integration;
 
-    std::vector<double> dt_buf;
-    std::vector<Eigen::Vector3d> linear_acceleration_buf;
-    std::vector<Eigen::Vector3d> angular_velocity_buf;
+  std::vector<double> dt_buf;
+  std::vector<Eigen::Vector3d> linear_acceleration_buf;
+  std::vector<Eigen::Vector3d> angular_velocity_buf;
 };
 #endif

--- a/include/common/image_frame.h
+++ b/include/common/image_frame.h
@@ -1,11 +1,12 @@
 #ifndef IMAGE_FRAME_H
 #define IMAGE_FRAME_H
 
-#include "backend/factor/imu_factor.h"
 #include <eigen3/Eigen/Dense>
 #include <map>
 #include <utility>
 #include <vector>
+
+#include "backend/factor/imu_factor.h"
 
 using namespace Eigen;
 using namespace std;
@@ -20,112 +21,116 @@ using ImageData = std::map<int, vector<Eigen::Matrix<double, 7, 1>>>;
  * data.
  */
 class ImageFrame {
-  public:
-    /**
-     * @brief Default constructor
-     */
-    ImageFrame() : t(0.0), pre_integration(nullptr), is_key_frame(false) {}
+public:
+  /**
+   * @brief Default constructor
+   */
+  ImageFrame() : t(0.0), pre_integration(nullptr), is_key_frame(false) {}
 
-    /**
-     * @brief Constructor with feature points and timestamp
-     * @param _points Feature points map: feature_id -> vector<camera_id,
-     * feature_data>
-     * @param _t Timestamp of the image frame
-     */
-    ImageFrame(const ImageData &_points, double _t)
-        : points(_points), t(_t), pre_integration(nullptr), is_key_frame(false) {
-        R = Matrix3d::Identity();
-        T = Vector3d::Zero();
+  /**
+   * @brief Constructor with feature points and timestamp
+   * @param _points Feature points map: feature_id -> vector<camera_id,
+   * feature_data>
+   * @param _t Timestamp of the image frame
+   */
+  ImageFrame(const ImageData &_points, double _t)
+      : points(_points), t(_t), pre_integration(nullptr), is_key_frame(false) {
+    R = Matrix3d::Identity();
+    T = Vector3d::Zero();
+  }
+
+  /**
+   * @brief Destructor
+   */
+  ~ImageFrame() = default;
+
+  /**
+   * @brief Copy constructor
+   */
+  ImageFrame(const ImageFrame &other)
+      : points(other.points),
+        t(other.t),
+        R(other.R),
+        T(other.T),
+        pre_integration(other.pre_integration),
+        is_key_frame(other.is_key_frame) {}
+
+  /**
+   * @brief Assignment operator
+   */
+  ImageFrame &operator=(const ImageFrame &other) {
+    if (this != &other) {
+      points = other.points;
+      t = other.t;
+      R = other.R;
+      T = other.T;
+      pre_integration = other.pre_integration;  // Note: shallow copy
+      is_key_frame = other.is_key_frame;
     }
+    return *this;
+  }
 
-    /**
-     * @brief Destructor
-     */
-    ~ImageFrame() = default;
-
-    /**
-     * @brief Copy constructor
-     */
-    ImageFrame(const ImageFrame &other)
-        : points(other.points), t(other.t), R(other.R), T(other.T), pre_integration(other.pre_integration),
-          is_key_frame(other.is_key_frame) {}
-
-    /**
-     * @brief Assignment operator
-     */
-    ImageFrame &operator=(const ImageFrame &other) {
-        if (this != &other) {
-            points = other.points;
-            t = other.t;
-            R = other.R;
-            T = other.T;
-            pre_integration = other.pre_integration; // Note: shallow copy
-            is_key_frame = other.is_key_frame;
-        }
-        return *this;
+  /**
+   * @brief Get the number of feature points in this frame
+   * @return Total number of feature observations
+   */
+  size_t getFeatureCount() const {
+    size_t count = 0;
+    for (const auto &feature : points) {
+      count += feature.second.size();
     }
+    return count;
+  }
 
-    /**
-     * @brief Get the number of feature points in this frame
-     * @return Total number of feature observations
-     */
-    size_t getFeatureCount() const {
-        size_t count = 0;
-        for (const auto &feature : points) {
-            count += feature.second.size();
-        }
-        return count;
-    }
+  /**
+   * @brief Check if this frame has enough features for processing
+   * @param min_features Minimum required number of features
+   * @return true if frame has enough features
+   */
+  bool hasEnoughFeatures(size_t min_features = 10) const {
+    return getFeatureCount() >= min_features;
+  }
 
-    /**
-     * @brief Check if this frame has enough features for processing
-     * @param min_features Minimum required number of features
-     * @return true if frame has enough features
-     */
-    bool hasEnoughFeatures(size_t min_features = 10) const {
-        return getFeatureCount() >= min_features;
-    }
+  /**
+   * @brief Get pose as a 4x4 transformation matrix
+   * @return 4x4 transformation matrix [R t; 0 1]
+   */
+  Matrix4d getPoseMatrix() const {
+    Matrix4d pose = Matrix4d::Identity();
+    pose.block<3, 3>(0, 0) = R;
+    pose.block<3, 1>(0, 3) = T;
+    return pose;
+  }
 
-    /**
-     * @brief Get pose as a 4x4 transformation matrix
-     * @return 4x4 transformation matrix [R t; 0 1]
-     */
-    Matrix4d getPoseMatrix() const {
-        Matrix4d pose = Matrix4d::Identity();
-        pose.block<3, 3>(0, 0) = R;
-        pose.block<3, 1>(0, 3) = T;
-        return pose;
-    }
+  /**
+   * @brief Set pose from a 4x4 transformation matrix
+   * @param pose 4x4 transformation matrix
+   */
+  void setPoseMatrix(const Matrix4d &pose) {
+    R = pose.block<3, 3>(0, 0);
+    T = pose.block<3, 1>(0, 3);
+  }
 
-    /**
-     * @brief Set pose from a 4x4 transformation matrix
-     * @param pose 4x4 transformation matrix
-     */
-    void setPoseMatrix(const Matrix4d &pose) {
-        R = pose.block<3, 3>(0, 0);
-        T = pose.block<3, 1>(0, 3);
-    }
+public:
+  /// Feature points: feature_id -> vector<camera_id, feature_measurement>
+  /// feature_measurement: [u, v, 1, u_velocity, v_velocity, depth,
+  /// depth_covariance]
+  ImageData points;
 
-  public:
-    /// Feature points: feature_id -> vector<camera_id, feature_measurement>
-    /// feature_measurement: [u, v, 1, u_velocity, v_velocity, depth,
-    /// depth_covariance]
-    ImageData points;
+  /// Timestamp of the image frame
+  double t;
 
-    /// Timestamp of the image frame
-    double t;
+  /// Rotation matrix (camera to world)
+  Matrix3d R;
 
-    /// Rotation matrix (camera to world)
-    Matrix3d R;
+  /// Translation vector (camera position in world frame)
+  Vector3d T;
 
-    /// Translation vector (camera position in world frame)
-    Vector3d T;
+  /// IMU pre-integration data from previous frame to this frame
+  backend::factor::IntegrationBase *pre_integration;
 
-    /// IMU pre-integration data from previous frame to this frame
-    backend::factor::IntegrationBase *pre_integration;
-
-    /// Flag indicating if this is a keyframe
-    bool is_key_frame;
+  /// Flag indicating if this is a keyframe
+  bool is_key_frame;
 };
 
 #endif

--- a/include/frontend/camodocal/camera_models/Camera.h
+++ b/include/frontend/camodocal/camera_models/Camera.h
@@ -6,137 +6,123 @@
 #include <opencv2/core/core.hpp>
 #include <vector>
 
-namespace camodocal
-{
+namespace camodocal {
 
-class Camera
-{
+class Camera {
 public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  enum ModelType { KANNALA_BRANDT, MEI, PINHOLE, SCARAMUZZA };
+
+  class Parameters {
+  public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-    enum ModelType
-    {
-        KANNALA_BRANDT,
-        MEI,
-        PINHOLE,
-        SCARAMUZZA
-    };
+    Parameters(ModelType modelType);
 
-    class Parameters
-    {
-    public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-        Parameters(ModelType modelType);
+    Parameters(ModelType modelType, const std::string& cameraName, int w, int h);
 
-        Parameters(ModelType modelType, const std::string& cameraName,
-                   int w, int h);
+    ModelType& modelType(void);
+    std::string& cameraName(void);
+    int& imageWidth(void);
+    int& imageHeight(void);
 
-        ModelType& modelType(void);
-        std::string& cameraName(void);
-        int& imageWidth(void);
-        int& imageHeight(void);
+    ModelType modelType(void) const;
+    const std::string& cameraName(void) const;
+    int imageWidth(void) const;
+    int imageHeight(void) const;
 
-        ModelType modelType(void) const;
-        const std::string& cameraName(void) const;
-        int imageWidth(void) const;
-        int imageHeight(void) const;
+    int nIntrinsics(void) const;
 
-        int nIntrinsics(void) const;
+    virtual bool readFromYamlFile(const std::string& filename) = 0;
+    virtual void writeToYamlFile(const std::string& filename) const = 0;
 
-        virtual bool readFromYamlFile(const std::string& filename) = 0;
-        virtual void writeToYamlFile(const std::string& filename) const = 0;
+  protected:
+    ModelType m_modelType;
+    int m_nIntrinsics;
+    std::string m_cameraName;
+    int m_imageWidth;
+    int m_imageHeight;
+  };
 
-    protected:
-        ModelType m_modelType;
-        int m_nIntrinsics;
-        std::string m_cameraName;
-        int m_imageWidth;
-        int m_imageHeight;
-    };
+  virtual ModelType modelType(void) const = 0;
+  virtual const std::string& cameraName(void) const = 0;
+  virtual int imageWidth(void) const = 0;
+  virtual int imageHeight(void) const = 0;
 
-    virtual ModelType modelType(void) const = 0;
-    virtual const std::string& cameraName(void) const = 0;
-    virtual int imageWidth(void) const = 0;
-    virtual int imageHeight(void) const = 0;
+  virtual cv::Mat& mask(void);
+  virtual const cv::Mat& mask(void) const;
 
-    virtual cv::Mat& mask(void);
-    virtual const cv::Mat& mask(void) const;
+  virtual void estimateIntrinsics(const cv::Size& boardSize,
+                                  const std::vector<std::vector<cv::Point3f> >& objectPoints,
+                                  const std::vector<std::vector<cv::Point2f> >& imagePoints) = 0;
+  virtual void estimateExtrinsics(const std::vector<cv::Point3f>& objectPoints,
+                                  const std::vector<cv::Point2f>& imagePoints, cv::Mat& rvec,
+                                  cv::Mat& tvec) const;
 
-    virtual void estimateIntrinsics(const cv::Size& boardSize,
-                                    const std::vector< std::vector<cv::Point3f> >& objectPoints,
-                                    const std::vector< std::vector<cv::Point2f> >& imagePoints) = 0;
-    virtual void estimateExtrinsics(const std::vector<cv::Point3f>& objectPoints,
-                                    const std::vector<cv::Point2f>& imagePoints,
-                                    cv::Mat& rvec, cv::Mat& tvec) const;
+  // Lift points from the image plane to the sphere
+  virtual void liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const = 0;
+  //%output P
 
-    // Lift points from the image plane to the sphere
-    virtual void liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const = 0;
-    //%output P
+  // Lift points from the image plane to the projective space
+  virtual void liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const = 0;
+  //%output P
 
-    // Lift points from the image plane to the projective space
-    virtual void liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const = 0;
-    //%output P
+  // Projects 3D points to the image plane (Pi function)
+  virtual void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const = 0;
+  //%output p
 
-    // Projects 3D points to the image plane (Pi function)
-    virtual void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const = 0;
-    //%output p
+  // Projects 3D points to the image plane (Pi function)
+  // and calculates jacobian
+  // virtual void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p,
+  //                          Eigen::Matrix<double,2,3>& J) const = 0;
+  //%output p
+  //%output J
 
-    // Projects 3D points to the image plane (Pi function)
-    // and calculates jacobian
-    //virtual void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p,
-    //                          Eigen::Matrix<double,2,3>& J) const = 0;
-    //%output p
-    //%output J
+  virtual void undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const = 0;
+  //%output p
 
-    virtual void undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const = 0;
-    //%output p
+  // virtual void initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale = 1.0) const = 0;
+  virtual cv::Mat initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2, float fx = -1.0f,
+                                          float fy = -1.0f, cv::Size imageSize = cv::Size(0, 0),
+                                          float cx = -1.0f, float cy = -1.0f,
+                                          cv::Mat rmat = cv::Mat::eye(3, 3, CV_32F)) const = 0;
 
-    //virtual void initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale = 1.0) const = 0;
-    virtual cv::Mat initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2,
-                                            float fx = -1.0f, float fy = -1.0f,
-                                            cv::Size imageSize = cv::Size(0, 0),
-                                            float cx = -1.0f, float cy = -1.0f,
-                                            cv::Mat rmat = cv::Mat::eye(3, 3, CV_32F)) const = 0;
+  virtual int parameterCount(void) const = 0;
 
-    virtual int parameterCount(void) const = 0;
+  virtual void readParameters(const std::vector<double>& parameters) = 0;
+  virtual void writeParameters(std::vector<double>& parameters) const = 0;
 
-    virtual void readParameters(const std::vector<double>& parameters) = 0;
-    virtual void writeParameters(std::vector<double>& parameters) const = 0;
+  virtual void writeParametersToYamlFile(const std::string& filename) const = 0;
 
-    virtual void writeParametersToYamlFile(const std::string& filename) const = 0;
+  virtual std::string parametersToString(void) const = 0;
 
-    virtual std::string parametersToString(void) const = 0;
+  /**
+   * \brief Calculates the reprojection distance between points
+   *
+   * \param P1 first 3D point coordinates
+   * \param P2 second 3D point coordinates
+   * \return euclidean distance in the plane
+   */
+  double reprojectionDist(const Eigen::Vector3d& P1, const Eigen::Vector3d& P2) const;
 
-    /**
-     * \brief Calculates the reprojection distance between points
-     *
-     * \param P1 first 3D point coordinates
-     * \param P2 second 3D point coordinates
-     * \return euclidean distance in the plane
-     */
-    double reprojectionDist(const Eigen::Vector3d& P1, const Eigen::Vector3d& P2) const;
+  double reprojectionError(const std::vector<std::vector<cv::Point3f> >& objectPoints,
+                           const std::vector<std::vector<cv::Point2f> >& imagePoints,
+                           const std::vector<cv::Mat>& rvecs, const std::vector<cv::Mat>& tvecs,
+                           cv::OutputArray perViewErrors = cv::noArray()) const;
 
-    double reprojectionError(const std::vector< std::vector<cv::Point3f> >& objectPoints,
-                             const std::vector< std::vector<cv::Point2f> >& imagePoints,
-                             const std::vector<cv::Mat>& rvecs,
-                             const std::vector<cv::Mat>& tvecs,
-                             cv::OutputArray perViewErrors = cv::noArray()) const;
+  double reprojectionError(const Eigen::Vector3d& P, const Eigen::Quaterniond& camera_q,
+                           const Eigen::Vector3d& camera_t,
+                           const Eigen::Vector2d& observed_p) const;
 
-    double reprojectionError(const Eigen::Vector3d& P,
-                             const Eigen::Quaterniond& camera_q,
-                             const Eigen::Vector3d& camera_t,
-                             const Eigen::Vector2d& observed_p) const;
+  void projectPoints(const std::vector<cv::Point3f>& objectPoints, const cv::Mat& rvec,
+                     const cv::Mat& tvec, std::vector<cv::Point2f>& imagePoints) const;
 
-    void projectPoints(const std::vector<cv::Point3f>& objectPoints,
-                       const cv::Mat& rvec,
-                       const cv::Mat& tvec,
-                       std::vector<cv::Point2f>& imagePoints) const;
 protected:
-    cv::Mat m_mask;
+  cv::Mat m_mask;
 };
 
 typedef boost::shared_ptr<Camera> CameraPtr;
 typedef boost::shared_ptr<const Camera> CameraConstPtr;
 
-}
+}  // namespace camodocal
 
 #endif

--- a/include/frontend/camodocal/camera_models/CameraFactory.h
+++ b/include/frontend/camodocal/camera_models/CameraFactory.h
@@ -6,27 +6,24 @@
 
 #include "frontend/camodocal/camera_models/Camera.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
-class CameraFactory
-{
+class CameraFactory {
 public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-    CameraFactory();
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  CameraFactory();
 
-    static boost::shared_ptr<CameraFactory> instance(void);
+  static boost::shared_ptr<CameraFactory> instance(void);
 
-    CameraPtr generateCamera(Camera::ModelType modelType,
-                             const std::string& cameraName,
-                             cv::Size imageSize) const;
+  CameraPtr generateCamera(Camera::ModelType modelType, const std::string& cameraName,
+                           cv::Size imageSize) const;
 
-    CameraPtr generateCameraFromYamlFile(const std::string& filename);
+  CameraPtr generateCameraFromYamlFile(const std::string& filename);
 
 private:
-    static boost::shared_ptr<CameraFactory> m_instance;
+  static boost::shared_ptr<CameraFactory> m_instance;
 };
 
-}
+}  // namespace camodocal
 
 #endif

--- a/include/frontend/camodocal/camera_models/CataCamera.h
+++ b/include/frontend/camodocal/camera_models/CataCamera.h
@@ -4,207 +4,191 @@
 #include <opencv2/core/core.hpp>
 #include <string>
 
-#include "ceres/rotation.h"
 #include "Camera.h"
+#include "ceres/rotation.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
 /**
  * C. Mei, and P. Rives, Single View Point Omnidirectional Camera Calibration
  * from Planar Grids, ICRA 2007
  */
 
-class CataCamera: public Camera
-{
+class CataCamera : public Camera {
 public:
-    class Parameters: public Camera::Parameters
-    {
-    public:
-        Parameters();
-        Parameters(const std::string& cameraName,
-                   int w, int h,
-                   double xi,
-                   double k1, double k2, double p1, double p2,
-                   double gamma1, double gamma2, double u0, double v0);
+  class Parameters : public Camera::Parameters {
+  public:
+    Parameters();
+    Parameters(const std::string& cameraName, int w, int h, double xi, double k1, double k2,
+               double p1, double p2, double gamma1, double gamma2, double u0, double v0);
 
-        double& xi(void);
-        double& k1(void);
-        double& k2(void);
-        double& p1(void);
-        double& p2(void);
-        double& gamma1(void);
-        double& gamma2(void);
-        double& u0(void);
-        double& v0(void);
+    double& xi(void);
+    double& k1(void);
+    double& k2(void);
+    double& p1(void);
+    double& p2(void);
+    double& gamma1(void);
+    double& gamma2(void);
+    double& u0(void);
+    double& v0(void);
 
-        double xi(void) const;
-        double k1(void) const;
-        double k2(void) const;
-        double p1(void) const;
-        double p2(void) const;
-        double gamma1(void) const;
-        double gamma2(void) const;
-        double u0(void) const;
-        double v0(void) const;
+    double xi(void) const;
+    double k1(void) const;
+    double k2(void) const;
+    double p1(void) const;
+    double p2(void) const;
+    double gamma1(void) const;
+    double gamma2(void) const;
+    double u0(void) const;
+    double v0(void) const;
 
-        bool readFromYamlFile(const std::string& filename);
-        void writeToYamlFile(const std::string& filename) const;
+    bool readFromYamlFile(const std::string& filename);
+    void writeToYamlFile(const std::string& filename) const;
 
-        Parameters& operator=(const Parameters& other);
-        friend std::ostream& operator<< (std::ostream& out, const Parameters& params);
+    Parameters& operator=(const Parameters& other);
+    friend std::ostream& operator<<(std::ostream& out, const Parameters& params);
 
-    private:
-        double m_xi;
-        double m_k1;
-        double m_k2;
-        double m_p1;
-        double m_p2;
-        double m_gamma1;
-        double m_gamma2;
-        double m_u0;
-        double m_v0;
-    };
+  private:
+    double m_xi;
+    double m_k1;
+    double m_k2;
+    double m_p1;
+    double m_p2;
+    double m_gamma1;
+    double m_gamma2;
+    double m_u0;
+    double m_v0;
+  };
 
-    CataCamera();
+  CataCamera();
 
-    /**
-    * \brief Constructor from the projection model parameters
-    */
-    CataCamera(const std::string& cameraName,
-               int imageWidth, int imageHeight,
-               double xi, double k1, double k2, double p1, double p2,
-               double gamma1, double gamma2, double u0, double v0);
-    /**
-    * \brief Constructor from the projection model parameters
-    */
-    CataCamera(const Parameters& params);
+  /**
+   * \brief Constructor from the projection model parameters
+   */
+  CataCamera(const std::string& cameraName, int imageWidth, int imageHeight, double xi, double k1,
+             double k2, double p1, double p2, double gamma1, double gamma2, double u0, double v0);
+  /**
+   * \brief Constructor from the projection model parameters
+   */
+  CataCamera(const Parameters& params);
 
-    Camera::ModelType modelType(void) const;
-    const std::string& cameraName(void) const;
-    int imageWidth(void) const;
-    int imageHeight(void) const;
+  Camera::ModelType modelType(void) const;
+  const std::string& cameraName(void) const;
+  int imageWidth(void) const;
+  int imageHeight(void) const;
 
-    void estimateIntrinsics(const cv::Size& boardSize,
-                            const std::vector< std::vector<cv::Point3f> >& objectPoints,
-                            const std::vector< std::vector<cv::Point2f> >& imagePoints);
+  void estimateIntrinsics(const cv::Size& boardSize,
+                          const std::vector<std::vector<cv::Point3f> >& objectPoints,
+                          const std::vector<std::vector<cv::Point2f> >& imagePoints);
 
-    // Lift points from the image plane to the sphere
-    void liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
-    //%output P
+  // Lift points from the image plane to the sphere
+  void liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
+  //%output P
 
-    // Lift points from the image plane to the projective space
-    void liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
-    //%output P
+  // Lift points from the image plane to the projective space
+  void liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
+  //%output P
 
-    // Projects 3D points to the image plane (Pi function)
-    void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const;
-    //%output p
+  // Projects 3D points to the image plane (Pi function)
+  void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const;
+  //%output p
 
-    // Projects 3D points to the image plane (Pi function)
-    // and calculates jacobian
-    void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p,
-                      Eigen::Matrix<double,2,3>& J) const;
-    //%output p
-    //%output J
+  // Projects 3D points to the image plane (Pi function)
+  // and calculates jacobian
+  void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p,
+                    Eigen::Matrix<double, 2, 3>& J) const;
+  //%output p
+  //%output J
 
-    void undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const;
-    //%output p
+  void undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const;
+  //%output p
 
-    template <typename T>
-    static void spaceToPlane(const T* const params,
-                             const T* const q, const T* const t,
-                             const Eigen::Matrix<T, 3, 1>& P,
-                             Eigen::Matrix<T, 2, 1>& p);
+  template <typename T>
+  static void spaceToPlane(const T* const params, const T* const q, const T* const t,
+                           const Eigen::Matrix<T, 3, 1>& P, Eigen::Matrix<T, 2, 1>& p);
 
-    void distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u) const;
-    void distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u,
-                    Eigen::Matrix2d& J) const;
+  void distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u) const;
+  void distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u, Eigen::Matrix2d& J) const;
 
-    void initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale = 1.0) const;
-    cv::Mat initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2,
-                                    float fx = -1.0f, float fy = -1.0f,
-                                    cv::Size imageSize = cv::Size(0, 0),
-                                    float cx = -1.0f, float cy = -1.0f,
-                                    cv::Mat rmat = cv::Mat::eye(3, 3, CV_32F)) const;
+  void initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale = 1.0) const;
+  cv::Mat initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2, float fx = -1.0f, float fy = -1.0f,
+                                  cv::Size imageSize = cv::Size(0, 0), float cx = -1.0f,
+                                  float cy = -1.0f,
+                                  cv::Mat rmat = cv::Mat::eye(3, 3, CV_32F)) const;
 
-    int parameterCount(void) const;
+  int parameterCount(void) const;
 
-    const Parameters& getParameters(void) const;
-    void setParameters(const Parameters& parameters);
+  const Parameters& getParameters(void) const;
+  void setParameters(const Parameters& parameters);
 
-    void readParameters(const std::vector<double>& parameterVec);
-    void writeParameters(std::vector<double>& parameterVec) const;
+  void readParameters(const std::vector<double>& parameterVec);
+  void writeParameters(std::vector<double>& parameterVec) const;
 
-    void writeParametersToYamlFile(const std::string& filename) const;
+  void writeParametersToYamlFile(const std::string& filename) const;
 
-    std::string parametersToString(void) const;
+  std::string parametersToString(void) const;
 
 private:
-    Parameters mParameters;
+  Parameters mParameters;
 
-    double m_inv_K11, m_inv_K13, m_inv_K22, m_inv_K23;
-    bool m_noDistortion;
+  double m_inv_K11, m_inv_K13, m_inv_K22, m_inv_K23;
+  bool m_noDistortion;
 };
 
 typedef boost::shared_ptr<CataCamera> CataCameraPtr;
 typedef boost::shared_ptr<const CataCamera> CataCameraConstPtr;
 
 template <typename T>
-void
-CataCamera::spaceToPlane(const T* const params,
-                         const T* const q, const T* const t,
-                         const Eigen::Matrix<T, 3, 1>& P,
-                         Eigen::Matrix<T, 2, 1>& p)
-{
-    T P_w[3];
-    P_w[0] = T(P(0));
-    P_w[1] = T(P(1));
-    P_w[2] = T(P(2));
+void CataCamera::spaceToPlane(const T* const params, const T* const q, const T* const t,
+                              const Eigen::Matrix<T, 3, 1>& P, Eigen::Matrix<T, 2, 1>& p) {
+  T P_w[3];
+  P_w[0] = T(P(0));
+  P_w[1] = T(P(1));
+  P_w[2] = T(P(2));
 
-    // Convert quaternion from Eigen convention (x, y, z, w)
-    // to Ceres convention (w, x, y, z)
-    T q_ceres[4] = {q[3], q[0], q[1], q[2]};
+  // Convert quaternion from Eigen convention (x, y, z, w)
+  // to Ceres convention (w, x, y, z)
+  T q_ceres[4] = {q[3], q[0], q[1], q[2]};
 
-    T P_c[3];
-    ceres::QuaternionRotatePoint(q_ceres, P_w, P_c);
+  T P_c[3];
+  ceres::QuaternionRotatePoint(q_ceres, P_w, P_c);
 
-    P_c[0] += t[0];
-    P_c[1] += t[1];
-    P_c[2] += t[2];
+  P_c[0] += t[0];
+  P_c[1] += t[1];
+  P_c[2] += t[2];
 
-    // project 3D object point to the image plane
-    T xi = params[0];
-    T k1 = params[1];
-    T k2 = params[2];
-    T p1 = params[3];
-    T p2 = params[4];
-    T gamma1 = params[5];
-    T gamma2 = params[6];
-    T alpha = T(0); //cameraParams.alpha();
-    T u0 = params[7];
-    T v0 = params[8];
+  // project 3D object point to the image plane
+  T xi = params[0];
+  T k1 = params[1];
+  T k2 = params[2];
+  T p1 = params[3];
+  T p2 = params[4];
+  T gamma1 = params[5];
+  T gamma2 = params[6];
+  T alpha = T(0);  // cameraParams.alpha();
+  T u0 = params[7];
+  T v0 = params[8];
 
-    // Transform to model plane
-    T len = sqrt(P_c[0] * P_c[0] + P_c[1] * P_c[1] + P_c[2] * P_c[2]);
-    P_c[0] /= len;
-    P_c[1] /= len;
-    P_c[2] /= len;
+  // Transform to model plane
+  T len = sqrt(P_c[0] * P_c[0] + P_c[1] * P_c[1] + P_c[2] * P_c[2]);
+  P_c[0] /= len;
+  P_c[1] /= len;
+  P_c[2] /= len;
 
-    T u = P_c[0] / (P_c[2] + xi);
-    T v = P_c[1] / (P_c[2] + xi);
+  T u = P_c[0] / (P_c[2] + xi);
+  T v = P_c[1] / (P_c[2] + xi);
 
-    T rho_sqr = u * u + v * v;
-    T L = T(1.0) + k1 * rho_sqr + k2 * rho_sqr * rho_sqr;
-    T du = T(2.0) * p1 * u * v + p2 * (rho_sqr + T(2.0) * u * u);
-    T dv = p1 * (rho_sqr + T(2.0) * v * v) + T(2.0) * p2 * u * v;
+  T rho_sqr = u * u + v * v;
+  T L = T(1.0) + k1 * rho_sqr + k2 * rho_sqr * rho_sqr;
+  T du = T(2.0) * p1 * u * v + p2 * (rho_sqr + T(2.0) * u * u);
+  T dv = p1 * (rho_sqr + T(2.0) * v * v) + T(2.0) * p2 * u * v;
 
-    u = L * u + du;
-    v = L * v + dv;
-    p(0) = gamma1 * (u + alpha * v) + u0;
-    p(1) = gamma2 * v + v0;
+  u = L * u + du;
+  v = L * v + dv;
+  p(0) = gamma1 * (u + alpha * v) + u0;
+  p(1) = gamma2 * v + v0;
 }
 
-}
+}  // namespace camodocal
 
 #endif

--- a/include/frontend/camodocal/camera_models/CostFunctionFactory.h
+++ b/include/frontend/camodocal/camera_models/CostFunctionFactory.h
@@ -6,77 +6,71 @@
 
 #include "frontend/camodocal/camera_models/Camera.h"
 
-namespace ceres
-{
-    class CostFunction;
+namespace ceres {
+class CostFunction;
 }
 
-namespace camodocal
-{
+namespace camodocal {
 
-enum
-{
-    CAMERA_INTRINSICS =         1 << 0,
-    CAMERA_POSE =               1 << 1,
-    POINT_3D =                  1 << 2,
-    ODOMETRY_INTRINSICS =       1 << 3,
-    ODOMETRY_3D_POSE =          1 << 4,
-    ODOMETRY_6D_POSE =          1 << 5,
-    CAMERA_ODOMETRY_TRANSFORM = 1 << 6
+enum {
+  CAMERA_INTRINSICS = 1 << 0,
+  CAMERA_POSE = 1 << 1,
+  POINT_3D = 1 << 2,
+  ODOMETRY_INTRINSICS = 1 << 3,
+  ODOMETRY_3D_POSE = 1 << 4,
+  ODOMETRY_6D_POSE = 1 << 5,
+  CAMERA_ODOMETRY_TRANSFORM = 1 << 6
 };
 
-class CostFunctionFactory
-{
+class CostFunctionFactory {
 public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-    CostFunctionFactory();
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  CostFunctionFactory();
 
-    static boost::shared_ptr<CostFunctionFactory> instance(void);
+  static boost::shared_ptr<CostFunctionFactory> instance(void);
 
-    ceres::CostFunction* generateCostFunction(const CameraConstPtr& camera,
-                                              const Eigen::Vector3d& observed_P,
-                                              const Eigen::Vector2d& observed_p,
-                                              int flags) const;
+  ceres::CostFunction* generateCostFunction(const CameraConstPtr& camera,
+                                            const Eigen::Vector3d& observed_P,
+                                            const Eigen::Vector2d& observed_p, int flags) const;
 
-    ceres::CostFunction* generateCostFunction(const CameraConstPtr& camera,
-                                              const Eigen::Vector3d& observed_P,
-                                              const Eigen::Vector2d& observed_p,
-                                              const Eigen::Matrix2d& sqrtPrecisionMat,
-                                              int flags) const;
+  ceres::CostFunction* generateCostFunction(const CameraConstPtr& camera,
+                                            const Eigen::Vector3d& observed_P,
+                                            const Eigen::Vector2d& observed_p,
+                                            const Eigen::Matrix2d& sqrtPrecisionMat,
+                                            int flags) const;
 
-    ceres::CostFunction* generateCostFunction(const CameraConstPtr& camera,
-                                              const Eigen::Vector2d& observed_p,
-                                              int flags, bool optimize_cam_odo_z = true) const;
+  ceres::CostFunction* generateCostFunction(const CameraConstPtr& camera,
+                                            const Eigen::Vector2d& observed_p, int flags,
+                                            bool optimize_cam_odo_z = true) const;
 
-    ceres::CostFunction* generateCostFunction(const CameraConstPtr& camera,
-                                              const Eigen::Vector2d& observed_p,
-                                              const Eigen::Matrix2d& sqrtPrecisionMat,
-                                              int flags, bool optimize_cam_odo_z = true) const;
+  ceres::CostFunction* generateCostFunction(const CameraConstPtr& camera,
+                                            const Eigen::Vector2d& observed_p,
+                                            const Eigen::Matrix2d& sqrtPrecisionMat, int flags,
+                                            bool optimize_cam_odo_z = true) const;
 
-    ceres::CostFunction* generateCostFunction(const CameraConstPtr& camera,
-                                              const Eigen::Vector3d& odo_pos,
-                                              const Eigen::Vector3d& odo_att,
-                                              const Eigen::Vector2d& observed_p,
-                                              int flags, bool optimize_cam_odo_z = true) const;
+  ceres::CostFunction* generateCostFunction(const CameraConstPtr& camera,
+                                            const Eigen::Vector3d& odo_pos,
+                                            const Eigen::Vector3d& odo_att,
+                                            const Eigen::Vector2d& observed_p, int flags,
+                                            bool optimize_cam_odo_z = true) const;
 
-    ceres::CostFunction* generateCostFunction(const CameraConstPtr& camera,
-                                              const Eigen::Quaterniond& cam_odo_q,
-                                              const Eigen::Vector3d& cam_odo_t,
-                                              const Eigen::Vector3d& odo_pos,
-                                              const Eigen::Vector3d& odo_att,
-                                              const Eigen::Vector2d& observed_p,
-                                              int flags) const;
+  ceres::CostFunction* generateCostFunction(const CameraConstPtr& camera,
+                                            const Eigen::Quaterniond& cam_odo_q,
+                                            const Eigen::Vector3d& cam_odo_t,
+                                            const Eigen::Vector3d& odo_pos,
+                                            const Eigen::Vector3d& odo_att,
+                                            const Eigen::Vector2d& observed_p, int flags) const;
 
-    ceres::CostFunction* generateCostFunction(const CameraConstPtr& cameraLeft,
-                                              const CameraConstPtr& cameraRight,
-                                              const Eigen::Vector3d& observed_P,
-                                              const Eigen::Vector2d& observed_p_left,
-                                              const Eigen::Vector2d& observed_p_right) const;
+  ceres::CostFunction* generateCostFunction(const CameraConstPtr& cameraLeft,
+                                            const CameraConstPtr& cameraRight,
+                                            const Eigen::Vector3d& observed_P,
+                                            const Eigen::Vector2d& observed_p_left,
+                                            const Eigen::Vector2d& observed_p_right) const;
 
 private:
-    static boost::shared_ptr<CostFunctionFactory> m_instance;
+  static boost::shared_ptr<CostFunctionFactory> m_instance;
 };
 
-}
+}  // namespace camodocal
 
 #endif

--- a/include/frontend/camodocal/camera_models/EquidistantCamera.h
+++ b/include/frontend/camodocal/camera_models/EquidistantCamera.h
@@ -4,212 +4,191 @@
 #include <opencv2/core/core.hpp>
 #include <string>
 
-#include "ceres/rotation.h"
 #include "Camera.h"
+#include "ceres/rotation.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
 /**
  * J. Kannala, and S. Brandt, A Generic Camera Model and Calibration Method
  * for Conventional, Wide-Angle, and Fish-Eye Lenses, PAMI 2006
  */
 
-class EquidistantCamera: public Camera
-{
+class EquidistantCamera : public Camera {
 public:
-    class Parameters: public Camera::Parameters
-    {
-    public:
-        Parameters();
-        Parameters(const std::string& cameraName,
-                   int w, int h,
-                   double k2, double k3, double k4, double k5,
-                   double mu, double mv,
-                   double u0, double v0);
+  class Parameters : public Camera::Parameters {
+  public:
+    Parameters();
+    Parameters(const std::string& cameraName, int w, int h, double k2, double k3, double k4,
+               double k5, double mu, double mv, double u0, double v0);
 
-        double& k2(void);
-        double& k3(void);
-        double& k4(void);
-        double& k5(void);
-        double& mu(void);
-        double& mv(void);
-        double& u0(void);
-        double& v0(void);
+    double& k2(void);
+    double& k3(void);
+    double& k4(void);
+    double& k5(void);
+    double& mu(void);
+    double& mv(void);
+    double& u0(void);
+    double& v0(void);
 
-        double k2(void) const;
-        double k3(void) const;
-        double k4(void) const;
-        double k5(void) const;
-        double mu(void) const;
-        double mv(void) const;
-        double u0(void) const;
-        double v0(void) const;
+    double k2(void) const;
+    double k3(void) const;
+    double k4(void) const;
+    double k5(void) const;
+    double mu(void) const;
+    double mv(void) const;
+    double u0(void) const;
+    double v0(void) const;
 
-        bool readFromYamlFile(const std::string& filename);
-        void writeToYamlFile(const std::string& filename) const;
+    bool readFromYamlFile(const std::string& filename);
+    void writeToYamlFile(const std::string& filename) const;
 
-        Parameters& operator=(const Parameters& other);
-        friend std::ostream& operator<< (std::ostream& out, const Parameters& params);
+    Parameters& operator=(const Parameters& other);
+    friend std::ostream& operator<<(std::ostream& out, const Parameters& params);
 
-    private:
-        // projection
-        double m_k2;
-        double m_k3;
-        double m_k4;
-        double m_k5;
+  private:
+    // projection
+    double m_k2;
+    double m_k3;
+    double m_k4;
+    double m_k5;
 
-        double m_mu;
-        double m_mv;
-        double m_u0;
-        double m_v0;
-    };
+    double m_mu;
+    double m_mv;
+    double m_u0;
+    double m_v0;
+  };
 
-    EquidistantCamera();
+  EquidistantCamera();
 
-    /**
-    * \brief Constructor from the projection model parameters
-    */
-    EquidistantCamera(const std::string& cameraName,
-                      int imageWidth, int imageHeight,
-                      double k2, double k3, double k4, double k5,
-                      double mu, double mv,
-                      double u0, double v0);
-    /**
-    * \brief Constructor from the projection model parameters
-    */
-    EquidistantCamera(const Parameters& params);
+  /**
+   * \brief Constructor from the projection model parameters
+   */
+  EquidistantCamera(const std::string& cameraName, int imageWidth, int imageHeight, double k2,
+                    double k3, double k4, double k5, double mu, double mv, double u0, double v0);
+  /**
+   * \brief Constructor from the projection model parameters
+   */
+  EquidistantCamera(const Parameters& params);
 
-    Camera::ModelType modelType(void) const;
-    const std::string& cameraName(void) const;
-    int imageWidth(void) const;
-    int imageHeight(void) const;
+  Camera::ModelType modelType(void) const;
+  const std::string& cameraName(void) const;
+  int imageWidth(void) const;
+  int imageHeight(void) const;
 
-    void estimateIntrinsics(const cv::Size& boardSize,
-                            const std::vector< std::vector<cv::Point3f> >& objectPoints,
-                            const std::vector< std::vector<cv::Point2f> >& imagePoints);
+  void estimateIntrinsics(const cv::Size& boardSize,
+                          const std::vector<std::vector<cv::Point3f> >& objectPoints,
+                          const std::vector<std::vector<cv::Point2f> >& imagePoints);
 
-    // Lift points from the image plane to the sphere
-    virtual void liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
-    //%output P
+  // Lift points from the image plane to the sphere
+  virtual void liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
+  //%output P
 
-    // Lift points from the image plane to the projective space
-    void liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
-    //%output P
+  // Lift points from the image plane to the projective space
+  void liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
+  //%output P
 
-    // Projects 3D points to the image plane (Pi function)
-    void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const;
-    //%output p
+  // Projects 3D points to the image plane (Pi function)
+  void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const;
+  //%output p
 
-    // Projects 3D points to the image plane (Pi function)
-    // and calculates jacobian
-    void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p,
-                      Eigen::Matrix<double,2,3>& J) const;
-    //%output p
-    //%output J
+  // Projects 3D points to the image plane (Pi function)
+  // and calculates jacobian
+  void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p,
+                    Eigen::Matrix<double, 2, 3>& J) const;
+  //%output p
+  //%output J
 
-    void undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const;
-    //%output p
+  void undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const;
+  //%output p
 
-    template <typename T>
-    static void spaceToPlane(const T* const params,
-                             const T* const q, const T* const t,
-                             const Eigen::Matrix<T, 3, 1>& P,
-                             Eigen::Matrix<T, 2, 1>& p);
+  template <typename T>
+  static void spaceToPlane(const T* const params, const T* const q, const T* const t,
+                           const Eigen::Matrix<T, 3, 1>& P, Eigen::Matrix<T, 2, 1>& p);
 
-    void initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale = 1.0) const;
-    cv::Mat initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2,
-                                    float fx = -1.0f, float fy = -1.0f,
-                                    cv::Size imageSize = cv::Size(0, 0),
-                                    float cx = -1.0f, float cy = -1.0f,
-                                    cv::Mat rmat = cv::Mat::eye(3, 3, CV_32F)) const;
+  void initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale = 1.0) const;
+  cv::Mat initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2, float fx = -1.0f, float fy = -1.0f,
+                                  cv::Size imageSize = cv::Size(0, 0), float cx = -1.0f,
+                                  float cy = -1.0f,
+                                  cv::Mat rmat = cv::Mat::eye(3, 3, CV_32F)) const;
 
-    int parameterCount(void) const;
+  int parameterCount(void) const;
 
-    const Parameters& getParameters(void) const;
-    void setParameters(const Parameters& parameters);
+  const Parameters& getParameters(void) const;
+  void setParameters(const Parameters& parameters);
 
-    void readParameters(const std::vector<double>& parameterVec);
-    void writeParameters(std::vector<double>& parameterVec) const;
+  void readParameters(const std::vector<double>& parameterVec);
+  void writeParameters(std::vector<double>& parameterVec) const;
 
-    void writeParametersToYamlFile(const std::string& filename) const;
+  void writeParametersToYamlFile(const std::string& filename) const;
 
-    std::string parametersToString(void) const;
+  std::string parametersToString(void) const;
 
 private:
-    template<typename T>
-    static T r(T k2, T k3, T k4, T k5, T theta);
+  template <typename T>
+  static T r(T k2, T k3, T k4, T k5, T theta);
 
+  void fitOddPoly(const std::vector<double>& x, const std::vector<double>& y, int n,
+                  std::vector<double>& coeffs) const;
 
-    void fitOddPoly(const std::vector<double>& x, const std::vector<double>& y,
-                    int n, std::vector<double>& coeffs) const;
+  void backprojectSymmetric(const Eigen::Vector2d& p_u, double& theta, double& phi) const;
 
-    void backprojectSymmetric(const Eigen::Vector2d& p_u,
-                              double& theta, double& phi) const;
+  Parameters mParameters;
 
-    Parameters mParameters;
-
-    double m_inv_K11, m_inv_K13, m_inv_K22, m_inv_K23;
+  double m_inv_K11, m_inv_K13, m_inv_K22, m_inv_K23;
 };
 
 typedef boost::shared_ptr<EquidistantCamera> EquidistantCameraPtr;
 typedef boost::shared_ptr<const EquidistantCamera> EquidistantCameraConstPtr;
 
-template<typename T>
-T
-EquidistantCamera::r(T k2, T k3, T k4, T k5, T theta)
-{
-    // k1 = 1
-    return theta +
-           k2 * theta * theta * theta +
-           k3 * theta * theta * theta * theta * theta +
-           k4 * theta * theta * theta * theta * theta * theta * theta +
-           k5 * theta * theta * theta * theta * theta * theta * theta * theta * theta;
+template <typename T>
+T EquidistantCamera::r(T k2, T k3, T k4, T k5, T theta) {
+  // k1 = 1
+  return theta + k2 * theta * theta * theta + k3 * theta * theta * theta * theta * theta +
+         k4 * theta * theta * theta * theta * theta * theta * theta +
+         k5 * theta * theta * theta * theta * theta * theta * theta * theta * theta;
 }
 
 template <typename T>
-void
-EquidistantCamera::spaceToPlane(const T* const params,
-                                const T* const q, const T* const t,
-                                const Eigen::Matrix<T, 3, 1>& P,
-                                Eigen::Matrix<T, 2, 1>& p)
-{
-    T P_w[3];
-    P_w[0] = T(P(0));
-    P_w[1] = T(P(1));
-    P_w[2] = T(P(2));
+void EquidistantCamera::spaceToPlane(const T* const params, const T* const q, const T* const t,
+                                     const Eigen::Matrix<T, 3, 1>& P, Eigen::Matrix<T, 2, 1>& p) {
+  T P_w[3];
+  P_w[0] = T(P(0));
+  P_w[1] = T(P(1));
+  P_w[2] = T(P(2));
 
-    // Convert quaternion from Eigen convention (x, y, z, w)
-    // to Ceres convention (w, x, y, z)
-    T q_ceres[4] = {q[3], q[0], q[1], q[2]};
+  // Convert quaternion from Eigen convention (x, y, z, w)
+  // to Ceres convention (w, x, y, z)
+  T q_ceres[4] = {q[3], q[0], q[1], q[2]};
 
-    T P_c[3];
-    ceres::QuaternionRotatePoint(q_ceres, P_w, P_c);
+  T P_c[3];
+  ceres::QuaternionRotatePoint(q_ceres, P_w, P_c);
 
-    P_c[0] += t[0];
-    P_c[1] += t[1];
-    P_c[2] += t[2];
+  P_c[0] += t[0];
+  P_c[1] += t[1];
+  P_c[2] += t[2];
 
-    // project 3D object point to the image plane;
-    T k2 = params[0];
-    T k3 = params[1];
-    T k4 = params[2];
-    T k5 = params[3];
-    T mu = params[4];
-    T mv = params[5];
-    T u0 = params[6];
-    T v0 = params[7];
+  // project 3D object point to the image plane;
+  T k2 = params[0];
+  T k3 = params[1];
+  T k4 = params[2];
+  T k5 = params[3];
+  T mu = params[4];
+  T mv = params[5];
+  T u0 = params[6];
+  T v0 = params[7];
 
-    T len = sqrt(P_c[0] * P_c[0] + P_c[1] * P_c[1] + P_c[2] * P_c[2]);
-    T theta = acos(P_c[2] / len);
-    T phi = atan2(P_c[1], P_c[0]);
+  T len = sqrt(P_c[0] * P_c[0] + P_c[1] * P_c[1] + P_c[2] * P_c[2]);
+  T theta = acos(P_c[2] / len);
+  T phi = atan2(P_c[1], P_c[0]);
 
-    Eigen::Matrix<T,2,1> p_u = r(k2, k3, k4, k5, theta) * Eigen::Matrix<T,2,1>(cos(phi), sin(phi));
+  Eigen::Matrix<T, 2, 1> p_u =
+      r(k2, k3, k4, k5, theta) * Eigen::Matrix<T, 2, 1>(cos(phi), sin(phi));
 
-    p(0) = mu * p_u(0) + u0;
-    p(1) = mv * p_u(1) + v0;
+  p(0) = mu * p_u(0) + u0;
+  p(1) = mv * p_u(1) + v0;
 }
 
-}
+}  // namespace camodocal
 
 #endif

--- a/include/frontend/camodocal/camera_models/PinholeCamera.h
+++ b/include/frontend/camodocal/camera_models/PinholeCamera.h
@@ -4,193 +4,178 @@
 #include <opencv2/core/core.hpp>
 #include <string>
 
-#include "ceres/rotation.h"
 #include "Camera.h"
+#include "ceres/rotation.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
-class PinholeCamera: public Camera
-{
+class PinholeCamera : public Camera {
 public:
-    class Parameters: public Camera::Parameters
-    {
-    public:
-        Parameters();
-        Parameters(const std::string& cameraName,
-                   int w, int h,
-                   double k1, double k2, double p1, double p2,
-                   double fx, double fy, double cx, double cy);
+  class Parameters : public Camera::Parameters {
+  public:
+    Parameters();
+    Parameters(const std::string& cameraName, int w, int h, double k1, double k2, double p1,
+               double p2, double fx, double fy, double cx, double cy);
 
-        double& k1(void);
-        double& k2(void);
-        double& p1(void);
-        double& p2(void);
-        double& fx(void);
-        double& fy(void);
-        double& cx(void);
-        double& cy(void);
+    double& k1(void);
+    double& k2(void);
+    double& p1(void);
+    double& p2(void);
+    double& fx(void);
+    double& fy(void);
+    double& cx(void);
+    double& cy(void);
 
-        double xi(void) const;
-        double k1(void) const;
-        double k2(void) const;
-        double p1(void) const;
-        double p2(void) const;
-        double fx(void) const;
-        double fy(void) const;
-        double cx(void) const;
-        double cy(void) const;
+    double xi(void) const;
+    double k1(void) const;
+    double k2(void) const;
+    double p1(void) const;
+    double p2(void) const;
+    double fx(void) const;
+    double fy(void) const;
+    double cx(void) const;
+    double cy(void) const;
 
-        bool readFromYamlFile(const std::string& filename);
-        void writeToYamlFile(const std::string& filename) const;
+    bool readFromYamlFile(const std::string& filename);
+    void writeToYamlFile(const std::string& filename) const;
 
-        Parameters& operator=(const Parameters& other);
-        friend std::ostream& operator<< (std::ostream& out, const Parameters& params);
+    Parameters& operator=(const Parameters& other);
+    friend std::ostream& operator<<(std::ostream& out, const Parameters& params);
 
-    private:
-        double m_k1;
-        double m_k2;
-        double m_p1;
-        double m_p2;
-        double m_fx;
-        double m_fy;
-        double m_cx;
-        double m_cy;
-    };
+  private:
+    double m_k1;
+    double m_k2;
+    double m_p1;
+    double m_p2;
+    double m_fx;
+    double m_fy;
+    double m_cx;
+    double m_cy;
+  };
 
-    PinholeCamera();
+  PinholeCamera();
 
-    /**
-    * \brief Constructor from the projection model parameters
-    */
-    PinholeCamera(const std::string& cameraName,
-                  int imageWidth, int imageHeight,
-                  double k1, double k2, double p1, double p2,
-                  double fx, double fy, double cx, double cy);
-    /**
-    * \brief Constructor from the projection model parameters
-    */
-    PinholeCamera(const Parameters& params);
+  /**
+   * \brief Constructor from the projection model parameters
+   */
+  PinholeCamera(const std::string& cameraName, int imageWidth, int imageHeight, double k1,
+                double k2, double p1, double p2, double fx, double fy, double cx, double cy);
+  /**
+   * \brief Constructor from the projection model parameters
+   */
+  PinholeCamera(const Parameters& params);
 
-    Camera::ModelType modelType(void) const;
-    const std::string& cameraName(void) const;
-    int imageWidth(void) const;
-    int imageHeight(void) const;
+  Camera::ModelType modelType(void) const;
+  const std::string& cameraName(void) const;
+  int imageWidth(void) const;
+  int imageHeight(void) const;
 
-    void estimateIntrinsics(const cv::Size& boardSize,
-                            const std::vector< std::vector<cv::Point3f> >& objectPoints,
-                            const std::vector< std::vector<cv::Point2f> >& imagePoints);
+  void estimateIntrinsics(const cv::Size& boardSize,
+                          const std::vector<std::vector<cv::Point3f> >& objectPoints,
+                          const std::vector<std::vector<cv::Point2f> >& imagePoints);
 
-    // Lift points from the image plane to the sphere
-    virtual void liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
-    //%output P
+  // Lift points from the image plane to the sphere
+  virtual void liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
+  //%output P
 
-    // Lift points from the image plane to the projective space
-    void liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
-    //%output P
+  // Lift points from the image plane to the projective space
+  void liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
+  //%output P
 
-    // Projects 3D points to the image plane (Pi function)
-    void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const;
-    //%output p
+  // Projects 3D points to the image plane (Pi function)
+  void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const;
+  //%output p
 
-    // Projects 3D points to the image plane (Pi function)
-    // and calculates jacobian
-    void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p,
-                      Eigen::Matrix<double,2,3>& J) const;
-    //%output p
-    //%output J
+  // Projects 3D points to the image plane (Pi function)
+  // and calculates jacobian
+  void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p,
+                    Eigen::Matrix<double, 2, 3>& J) const;
+  //%output p
+  //%output J
 
-    void undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const;
-    //%output p
+  void undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const;
+  //%output p
 
-    template <typename T>
-    static void spaceToPlane(const T* const params,
-                             const T* const q, const T* const t,
-                             const Eigen::Matrix<T, 3, 1>& P,
-                             Eigen::Matrix<T, 2, 1>& p);
+  template <typename T>
+  static void spaceToPlane(const T* const params, const T* const q, const T* const t,
+                           const Eigen::Matrix<T, 3, 1>& P, Eigen::Matrix<T, 2, 1>& p);
 
-    void distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u) const;
-    void distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u,
-                    Eigen::Matrix2d& J) const;
+  void distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u) const;
+  void distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u, Eigen::Matrix2d& J) const;
 
-    void initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale = 1.0) const;
-    cv::Mat initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2,
-                                    float fx = -1.0f, float fy = -1.0f,
-                                    cv::Size imageSize = cv::Size(0, 0),
-                                    float cx = -1.0f, float cy = -1.0f,
-                                    cv::Mat rmat = cv::Mat::eye(3, 3, CV_32F)) const;
+  void initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale = 1.0) const;
+  cv::Mat initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2, float fx = -1.0f, float fy = -1.0f,
+                                  cv::Size imageSize = cv::Size(0, 0), float cx = -1.0f,
+                                  float cy = -1.0f,
+                                  cv::Mat rmat = cv::Mat::eye(3, 3, CV_32F)) const;
 
-    int parameterCount(void) const;
+  int parameterCount(void) const;
 
-    const Parameters& getParameters(void) const;
-    void setParameters(const Parameters& parameters);
+  const Parameters& getParameters(void) const;
+  void setParameters(const Parameters& parameters);
 
-    void readParameters(const std::vector<double>& parameterVec);
-    void writeParameters(std::vector<double>& parameterVec) const;
+  void readParameters(const std::vector<double>& parameterVec);
+  void writeParameters(std::vector<double>& parameterVec) const;
 
-    void writeParametersToYamlFile(const std::string& filename) const;
+  void writeParametersToYamlFile(const std::string& filename) const;
 
-    std::string parametersToString(void) const;
+  std::string parametersToString(void) const;
 
 private:
-    Parameters mParameters;
+  Parameters mParameters;
 
-    double m_inv_K11, m_inv_K13, m_inv_K22, m_inv_K23;
-    bool m_noDistortion;
+  double m_inv_K11, m_inv_K13, m_inv_K22, m_inv_K23;
+  bool m_noDistortion;
 };
 
 typedef boost::shared_ptr<PinholeCamera> PinholeCameraPtr;
 typedef boost::shared_ptr<const PinholeCamera> PinholeCameraConstPtr;
 
 template <typename T>
-void
-PinholeCamera::spaceToPlane(const T* const params,
-                            const T* const q, const T* const t,
-                            const Eigen::Matrix<T, 3, 1>& P,
-                            Eigen::Matrix<T, 2, 1>& p)
-{
-    T P_w[3];
-    P_w[0] = T(P(0));
-    P_w[1] = T(P(1));
-    P_w[2] = T(P(2));
+void PinholeCamera::spaceToPlane(const T* const params, const T* const q, const T* const t,
+                                 const Eigen::Matrix<T, 3, 1>& P, Eigen::Matrix<T, 2, 1>& p) {
+  T P_w[3];
+  P_w[0] = T(P(0));
+  P_w[1] = T(P(1));
+  P_w[2] = T(P(2));
 
-    // Convert quaternion from Eigen convention (x, y, z, w)
-    // to Ceres convention (w, x, y, z)
-    T q_ceres[4] = {q[3], q[0], q[1], q[2]};
+  // Convert quaternion from Eigen convention (x, y, z, w)
+  // to Ceres convention (w, x, y, z)
+  T q_ceres[4] = {q[3], q[0], q[1], q[2]};
 
-    T P_c[3];
-    ceres::QuaternionRotatePoint(q_ceres, P_w, P_c);
+  T P_c[3];
+  ceres::QuaternionRotatePoint(q_ceres, P_w, P_c);
 
-    P_c[0] += t[0];
-    P_c[1] += t[1];
-    P_c[2] += t[2];
+  P_c[0] += t[0];
+  P_c[1] += t[1];
+  P_c[2] += t[2];
 
-    // project 3D object point to the image plane
-    T k1 = params[0];
-    T k2 = params[1];
-    T p1 = params[2];
-    T p2 = params[3];
-    T fx = params[4];
-    T fy = params[5];
-    T alpha = T(0); //cameraParams.alpha();
-    T cx = params[6];
-    T cy = params[7];
+  // project 3D object point to the image plane
+  T k1 = params[0];
+  T k2 = params[1];
+  T p1 = params[2];
+  T p2 = params[3];
+  T fx = params[4];
+  T fy = params[5];
+  T alpha = T(0);  // cameraParams.alpha();
+  T cx = params[6];
+  T cy = params[7];
 
-    // Transform to model plane
-    T u = P_c[0] / P_c[2];
-    T v = P_c[1] / P_c[2];
+  // Transform to model plane
+  T u = P_c[0] / P_c[2];
+  T v = P_c[1] / P_c[2];
 
-    T rho_sqr = u * u + v * v;
-    T L = T(1.0) + k1 * rho_sqr + k2 * rho_sqr * rho_sqr;
-    T du = T(2.0) * p1 * u * v + p2 * (rho_sqr + T(2.0) * u * u);
-    T dv = p1 * (rho_sqr + T(2.0) * v * v) + T(2.0) * p2 * u * v;
+  T rho_sqr = u * u + v * v;
+  T L = T(1.0) + k1 * rho_sqr + k2 * rho_sqr * rho_sqr;
+  T du = T(2.0) * p1 * u * v + p2 * (rho_sqr + T(2.0) * u * u);
+  T dv = p1 * (rho_sqr + T(2.0) * v * v) + T(2.0) * p2 * u * v;
 
-    u = L * u + du;
-    v = L * v + dv;
-    p(0) = fx * (u + alpha * v) + cx;
-    p(1) = fy * v + cy;
+  u = L * u + du;
+  v = L * v + dv;
+  p(0) = fx * (u + alpha * v) + cx;
+  p(1) = fy * v + cy;
 }
 
-}
+}  // namespace camodocal
 
 #endif

--- a/include/frontend/camodocal/camera_models/ScaramuzzaCamera.h
+++ b/include/frontend/camodocal/camera_models/ScaramuzzaCamera.h
@@ -4,345 +4,317 @@
 #include <opencv2/core/core.hpp>
 #include <string>
 
-#include "ceres/rotation.h"
 #include "Camera.h"
+#include "ceres/rotation.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
 #define SCARAMUZZA_POLY_SIZE 5
 #define SCARAMUZZA_INV_POLY_SIZE 20
 
-#define SCARAMUZZA_CAMERA_NUM_PARAMS (SCARAMUZZA_POLY_SIZE + SCARAMUZZA_INV_POLY_SIZE + 2 /*center*/ + 3 /*affine*/)
+#define SCARAMUZZA_CAMERA_NUM_PARAMS \
+  (SCARAMUZZA_POLY_SIZE + SCARAMUZZA_INV_POLY_SIZE + 2 /*center*/ + 3 /*affine*/)
 
 /**
  * Scaramuzza Camera (Omnidirectional)
  * https://sites.google.com/site/scarabotix/ocamcalib-toolbox
  */
 
-class OCAMCamera: public Camera
-{
+class OCAMCamera : public Camera {
 public:
-    class Parameters: public Camera::Parameters
-    {
-    public:
-        Parameters();
+  class Parameters : public Camera::Parameters {
+  public:
+    Parameters();
 
-        double& C(void) { return m_C; }
-        double& D(void) { return m_D; }
-        double& E(void) { return m_E; }
+    double& C(void) { return m_C; }
+    double& D(void) { return m_D; }
+    double& E(void) { return m_E; }
 
-        double& center_x(void) { return m_center_x; }
-        double& center_y(void) { return m_center_y; }
+    double& center_x(void) { return m_center_x; }
+    double& center_y(void) { return m_center_y; }
 
-        double& poly(int idx) { return m_poly[idx]; }
-        double& inv_poly(int idx) { return m_inv_poly[idx]; }
+    double& poly(int idx) { return m_poly[idx]; }
+    double& inv_poly(int idx) { return m_inv_poly[idx]; }
 
-        double C(void) const { return m_C; }
-        double D(void) const { return m_D; }
-        double E(void) const { return m_E; }
+    double C(void) const { return m_C; }
+    double D(void) const { return m_D; }
+    double E(void) const { return m_E; }
 
-        double center_x(void) const { return m_center_x; }
-        double center_y(void) const { return m_center_y; }
+    double center_x(void) const { return m_center_x; }
+    double center_y(void) const { return m_center_y; }
 
-        double poly(int idx) const { return m_poly[idx]; }
-        double inv_poly(int idx) const { return m_inv_poly[idx]; }
+    double poly(int idx) const { return m_poly[idx]; }
+    double inv_poly(int idx) const { return m_inv_poly[idx]; }
 
-        bool readFromYamlFile(const std::string& filename);
-        void writeToYamlFile(const std::string& filename) const;
+    bool readFromYamlFile(const std::string& filename);
+    void writeToYamlFile(const std::string& filename) const;
 
-        Parameters& operator=(const Parameters& other);
-        friend std::ostream& operator<< (std::ostream& out, const Parameters& params);
+    Parameters& operator=(const Parameters& other);
+    friend std::ostream& operator<<(std::ostream& out, const Parameters& params);
 
-    private:
-        double m_poly[SCARAMUZZA_POLY_SIZE];
-        double m_inv_poly[SCARAMUZZA_INV_POLY_SIZE];
-        double m_C;
-        double m_D;
-        double m_E;
-        double m_center_x;
-        double m_center_y;
-    };
+  private:
+    double m_poly[SCARAMUZZA_POLY_SIZE];
+    double m_inv_poly[SCARAMUZZA_INV_POLY_SIZE];
+    double m_C;
+    double m_D;
+    double m_E;
+    double m_center_x;
+    double m_center_y;
+  };
 
-    OCAMCamera();
+  OCAMCamera();
 
-    /**
-    * \brief Constructor from the projection model parameters
-    */
-    OCAMCamera(const Parameters& params);
+  /**
+   * \brief Constructor from the projection model parameters
+   */
+  OCAMCamera(const Parameters& params);
 
-    Camera::ModelType modelType(void) const;
-    const std::string& cameraName(void) const;
-    int imageWidth(void) const;
-    int imageHeight(void) const;
+  Camera::ModelType modelType(void) const;
+  const std::string& cameraName(void) const;
+  int imageWidth(void) const;
+  int imageHeight(void) const;
 
-    void estimateIntrinsics(const cv::Size& boardSize,
-                            const std::vector< std::vector<cv::Point3f> >& objectPoints,
-                            const std::vector< std::vector<cv::Point2f> >& imagePoints);
+  void estimateIntrinsics(const cv::Size& boardSize,
+                          const std::vector<std::vector<cv::Point3f> >& objectPoints,
+                          const std::vector<std::vector<cv::Point2f> >& imagePoints);
 
-    // Lift points from the image plane to the sphere
-    void liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
-    //%output P
+  // Lift points from the image plane to the sphere
+  void liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
+  //%output P
 
-    // Lift points from the image plane to the projective space
-    void liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
-    //%output P
+  // Lift points from the image plane to the projective space
+  void liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const;
+  //%output P
 
-    // Projects 3D points to the image plane (Pi function)
-    void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const;
-    //%output p
+  // Projects 3D points to the image plane (Pi function)
+  void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const;
+  //%output p
 
-    // Projects 3D points to the image plane (Pi function)
-    // and calculates jacobian
-    //void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p,
-    //                  Eigen::Matrix<double,2,3>& J) const;
-    //%output p
-    //%output J
+  // Projects 3D points to the image plane (Pi function)
+  // and calculates jacobian
+  // void spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p,
+  //                  Eigen::Matrix<double,2,3>& J) const;
+  //%output p
+  //%output J
 
-    void undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const;
-    //%output p
+  void undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const;
+  //%output p
 
-    template <typename T>
-    static void spaceToPlane(const T* const params,
-                             const T* const q, const T* const t,
-                             const Eigen::Matrix<T, 3, 1>& P,
-                             Eigen::Matrix<T, 2, 1>& p);
-    template <typename T>
-    static void spaceToSphere(const T* const params,
-                              const T* const q, const T* const t,
-                              const Eigen::Matrix<T, 3, 1>& P,
-                              Eigen::Matrix<T, 3, 1>& P_s);
-    template <typename T>
-    static void LiftToSphere(const T* const params,
-                              const Eigen::Matrix<T, 2, 1>& p,
-                              Eigen::Matrix<T, 3, 1>& P);
+  template <typename T>
+  static void spaceToPlane(const T* const params, const T* const q, const T* const t,
+                           const Eigen::Matrix<T, 3, 1>& P, Eigen::Matrix<T, 2, 1>& p);
+  template <typename T>
+  static void spaceToSphere(const T* const params, const T* const q, const T* const t,
+                            const Eigen::Matrix<T, 3, 1>& P, Eigen::Matrix<T, 3, 1>& P_s);
+  template <typename T>
+  static void LiftToSphere(const T* const params, const Eigen::Matrix<T, 2, 1>& p,
+                           Eigen::Matrix<T, 3, 1>& P);
 
-    template <typename T>
-    static void SphereToPlane(const T* const params, const Eigen::Matrix<T, 3, 1>& P,
-                               Eigen::Matrix<T, 2, 1>& p);
+  template <typename T>
+  static void SphereToPlane(const T* const params, const Eigen::Matrix<T, 3, 1>& P,
+                            Eigen::Matrix<T, 2, 1>& p);
 
+  void initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale = 1.0) const;
+  cv::Mat initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2, float fx = -1.0f, float fy = -1.0f,
+                                  cv::Size imageSize = cv::Size(0, 0), float cx = -1.0f,
+                                  float cy = -1.0f,
+                                  cv::Mat rmat = cv::Mat::eye(3, 3, CV_32F)) const;
 
-    void initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale = 1.0) const;
-    cv::Mat initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2,
-                                    float fx = -1.0f, float fy = -1.0f,
-                                    cv::Size imageSize = cv::Size(0, 0),
-                                    float cx = -1.0f, float cy = -1.0f,
-                                    cv::Mat rmat = cv::Mat::eye(3, 3, CV_32F)) const;
+  int parameterCount(void) const;
 
-    int parameterCount(void) const;
+  const Parameters& getParameters(void) const;
+  void setParameters(const Parameters& parameters);
 
-    const Parameters& getParameters(void) const;
-    void setParameters(const Parameters& parameters);
+  void readParameters(const std::vector<double>& parameterVec);
+  void writeParameters(std::vector<double>& parameterVec) const;
 
-    void readParameters(const std::vector<double>& parameterVec);
-    void writeParameters(std::vector<double>& parameterVec) const;
+  void writeParametersToYamlFile(const std::string& filename) const;
 
-    void writeParametersToYamlFile(const std::string& filename) const;
-
-    std::string parametersToString(void) const;
+  std::string parametersToString(void) const;
 
 private:
-    Parameters mParameters;
+  Parameters mParameters;
 
-    double m_inv_scale;
+  double m_inv_scale;
 };
 
 typedef boost::shared_ptr<OCAMCamera> OCAMCameraPtr;
 typedef boost::shared_ptr<const OCAMCamera> OCAMCameraConstPtr;
 
 template <typename T>
-void
-OCAMCamera::spaceToPlane(const T* const params,
-                         const T* const q, const T* const t,
-                         const Eigen::Matrix<T, 3, 1>& P,
-                         Eigen::Matrix<T, 2, 1>& p)
-{
-    T P_c[3];
-    {
-        T P_w[3];
-        P_w[0] = T(P(0));
-        P_w[1] = T(P(1));
-        P_w[2] = T(P(2));
+void OCAMCamera::spaceToPlane(const T* const params, const T* const q, const T* const t,
+                              const Eigen::Matrix<T, 3, 1>& P, Eigen::Matrix<T, 2, 1>& p) {
+  T P_c[3];
+  {
+    T P_w[3];
+    P_w[0] = T(P(0));
+    P_w[1] = T(P(1));
+    P_w[2] = T(P(2));
 
-        // Convert quaternion from Eigen convention (x, y, z, w)
-        // to Ceres convention (w, x, y, z)
-        T q_ceres[4] = {q[3], q[0], q[1], q[2]};
+    // Convert quaternion from Eigen convention (x, y, z, w)
+    // to Ceres convention (w, x, y, z)
+    T q_ceres[4] = {q[3], q[0], q[1], q[2]};
 
-        ceres::QuaternionRotatePoint(q_ceres, P_w, P_c);
+    ceres::QuaternionRotatePoint(q_ceres, P_w, P_c);
 
-        P_c[0] += t[0];
-        P_c[1] += t[1];
-        P_c[2] += t[2];
-    }
+    P_c[0] += t[0];
+    P_c[1] += t[1];
+    P_c[2] += t[2];
+  }
 
-    T c = params[0];
-    T d = params[1];
-    T e = params[2];
-    T xc[2] = { params[3], params[4] };
+  T c = params[0];
+  T d = params[1];
+  T e = params[2];
+  T xc[2] = {params[3], params[4]};
 
-    //T poly[SCARAMUZZA_POLY_SIZE];
-    //for (int i=0; i < SCARAMUZZA_POLY_SIZE; i++)
-    //    poly[i] = params[5+i];
+  // T poly[SCARAMUZZA_POLY_SIZE];
+  // for (int i=0; i < SCARAMUZZA_POLY_SIZE; i++)
+  //     poly[i] = params[5+i];
 
-    T inv_poly[SCARAMUZZA_INV_POLY_SIZE];
-    for (int i=0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
-        inv_poly[i] = params[5 + SCARAMUZZA_POLY_SIZE + i];
+  T inv_poly[SCARAMUZZA_INV_POLY_SIZE];
+  for (int i = 0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
+    inv_poly[i] = params[5 + SCARAMUZZA_POLY_SIZE + i];
 
-    T norm_sqr = P_c[0] * P_c[0] + P_c[1] * P_c[1];
-    T norm = T(0.0);
-    if (norm_sqr > T(0.0))
-        norm = sqrt(norm_sqr);
+  T norm_sqr = P_c[0] * P_c[0] + P_c[1] * P_c[1];
+  T norm = T(0.0);
+  if (norm_sqr > T(0.0)) norm = sqrt(norm_sqr);
 
-    T theta = atan2(-P_c[2], norm);
-    T rho = T(0.0);
-    T theta_i = T(1.0);
+  T theta = atan2(-P_c[2], norm);
+  T rho = T(0.0);
+  T theta_i = T(1.0);
 
-    for (int i = 0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
-    {
-        rho += theta_i * inv_poly[i];
-        theta_i *= theta;
-    }
+  for (int i = 0; i < SCARAMUZZA_INV_POLY_SIZE; i++) {
+    rho += theta_i * inv_poly[i];
+    theta_i *= theta;
+  }
 
-    T invNorm = T(1.0) / norm;
-    T xn[2] = {
-        P_c[0] * invNorm * rho,
-        P_c[1] * invNorm * rho
-    };
+  T invNorm = T(1.0) / norm;
+  T xn[2] = {P_c[0] * invNorm * rho, P_c[1] * invNorm * rho};
 
-    p(0) = xn[0] * c + xn[1] * d + xc[0];
-    p(1) = xn[0] * e + xn[1]     + xc[1];
+  p(0) = xn[0] * c + xn[1] * d + xc[0];
+  p(1) = xn[0] * e + xn[1] + xc[1];
 }
 
 template <typename T>
-void
-OCAMCamera::spaceToSphere(const T* const params,
-                          const T* const q, const T* const t,
-                          const Eigen::Matrix<T, 3, 1>& P,
-                          Eigen::Matrix<T, 3, 1>& P_s)
-{
-    T P_c[3];
-    {
-        T P_w[3];
-        P_w[0] = T(P(0));
-        P_w[1] = T(P(1));
-        P_w[2] = T(P(2));
+void OCAMCamera::spaceToSphere(const T* const params, const T* const q, const T* const t,
+                               const Eigen::Matrix<T, 3, 1>& P, Eigen::Matrix<T, 3, 1>& P_s) {
+  T P_c[3];
+  {
+    T P_w[3];
+    P_w[0] = T(P(0));
+    P_w[1] = T(P(1));
+    P_w[2] = T(P(2));
 
-        // Convert quaternion from Eigen convention (x, y, z, w)
-        // to Ceres convention (w, x, y, z)
-        T q_ceres[4] = {q[3], q[0], q[1], q[2]};
+    // Convert quaternion from Eigen convention (x, y, z, w)
+    // to Ceres convention (w, x, y, z)
+    T q_ceres[4] = {q[3], q[0], q[1], q[2]};
 
-        ceres::QuaternionRotatePoint(q_ceres, P_w, P_c);
+    ceres::QuaternionRotatePoint(q_ceres, P_w, P_c);
 
-        P_c[0] += t[0];
-        P_c[1] += t[1];
-        P_c[2] += t[2];
-    }
+    P_c[0] += t[0];
+    P_c[1] += t[1];
+    P_c[2] += t[2];
+  }
 
-    //T poly[SCARAMUZZA_POLY_SIZE];
-    //for (int i=0; i < SCARAMUZZA_POLY_SIZE; i++)
-    //    poly[i] = params[5+i];
+  // T poly[SCARAMUZZA_POLY_SIZE];
+  // for (int i=0; i < SCARAMUZZA_POLY_SIZE; i++)
+  //     poly[i] = params[5+i];
 
-    T norm_sqr = P_c[0] * P_c[0] + P_c[1] * P_c[1] + P_c[2] * P_c[2];
-    T norm = T(0.0);
-    if (norm_sqr > T(0.0))
-        norm = sqrt(norm_sqr);
+  T norm_sqr = P_c[0] * P_c[0] + P_c[1] * P_c[1] + P_c[2] * P_c[2];
+  T norm = T(0.0);
+  if (norm_sqr > T(0.0)) norm = sqrt(norm_sqr);
 
-    P_s(0) = P_c[0] / norm;
-    P_s(1) = P_c[1] / norm;
-    P_s(2) = P_c[2] / norm;
+  P_s(0) = P_c[0] / norm;
+  P_s(1) = P_c[1] / norm;
+  P_s(2) = P_c[2] / norm;
 }
 
 template <typename T>
-void
-OCAMCamera::LiftToSphere(const T* const params,
-                          const Eigen::Matrix<T, 2, 1>& p,
-                          Eigen::Matrix<T, 3, 1>& P)
-{
-    T c = params[0];
-    T d = params[1];
-    T e = params[2];
-    T cc[2] = { params[3], params[4] };
-    T poly[SCARAMUZZA_POLY_SIZE];
-    for (int i=0; i < SCARAMUZZA_POLY_SIZE; i++)
-       poly[i] = params[5+i];
+void OCAMCamera::LiftToSphere(const T* const params, const Eigen::Matrix<T, 2, 1>& p,
+                              Eigen::Matrix<T, 3, 1>& P) {
+  T c = params[0];
+  T d = params[1];
+  T e = params[2];
+  T cc[2] = {params[3], params[4]};
+  T poly[SCARAMUZZA_POLY_SIZE];
+  for (int i = 0; i < SCARAMUZZA_POLY_SIZE; i++) poly[i] = params[5 + i];
 
-    // Relative to Center
-    T p_2d[2];
-    p_2d[0] = T(p(0));
-    p_2d[1] = T(p(1));
+  // Relative to Center
+  T p_2d[2];
+  p_2d[0] = T(p(0));
+  p_2d[1] = T(p(1));
 
-    T xc[2] = { p_2d[0] - cc[0], p_2d[1] - cc[1]};
+  T xc[2] = {p_2d[0] - cc[0], p_2d[1] - cc[1]};
 
-    T inv_scale = T(1.0) / (c - d * e);
+  T inv_scale = T(1.0) / (c - d * e);
 
-    // Affine Transformation
-    T xc_a[2];
+  // Affine Transformation
+  T xc_a[2];
 
-    xc_a[0] = inv_scale * (xc[0] - d * xc[1]);
-    xc_a[1] = inv_scale * (-e * xc[0] + c * xc[1]);
+  xc_a[0] = inv_scale * (xc[0] - d * xc[1]);
+  xc_a[1] = inv_scale * (-e * xc[0] + c * xc[1]);
 
-    T norm_sqr = xc_a[0] * xc_a[0] + xc_a[1] * xc_a[1];
-    T phi = sqrt(norm_sqr);
-    T phi_i = T(1.0);
-    T z = T(0.0);
+  T norm_sqr = xc_a[0] * xc_a[0] + xc_a[1] * xc_a[1];
+  T phi = sqrt(norm_sqr);
+  T phi_i = T(1.0);
+  T z = T(0.0);
 
-    for (int i = 0; i < SCARAMUZZA_POLY_SIZE; i++)
-    {
-        if (i!=1) {
-            z += phi_i * poly[i];
-        }
-        phi_i *= phi;
+  for (int i = 0; i < SCARAMUZZA_POLY_SIZE; i++) {
+    if (i != 1) {
+      z += phi_i * poly[i];
     }
+    phi_i *= phi;
+  }
 
-    T p_3d[3];
-    p_3d[0] = xc[0];
-    p_3d[1] = xc[1];
-    p_3d[2] = -z;
+  T p_3d[3];
+  p_3d[0] = xc[0];
+  p_3d[1] = xc[1];
+  p_3d[2] = -z;
 
-    T p_3d_norm_sqr = p_3d[0] * p_3d[0] + p_3d[1] * p_3d[1] + p_3d[2] * p_3d[2];
-    T p_3d_norm = sqrt(p_3d_norm_sqr);
+  T p_3d_norm_sqr = p_3d[0] * p_3d[0] + p_3d[1] * p_3d[1] + p_3d[2] * p_3d[2];
+  T p_3d_norm = sqrt(p_3d_norm_sqr);
 
-    P << p_3d[0] / p_3d_norm, p_3d[1] / p_3d_norm, p_3d[2] / p_3d_norm;
+  P << p_3d[0] / p_3d_norm, p_3d[1] / p_3d_norm, p_3d[2] / p_3d_norm;
 }
 
 template <typename T>
 void OCAMCamera::SphereToPlane(const T* const params, const Eigen::Matrix<T, 3, 1>& P,
                                Eigen::Matrix<T, 2, 1>& p) {
-    T P_c[3];
-    {
-        P_c[0] = T(P(0));
-        P_c[1] = T(P(1));
-        P_c[2] = T(P(2));
-    }
+  T P_c[3];
+  {
+    P_c[0] = T(P(0));
+    P_c[1] = T(P(1));
+    P_c[2] = T(P(2));
+  }
 
-    T c = params[0];
-    T d = params[1];
-    T e = params[2];
-    T xc[2] = {params[3], params[4]};
+  T c = params[0];
+  T d = params[1];
+  T e = params[2];
+  T xc[2] = {params[3], params[4]};
 
-    T inv_poly[SCARAMUZZA_INV_POLY_SIZE];
-    for (int i = 0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
-        inv_poly[i] = params[5 + SCARAMUZZA_POLY_SIZE + i];
+  T inv_poly[SCARAMUZZA_INV_POLY_SIZE];
+  for (int i = 0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
+    inv_poly[i] = params[5 + SCARAMUZZA_POLY_SIZE + i];
 
-    T norm_sqr = P_c[0] * P_c[0] + P_c[1] * P_c[1];
-    T norm = T(0.0);
-    if (norm_sqr > T(0.0)) norm = sqrt(norm_sqr);
+  T norm_sqr = P_c[0] * P_c[0] + P_c[1] * P_c[1];
+  T norm = T(0.0);
+  if (norm_sqr > T(0.0)) norm = sqrt(norm_sqr);
 
-    T theta = atan2(-P_c[2], norm);
-    T rho = T(0.0);
-    T theta_i = T(1.0);
+  T theta = atan2(-P_c[2], norm);
+  T rho = T(0.0);
+  T theta_i = T(1.0);
 
-    for (int i = 0; i < SCARAMUZZA_INV_POLY_SIZE; i++) {
-        rho += theta_i * inv_poly[i];
-        theta_i *= theta;
-    }
+  for (int i = 0; i < SCARAMUZZA_INV_POLY_SIZE; i++) {
+    rho += theta_i * inv_poly[i];
+    theta_i *= theta;
+  }
 
-    T invNorm = T(1.0) / norm;
-    T xn[2] = {P_c[0] * invNorm * rho, P_c[1] * invNorm * rho};
+  T invNorm = T(1.0) / norm;
+  T xn[2] = {P_c[0] * invNorm * rho, P_c[1] * invNorm * rho};
 
-    p(0) = xn[0] * c + xn[1] * d + xc[0];
-    p(1) = xn[0] * e + xn[1] + xc[1];
+  p(0) = xn[0] * c + xn[1] * d + xc[0];
+  p(1) = xn[0] * e + xn[1] + xc[1];
 }
-}
+}  // namespace camodocal
 
 #endif

--- a/include/frontend/camodocal/gpl/EigenQuaternionParameterization.h
+++ b/include/frontend/camodocal/gpl/EigenQuaternionParameterization.h
@@ -3,38 +3,30 @@
 
 #include "ceres/local_parameterization.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
-class EigenQuaternionParameterization : public ceres::LocalParameterization
-{
+class EigenQuaternionParameterization : public ceres::LocalParameterization {
 public:
-    virtual ~EigenQuaternionParameterization() {}
-    virtual bool Plus(const double* x,
-                      const double* delta,
-                      double* x_plus_delta) const;
-    virtual bool ComputeJacobian(const double* x,
-                                 double* jacobian) const;
-    virtual int GlobalSize() const { return 4; }
-    virtual int LocalSize() const { return 3; }
+  virtual ~EigenQuaternionParameterization() {}
+  virtual bool Plus(const double* x, const double* delta, double* x_plus_delta) const;
+  virtual bool ComputeJacobian(const double* x, double* jacobian) const;
+  virtual int GlobalSize() const { return 4; }
+  virtual int LocalSize() const { return 3; }
 
 private:
-    template<typename T>
-    void EigenQuaternionProduct(const T z[4], const T w[4], T zw[4]) const;
+  template <typename T>
+  void EigenQuaternionProduct(const T z[4], const T w[4], T zw[4]) const;
 };
 
-
-template<typename T>
-void
-EigenQuaternionParameterization::EigenQuaternionProduct(const T z[4], const T w[4], T zw[4]) const
-{
-    zw[0] = z[3] * w[0] + z[0] * w[3] + z[1] * w[2] - z[2] * w[1];
-    zw[1] = z[3] * w[1] - z[0] * w[2] + z[1] * w[3] + z[2] * w[0];
-    zw[2] = z[3] * w[2] + z[0] * w[1] - z[1] * w[0] + z[2] * w[3];
-    zw[3] = z[3] * w[3] - z[0] * w[0] - z[1] * w[1] - z[2] * w[2];
+template <typename T>
+void EigenQuaternionParameterization::EigenQuaternionProduct(const T z[4], const T w[4],
+                                                             T zw[4]) const {
+  zw[0] = z[3] * w[0] + z[0] * w[3] + z[1] * w[2] - z[2] * w[1];
+  zw[1] = z[3] * w[1] - z[0] * w[2] + z[1] * w[3] + z[2] * w[0];
+  zw[2] = z[3] * w[2] + z[0] * w[1] - z[1] * w[0] + z[2] * w[3];
+  zw[3] = z[3] * w[3] - z[0] * w[0] - z[1] * w[1] - z[2] * w[2];
 }
 
-}
+}  // namespace camodocal
 
 #endif
-

--- a/include/frontend/camodocal/gpl/EigenUtils.h
+++ b/include/frontend/camodocal/gpl/EigenUtils.h
@@ -3,416 +3,379 @@
 
 #include <eigen3/Eigen/Dense>
 
-#include "ceres/rotation.h"
 #include "camodocal/gpl/gpl.h"
+#include "ceres/rotation.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
 // Returns the 3D cross product skew symmetric matrix of a given 3D vector
-template<typename T>
-Eigen::Matrix<T, 3, 3> skew(const Eigen::Matrix<T, 3, 1>& vec)
-{
-    return (Eigen::Matrix<T, 3, 3>() << T(0), -vec(2), vec(1),
-                                        vec(2), T(0), -vec(0),
-                                        -vec(1), vec(0), T(0)).finished();
+template <typename T>
+Eigen::Matrix<T, 3, 3> skew(const Eigen::Matrix<T, 3, 1>& vec) {
+  return (Eigen::Matrix<T, 3, 3>() << T(0), -vec(2), vec(1), vec(2), T(0), -vec(0), -vec(1), vec(0),
+          T(0))
+      .finished();
 }
 
-template<typename Derived>
-typename Eigen::MatrixBase<Derived>::PlainObject sqrtm(const Eigen::MatrixBase<Derived>& A)
-{
-    Eigen::SelfAdjointEigenSolver<typename Derived::PlainObject> es(A);
+template <typename Derived>
+typename Eigen::MatrixBase<Derived>::PlainObject sqrtm(const Eigen::MatrixBase<Derived>& A) {
+  Eigen::SelfAdjointEigenSolver<typename Derived::PlainObject> es(A);
 
-    return es.operatorSqrt();
+  return es.operatorSqrt();
 }
 
-template<typename T>
-Eigen::Matrix<T, 3, 3> AngleAxisToRotationMatrix(const Eigen::Matrix<T, 3, 1>& rvec)
-{
-    T angle = rvec.norm();
-    if (angle == T(0))
-    {
-        return Eigen::Matrix<T, 3, 3>::Identity();
+template <typename T>
+Eigen::Matrix<T, 3, 3> AngleAxisToRotationMatrix(const Eigen::Matrix<T, 3, 1>& rvec) {
+  T angle = rvec.norm();
+  if (angle == T(0)) {
+    return Eigen::Matrix<T, 3, 3>::Identity();
+  }
+
+  Eigen::Matrix<T, 3, 1> axis;
+  axis = rvec.normalized();
+
+  Eigen::Matrix<T, 3, 3> rmat;
+  rmat = Eigen::AngleAxis<T>(angle, axis);
+
+  return rmat;
+}
+
+template <typename T>
+Eigen::Quaternion<T> AngleAxisToQuaternion(const Eigen::Matrix<T, 3, 1>& rvec) {
+  Eigen::Matrix<T, 3, 3> rmat = AngleAxisToRotationMatrix<T>(rvec);
+
+  return Eigen::Quaternion<T>(rmat);
+}
+
+template <typename T>
+void AngleAxisToQuaternion(const Eigen::Matrix<T, 3, 1>& rvec, T* q) {
+  Eigen::Quaternion<T> quat = AngleAxisToQuaternion<T>(rvec);
+
+  q[0] = quat.x();
+  q[1] = quat.y();
+  q[2] = quat.z();
+  q[3] = quat.w();
+}
+
+template <typename T>
+Eigen::Matrix<T, 3, 1> RotationToAngleAxis(const Eigen::Matrix<T, 3, 3>& rmat) {
+  Eigen::AngleAxis<T> angleaxis;
+  angleaxis.fromRotationMatrix(rmat);
+  return angleaxis.angle() * angleaxis.axis();
+}
+
+template <typename T>
+void QuaternionToAngleAxis(const T* const q, Eigen::Matrix<T, 3, 1>& rvec) {
+  Eigen::Quaternion<T> quat(q[3], q[0], q[1], q[2]);
+
+  Eigen::Matrix<T, 3, 3> rmat = quat.toRotationMatrix();
+
+  Eigen::AngleAxis<T> angleaxis;
+  angleaxis.fromRotationMatrix(rmat);
+
+  rvec = angleaxis.angle() * angleaxis.axis();
+}
+
+template <typename T>
+Eigen::Matrix<T, 3, 3> QuaternionToRotation(const T* const q) {
+  T R[9];
+  ceres::QuaternionToRotation(q, R);
+
+  Eigen::Matrix<T, 3, 3> rmat;
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      rmat(i, j) = R[i * 3 + j];
     }
+  }
 
-    Eigen::Matrix<T, 3, 1> axis;
-    axis = rvec.normalized();
-
-    Eigen::Matrix<T, 3, 3> rmat;
-    rmat = Eigen::AngleAxis<T>(angle, axis);
-
-    return rmat;
+  return rmat;
 }
 
-template<typename T>
-Eigen::Quaternion<T> AngleAxisToQuaternion(const Eigen::Matrix<T, 3, 1>& rvec)
-{
-    Eigen::Matrix<T, 3, 3> rmat = AngleAxisToRotationMatrix<T>(rvec);
-
-    return Eigen::Quaternion<T>(rmat);
+template <typename T>
+void QuaternionToRotation(const T* const q, T* rot) {
+  ceres::QuaternionToRotation(q, rot);
 }
 
-template<typename T>
-void AngleAxisToQuaternion(const Eigen::Matrix<T, 3, 1>& rvec, T* q)
-{
-    Eigen::Quaternion<T> quat = AngleAxisToQuaternion<T>(rvec);
-
-    q[0] = quat.x();
-    q[1] = quat.y();
-    q[2] = quat.z();
-    q[3] = quat.w();
+template <typename T>
+Eigen::Matrix<T, 4, 4> QuaternionMultMatLeft(const Eigen::Quaternion<T>& q) {
+  return (Eigen::Matrix<T, 4, 4>() << q.w(), -q.z(), q.y(), q.x(), q.z(), q.w(), -q.x(), q.y(),
+          -q.y(), q.x(), q.w(), q.z(), -q.x(), -q.y(), -q.z(), q.w())
+      .finished();
 }
 
-template<typename T>
-Eigen::Matrix<T, 3, 1> RotationToAngleAxis(const Eigen::Matrix<T, 3, 3> & rmat)
-{
-    Eigen::AngleAxis<T> angleaxis; 
-    angleaxis.fromRotationMatrix(rmat); 
-    return angleaxis.angle() * angleaxis.axis(); 
-    
-}
-
-template<typename T>
-void QuaternionToAngleAxis(const T* const q, Eigen::Matrix<T, 3, 1>& rvec)
-{
-    Eigen::Quaternion<T> quat(q[3], q[0], q[1], q[2]);
-
-    Eigen::Matrix<T, 3, 3> rmat = quat.toRotationMatrix();
-
-    Eigen::AngleAxis<T> angleaxis;
-    angleaxis.fromRotationMatrix(rmat);
-
-    rvec = angleaxis.angle() * angleaxis.axis();
-}
-
-template<typename T>
-Eigen::Matrix<T, 3, 3> QuaternionToRotation(const T* const q)
-{
-    T R[9];
-    ceres::QuaternionToRotation(q, R);
-
-    Eigen::Matrix<T, 3, 3> rmat;
-    for (int i = 0; i < 3; ++i)
-    {
-        for (int j = 0; j < 3; ++j)
-        {
-            rmat(i,j) = R[i * 3 + j];
-        }
-    }
-
-    return rmat;
-}
-
-template<typename T>
-void QuaternionToRotation(const T* const q, T* rot)
-{
-    ceres::QuaternionToRotation(q, rot);
-}
-
-template<typename T>
-Eigen::Matrix<T,4,4> QuaternionMultMatLeft(const Eigen::Quaternion<T>& q)
-{
-    return (Eigen::Matrix<T,4,4>() << q.w(), -q.z(), q.y(), q.x(),
-                                      q.z(), q.w(), -q.x(), q.y(),
-                                      -q.y(), q.x(), q.w(), q.z(),
-                                      -q.x(), -q.y(), -q.z(), q.w()).finished();
-}
-
-template<typename T>
-Eigen::Matrix<T,4,4> QuaternionMultMatRight(const Eigen::Quaternion<T>& q)
-{
-    return (Eigen::Matrix<T,4,4>() << q.w(), q.z(), -q.y(), q.x(),
-                                      -q.z(), q.w(), q.x(), q.y(),
-                                      q.y(), -q.x(), q.w(), q.z(),
-                                      -q.x(), -q.y(), -q.z(), q.w()).finished();
+template <typename T>
+Eigen::Matrix<T, 4, 4> QuaternionMultMatRight(const Eigen::Quaternion<T>& q) {
+  return (Eigen::Matrix<T, 4, 4>() << q.w(), q.z(), -q.y(), q.x(), -q.z(), q.w(), q.x(), q.y(),
+          q.y(), -q.x(), q.w(), q.z(), -q.x(), -q.y(), -q.z(), q.w())
+      .finished();
 }
 
 /// @param theta - rotation about screw axis
 /// @param d - projection of tvec on the rotation axis
 /// @param l - screw axis direction
 /// @param m - screw axis moment
-template<typename T>
+template <typename T>
 void AngleAxisAndTranslationToScrew(const Eigen::Matrix<T, 3, 1>& rvec,
-                                    const Eigen::Matrix<T, 3, 1>& tvec,
-                                    T& theta, T& d,
-                                    Eigen::Matrix<T, 3, 1>& l,
-                                    Eigen::Matrix<T, 3, 1>& m)
-{
+                                    const Eigen::Matrix<T, 3, 1>& tvec, T& theta, T& d,
+                                    Eigen::Matrix<T, 3, 1>& l, Eigen::Matrix<T, 3, 1>& m) {
+  theta = rvec.norm();
+  if (theta == 0) {
+    l.setZero();
+    m.setZero();
+    std::cout << "Warning: Undefined screw! Returned 0. " << std::endl;
+  }
 
-    theta = rvec.norm();
-    if (theta == 0)
-    {
-        l.setZero(); 
-        m.setZero(); 
-        std::cout << "Warning: Undefined screw! Returned 0. " << std::endl; 
+  l = rvec.normalized();
+
+  Eigen::Matrix<T, 3, 1> t = tvec;
+
+  d = t.transpose() * l;
+
+  // point on screw axis - projection of origin on screw axis
+  Eigen::Matrix<T, 3, 1> c;
+  c = 0.5 * (t - d * l + (1.0 / tan(theta / 2.0) * l).cross(t));
+
+  // c and hence the screw axis is not defined if theta is either 0 or M_PI
+  m = c.cross(l);
+}
+
+template <typename T>
+Eigen::Matrix<T, 3, 3> RPY2mat(T roll, T pitch, T yaw) {
+  Eigen::Matrix<T, 3, 3> m;
+
+  T cr = cos(roll);
+  T sr = sin(roll);
+  T cp = cos(pitch);
+  T sp = sin(pitch);
+  T cy = cos(yaw);
+  T sy = sin(yaw);
+
+  m(0, 0) = cy * cp;
+  m(0, 1) = cy * sp * sr - sy * cr;
+  m(0, 2) = cy * sp * cr + sy * sr;
+  m(1, 0) = sy * cp;
+  m(1, 1) = sy * sp * sr + cy * cr;
+  m(1, 2) = sy * sp * cr - cy * sr;
+  m(2, 0) = -sp;
+  m(2, 1) = cp * sr;
+  m(2, 2) = cp * cr;
+  return m;
+}
+
+template <typename T>
+void mat2RPY(const Eigen::Matrix<T, 3, 3>& m, T& roll, T& pitch, T& yaw) {
+  roll = atan2(m(2, 1), m(2, 2));
+  pitch = atan2(-m(2, 0), sqrt(m(2, 1) * m(2, 1) + m(2, 2) * m(2, 2)));
+  yaw = atan2(m(1, 0), m(0, 0));
+}
+
+template <typename T>
+Eigen::Matrix<T, 4, 4> homogeneousTransform(const Eigen::Matrix<T, 3, 3>& R,
+                                            const Eigen::Matrix<T, 3, 1>& t) {
+  Eigen::Matrix<T, 4, 4> H;
+  H.setIdentity();
+
+  H.block(0, 0, 3, 3) = R;
+  H.block(0, 3, 3, 1) = t;
+
+  return H;
+}
+
+template <typename T>
+Eigen::Matrix<T, 4, 4> poseWithCartesianTranslation(const T* const q, const T* const p) {
+  Eigen::Matrix<T, 4, 4> pose = Eigen::Matrix<T, 4, 4>::Identity();
+
+  T rotation[9];
+  ceres::QuaternionToRotation(q, rotation);
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      pose(i, j) = rotation[i * 3 + j];
     }
+  }
 
-    l = rvec.normalized();
+  pose(0, 3) = p[0];
+  pose(1, 3) = p[1];
+  pose(2, 3) = p[2];
 
-    Eigen::Matrix<T, 3, 1> t = tvec;
-
-    d = t.transpose() * l;
-
-    // point on screw axis - projection of origin on screw axis
-    Eigen::Matrix<T, 3, 1> c;
-    c = 0.5 * (t - d * l + (1.0 / tan(theta / 2.0) * l).cross(t));
-
-    // c and hence the screw axis is not defined if theta is either 0 or M_PI
-    m = c.cross(l);
+  return pose;
 }
 
-template<typename T>
-Eigen::Matrix<T, 3, 3> RPY2mat(T roll, T pitch, T yaw)
-{
-    Eigen::Matrix<T, 3, 3> m;
+template <typename T>
+Eigen::Matrix<T, 4, 4> poseWithSphericalTranslation(const T* const q, const T* const p,
+                                                    const T scale = T(1.0)) {
+  Eigen::Matrix<T, 4, 4> pose = Eigen::Matrix<T, 4, 4>::Identity();
 
-    T cr = cos(roll);
-    T sr = sin(roll);
-    T cp = cos(pitch);
-    T sp = sin(pitch);
-    T cy = cos(yaw);
-    T sy = sin(yaw);
-
-    m(0,0) = cy * cp;
-    m(0,1) = cy * sp * sr - sy * cr;
-    m(0,2) = cy * sp * cr + sy * sr;
-    m(1,0) = sy * cp;
-    m(1,1) = sy * sp * sr + cy * cr;
-    m(1,2) = sy * sp * cr - cy * sr;
-    m(2,0) = - sp;
-    m(2,1) = cp * sr;
-    m(2,2) = cp * cr;
-    return m; 
-}
-
-template<typename T>
-void mat2RPY(const Eigen::Matrix<T, 3, 3>& m, T& roll, T& pitch, T& yaw)
-{
-    roll = atan2(m(2,1), m(2,2));
-    pitch = atan2(-m(2,0), sqrt(m(2,1) * m(2,1) + m(2,2) * m(2,2)));
-    yaw = atan2(m(1,0), m(0,0));
-}
-
-template<typename T>
-Eigen::Matrix<T, 4, 4> homogeneousTransform(const Eigen::Matrix<T, 3, 3>& R, const Eigen::Matrix<T, 3, 1>& t)
-{
-    Eigen::Matrix<T, 4, 4> H;
-    H.setIdentity();
-
-    H.block(0,0,3,3) = R;
-    H.block(0,3,3,1) = t;
-
-    return H;
-}
-
-template<typename T>
-Eigen::Matrix<T, 4, 4> poseWithCartesianTranslation(const T* const q, const T* const p)
-{
-    Eigen::Matrix<T, 4, 4> pose = Eigen::Matrix<T, 4, 4>::Identity();
-
-    T rotation[9];
-    ceres::QuaternionToRotation(q, rotation);
-    for (int i = 0; i < 3; ++i)
-    {
-        for (int j = 0; j < 3; ++j)
-        {
-            pose(i,j) = rotation[i * 3 + j];
-        }
+  T rotation[9];
+  ceres::QuaternionToRotation(q, rotation);
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      pose(i, j) = rotation[i * 3 + j];
     }
+  }
 
-    pose(0,3) = p[0];
-    pose(1,3) = p[1];
-    pose(2,3) = p[2];
+  T theta = p[0];
+  T phi = p[1];
+  pose(0, 3) = sin(theta) * cos(phi) * scale;
+  pose(1, 3) = sin(theta) * sin(phi) * scale;
+  pose(2, 3) = cos(theta) * scale;
 
-    return pose;
-}
-
-template<typename T>
-Eigen::Matrix<T, 4, 4> poseWithSphericalTranslation(const T* const q, const T* const p, const T scale = T(1.0))
-{
-    Eigen::Matrix<T, 4, 4> pose = Eigen::Matrix<T, 4, 4>::Identity();
-
-    T rotation[9];
-    ceres::QuaternionToRotation(q, rotation);
-    for (int i = 0; i < 3; ++i)
-    {
-        for (int j = 0; j < 3; ++j)
-        {
-            pose(i,j) = rotation[i * 3 + j];
-        }
-    }
-
-    T theta = p[0];
-    T phi = p[1];
-    pose(0,3) = sin(theta) * cos(phi) * scale;
-    pose(1,3) = sin(theta) * sin(phi) * scale;
-    pose(2,3) = cos(theta) * scale;
-
-    return pose;
+  return pose;
 }
 
 // Returns the Sampson error of a given essential matrix and 2 image points
-template<typename T>
-T sampsonError(const Eigen::Matrix<T, 3, 3>& E,
-               const Eigen::Matrix<T, 3, 1>& p1,
-               const Eigen::Matrix<T, 3, 1>& p2)
-{
-    Eigen::Matrix<T, 3, 1> Ex1 = E * p1;
-    Eigen::Matrix<T, 3, 1> Etx2 = E.transpose() * p2;
+template <typename T>
+T sampsonError(const Eigen::Matrix<T, 3, 3>& E, const Eigen::Matrix<T, 3, 1>& p1,
+               const Eigen::Matrix<T, 3, 1>& p2) {
+  Eigen::Matrix<T, 3, 1> Ex1 = E * p1;
+  Eigen::Matrix<T, 3, 1> Etx2 = E.transpose() * p2;
 
-    T x2tEx1 = p2.dot(Ex1);
+  T x2tEx1 = p2.dot(Ex1);
 
-    // compute Sampson error
-    T err = square(x2tEx1) / (square(Ex1(0,0)) + square(Ex1(1,0)) + square(Etx2(0,0)) + square(Etx2(1,0)));
+  // compute Sampson error
+  T err = square(x2tEx1) /
+          (square(Ex1(0, 0)) + square(Ex1(1, 0)) + square(Etx2(0, 0)) + square(Etx2(1, 0)));
 
-    return err;
+  return err;
 }
 
 // Returns the Sampson error of a given rotation/translation and 2 image points
-template<typename T>
-T sampsonError(const Eigen::Matrix<T, 3, 3>& R,
-               const Eigen::Matrix<T, 3, 1>& t,
-               const Eigen::Matrix<T, 3, 1>& p1,
-               const Eigen::Matrix<T, 3, 1>& p2)
-{
-    // construct essential matrix
-    Eigen::Matrix<T, 3, 3> E = skew(t) * R;
+template <typename T>
+T sampsonError(const Eigen::Matrix<T, 3, 3>& R, const Eigen::Matrix<T, 3, 1>& t,
+               const Eigen::Matrix<T, 3, 1>& p1, const Eigen::Matrix<T, 3, 1>& p2) {
+  // construct essential matrix
+  Eigen::Matrix<T, 3, 3> E = skew(t) * R;
 
-    Eigen::Matrix<T, 3, 1> Ex1 = E * p1;
-    Eigen::Matrix<T, 3, 1> Etx2 = E.transpose() * p2;
+  Eigen::Matrix<T, 3, 1> Ex1 = E * p1;
+  Eigen::Matrix<T, 3, 1> Etx2 = E.transpose() * p2;
 
-    T x2tEx1 = p2.dot(Ex1);
+  T x2tEx1 = p2.dot(Ex1);
 
-    // compute Sampson error
-    T err = square(x2tEx1) / (square(Ex1(0,0)) + square(Ex1(1,0)) + square(Etx2(0,0)) + square(Etx2(1,0)));
+  // compute Sampson error
+  T err = square(x2tEx1) /
+          (square(Ex1(0, 0)) + square(Ex1(1, 0)) + square(Etx2(0, 0)) + square(Etx2(1, 0)));
 
-    return err;
+  return err;
 }
 
 // Returns the Sampson error of a given rotation/translation and 2 image points
-template<typename T>
-T sampsonError(const Eigen::Matrix<T, 4, 4>& H,
-               const Eigen::Matrix<T, 3, 1>& p1,
-               const Eigen::Matrix<T, 3, 1>& p2)
-{
-    Eigen::Matrix<T, 3, 3> R = H.block(0, 0, 3, 3);
-    Eigen::Matrix<T, 3, 1> t = H.block(0, 3, 3, 1);
+template <typename T>
+T sampsonError(const Eigen::Matrix<T, 4, 4>& H, const Eigen::Matrix<T, 3, 1>& p1,
+               const Eigen::Matrix<T, 3, 1>& p2) {
+  Eigen::Matrix<T, 3, 3> R = H.block(0, 0, 3, 3);
+  Eigen::Matrix<T, 3, 1> t = H.block(0, 3, 3, 1);
 
-    return sampsonError(R, t, p1, p2);
+  return sampsonError(R, t, p1, p2);
 }
 
-template<typename T>
-Eigen::Matrix<T, 3, 1>
-transformPoint(const Eigen::Matrix<T, 4, 4>& H, const Eigen::Matrix<T, 3, 1>& P)
-{
-    Eigen::Matrix<T, 3, 1> P_trans = H.block(0, 0, 3, 3) * P + H.block(0, 3, 3, 1);
+template <typename T>
+Eigen::Matrix<T, 3, 1> transformPoint(const Eigen::Matrix<T, 4, 4>& H,
+                                      const Eigen::Matrix<T, 3, 1>& P) {
+  Eigen::Matrix<T, 3, 1> P_trans = H.block(0, 0, 3, 3) * P + H.block(0, 3, 3, 1);
 
-    return P_trans;
+  return P_trans;
 }
 
-template<typename T>
-Eigen::Matrix<T, 4, 4>
-estimate3DRigidTransform(const std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1> > >& points1,
-                         const std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1> > >& points2)
-{
-    // compute centroids
-    Eigen::Matrix<T, 3, 1> c1, c2;
-    c1.setZero(); c2.setZero();
+template <typename T>
+Eigen::Matrix<T, 4, 4> estimate3DRigidTransform(
+    const std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1> > >&
+        points1,
+    const std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1> > >&
+        points2) {
+  // compute centroids
+  Eigen::Matrix<T, 3, 1> c1, c2;
+  c1.setZero();
+  c2.setZero();
 
-    for (size_t i = 0; i < points1.size(); ++i)
-    {
-        c1 += points1.at(i);
-        c2 += points2.at(i);
-    }
+  for (size_t i = 0; i < points1.size(); ++i) {
+    c1 += points1.at(i);
+    c2 += points2.at(i);
+  }
 
-    c1 /= points1.size();
-    c2 /= points1.size();
+  c1 /= points1.size();
+  c2 /= points1.size();
 
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> X(3, points1.size());
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> Y(3, points1.size());
-    for (size_t i = 0; i < points1.size(); ++i)
-    {
-        X.col(i) = points1.at(i) - c1;
-        Y.col(i) = points2.at(i) - c2;
-    }
+  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> X(3, points1.size());
+  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> Y(3, points1.size());
+  for (size_t i = 0; i < points1.size(); ++i) {
+    X.col(i) = points1.at(i) - c1;
+    Y.col(i) = points2.at(i) - c2;
+  }
 
-    Eigen::Matrix<T, 3, 3> H = X * Y.transpose();
+  Eigen::Matrix<T, 3, 3> H = X * Y.transpose();
 
-    Eigen::JacobiSVD< Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> > svd(H, Eigen::ComputeFullU | Eigen::ComputeFullV);
+  Eigen::JacobiSVD<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> > svd(
+      H, Eigen::ComputeFullU | Eigen::ComputeFullV);
 
-    Eigen::Matrix<T, 3, 3> U = svd.matrixU();
-    Eigen::Matrix<T, 3, 3> V = svd.matrixV();
-    if (U.determinant() * V.determinant() < 0.0)
-    {
-        V.col(2) *= -1.0;
-    }
+  Eigen::Matrix<T, 3, 3> U = svd.matrixU();
+  Eigen::Matrix<T, 3, 3> V = svd.matrixV();
+  if (U.determinant() * V.determinant() < 0.0) {
+    V.col(2) *= -1.0;
+  }
 
-    Eigen::Matrix<T, 3, 3> R = V * U.transpose();
-    Eigen::Matrix<T, 3, 1> t = c2 - R * c1;
+  Eigen::Matrix<T, 3, 3> R = V * U.transpose();
+  Eigen::Matrix<T, 3, 1> t = c2 - R * c1;
 
-    return homogeneousTransform(R, t);
+  return homogeneousTransform(R, t);
 }
 
-template<typename T>
-Eigen::Matrix<T, 4, 4>
-estimate3DRigidSimilarityTransform(const std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1> > >& points1,
-                                   const std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1> > >& points2)
-{
-    // compute centroids
-    Eigen::Matrix<T, 3, 1> c1, c2;
-    c1.setZero(); c2.setZero();
+template <typename T>
+Eigen::Matrix<T, 4, 4> estimate3DRigidSimilarityTransform(
+    const std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1> > >&
+        points1,
+    const std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1> > >&
+        points2) {
+  // compute centroids
+  Eigen::Matrix<T, 3, 1> c1, c2;
+  c1.setZero();
+  c2.setZero();
 
-    for (size_t i = 0; i < points1.size(); ++i)
-    {
-        c1 += points1.at(i);
-        c2 += points2.at(i);
-    }
+  for (size_t i = 0; i < points1.size(); ++i) {
+    c1 += points1.at(i);
+    c2 += points2.at(i);
+  }
 
-    c1 /= points1.size();
-    c2 /= points1.size();
+  c1 /= points1.size();
+  c2 /= points1.size();
 
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> X(3, points1.size());
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> Y(3, points1.size());
-    for (size_t i = 0; i < points1.size(); ++i)
-    {
-        X.col(i) = points1.at(i) - c1;
-        Y.col(i) = points2.at(i) - c2;
-    }
+  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> X(3, points1.size());
+  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> Y(3, points1.size());
+  for (size_t i = 0; i < points1.size(); ++i) {
+    X.col(i) = points1.at(i) - c1;
+    Y.col(i) = points2.at(i) - c2;
+  }
 
-    Eigen::Matrix<T, 3, 3> H = X * Y.transpose();
+  Eigen::Matrix<T, 3, 3> H = X * Y.transpose();
 
-    Eigen::JacobiSVD< Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> > svd(H, Eigen::ComputeFullU | Eigen::ComputeFullV);
+  Eigen::JacobiSVD<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> > svd(
+      H, Eigen::ComputeFullU | Eigen::ComputeFullV);
 
-    Eigen::Matrix<T, 3, 3> U = svd.matrixU();
-    Eigen::Matrix<T, 3, 3> V = svd.matrixV();
-    if (U.determinant() * V.determinant() < 0.0)
-    {
-        V.col(2) *= -1.0;
-    }
+  Eigen::Matrix<T, 3, 3> U = svd.matrixU();
+  Eigen::Matrix<T, 3, 3> V = svd.matrixV();
+  if (U.determinant() * V.determinant() < 0.0) {
+    V.col(2) *= -1.0;
+  }
 
-    Eigen::Matrix<T, 3, 3> R = V * U.transpose();
+  Eigen::Matrix<T, 3, 3> R = V * U.transpose();
 
-    std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1> > > rotatedPoints1(points1.size());
-    for (size_t i = 0; i < points1.size(); ++i)
-    {
-        rotatedPoints1.at(i) = R * (points1.at(i) - c1);
-    }
+  std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1> > >
+      rotatedPoints1(points1.size());
+  for (size_t i = 0; i < points1.size(); ++i) {
+    rotatedPoints1.at(i) = R * (points1.at(i) - c1);
+  }
 
-    double sum_ss = 0.0, sum_tt = 0.0;
-    for (size_t i = 0; i < points1.size(); ++i)
-    {
-        sum_ss += (points1.at(i) - c1).squaredNorm();
-        sum_tt += (points2.at(i) - c2).dot(rotatedPoints1.at(i));
-    }
+  double sum_ss = 0.0, sum_tt = 0.0;
+  for (size_t i = 0; i < points1.size(); ++i) {
+    sum_ss += (points1.at(i) - c1).squaredNorm();
+    sum_tt += (points2.at(i) - c2).dot(rotatedPoints1.at(i));
+  }
 
-    double scale = sum_tt / sum_ss;
+  double scale = sum_tt / sum_ss;
 
-    Eigen::Matrix<T, 3, 3> sR = scale * R;
-    Eigen::Matrix<T, 3, 1> t = c2 - sR * c1;
+  Eigen::Matrix<T, 3, 3> sR = scale * R;
+  Eigen::Matrix<T, 3, 1> t = c2 - sR * c1;
 
-    return homogeneousTransform(sR, t);
+  return homogeneousTransform(sR, t);
 }
 
-}
+}  // namespace camodocal
 
 #endif

--- a/include/frontend/camodocal/gpl/gpl.h
+++ b/include/frontend/camodocal/gpl/gpl.h
@@ -5,33 +5,28 @@
 #include <cmath>
 #include <opencv2/core/core.hpp>
 
-namespace camodocal
-{
+namespace camodocal {
 
-template<class T>
-const T clamp(const T& v, const T& a, const T& b)
-{
-	return std::min(b, std::max(a, v));
+template <class T>
+const T clamp(const T& v, const T& a, const T& b) {
+  return std::min(b, std::max(a, v));
 }
 
 double hypot3(double x, double y, double z);
 float hypot3f(float x, float y, float z);
 
-template<class T>
-const T normalizeTheta(const T& theta)
-{
-	T normTheta = theta;
+template <class T>
+const T normalizeTheta(const T& theta) {
+  T normTheta = theta;
 
-	while (normTheta < - M_PI)
-	{
-		normTheta += 2.0 * M_PI;
-	}
-	while (normTheta > M_PI)
-	{
-		normTheta -= 2.0 * M_PI;
-	}
+  while (normTheta < -M_PI) {
+    normTheta += 2.0 * M_PI;
+  }
+  while (normTheta > M_PI) {
+    normTheta -= 2.0 * M_PI;
+  }
 
-	return normTheta;
+  return normTheta;
 }
 
 double d2r(double deg);
@@ -41,71 +36,60 @@ float r2d(float rad);
 
 double sinc(double theta);
 
-template<class T>
-const T square(const T& x)
-{
-	return x * x;
+template <class T>
+const T square(const T& x) {
+  return x * x;
 }
 
-template<class T>
-const T cube(const T& x)
-{
-	return x * x * x;
+template <class T>
+const T cube(const T& x) {
+  return x * x * x;
 }
 
-template<class T>
-const T random(const T& a, const T& b)
-{
-	return static_cast<double>(rand()) / RAND_MAX * (b - a) + a;
+template <class T>
+const T random(const T& a, const T& b) {
+  return static_cast<double>(rand()) / RAND_MAX * (b - a) + a;
 }
 
-template<class T>
-const T randomNormal(const T& sigma)
-{
-    T x1, x2, w;
+template <class T>
+const T randomNormal(const T& sigma) {
+  T x1, x2, w;
 
-    do
-    {
-        x1 = 2.0 * random(0.0, 1.0) - 1.0;
-        x2 = 2.0 * random(0.0, 1.0) - 1.0;
-        w = x1 * x1 + x2 * x2;
-    }
-    while (w >= 1.0 || w == 0.0);
+  do {
+    x1 = 2.0 * random(0.0, 1.0) - 1.0;
+    x2 = 2.0 * random(0.0, 1.0) - 1.0;
+    w = x1 * x1 + x2 * x2;
+  } while (w >= 1.0 || w == 0.0);
 
-    w = sqrt((-2.0 * log(w)) / w);
+  w = sqrt((-2.0 * log(w)) / w);
 
-    return x1 * w * sigma;
+  return x1 * w * sigma;
 }
 
 unsigned long long timeInMicroseconds(void);
 
 double timeInSeconds(void);
 
-void colorDepthImage(cv::Mat& imgDepth,
-                     cv::Mat& imgColoredDepth,
-                     float minRange, float maxRange);
+void colorDepthImage(cv::Mat& imgDepth, cv::Mat& imgColoredDepth, float minRange, float maxRange);
 
-bool colormap(const std::string& name, unsigned char idx,
-              float& r, float& g, float& b);
+bool colormap(const std::string& name, unsigned char idx, float& r, float& g, float& b);
 
 std::vector<cv::Point2i> bresLine(int x0, int y0, int x1, int y1);
 std::vector<cv::Point2i> bresCircle(int x0, int y0, int r);
 
-void fitCircle(const std::vector<cv::Point2d>& points,
-               double& centerX, double& centerY, double& radius);
+void fitCircle(const std::vector<cv::Point2d>& points, double& centerX, double& centerY,
+               double& radius);
 
-std::vector<cv::Point2d> intersectCircles(double x1, double y1, double r1,
-                                          double x2, double y2, double r2);
+std::vector<cv::Point2d> intersectCircles(double x1, double y1, double r1, double x2, double y2,
+                                          double r2);
 
-void LLtoUTM(double latitude, double longitude,
-             double& utmNorthing, double& utmEasting,
+void LLtoUTM(double latitude, double longitude, double& utmNorthing, double& utmEasting,
              std::string& utmZone);
-void UTMtoLL(double utmNorthing, double utmEasting,
-             const std::string& utmZone,
-             double& latitude, double& longitude);
+void UTMtoLL(double utmNorthing, double utmEasting, const std::string& utmZone, double& latitude,
+             double& longitude);
 
 long int timestampDiff(uint64_t t1, uint64_t t2);
 
-}
+}  // namespace camodocal
 
 #endif

--- a/include/frontend/failure_detector.h
+++ b/include/frontend/failure_detector.h
@@ -1,46 +1,47 @@
 #ifndef FAILURE_DETECTOR_H
 #define FAILURE_DETECTOR_H
 
-#include <iostream>
 #include <Eigen/Dense>
+#include <iostream>
+
 #include "backend/sliding_window.h"
 #include "frontend/feature_manager.h"
 
 class FailureDetector {
 public:
-    FailureDetector(backend::SlidingWindow* sliding_window, FeatureManager* feature_manager);
-    
-    // Main failure detection method
-    bool detectFailure(const Vector3d& last_P_end, const Matrix3d& last_R_end);
-    
-    // Individual failure detection methods
-    bool detectFeatureFailure();
-    bool detectIMUAccBiasFailure();
-    bool detectIMUGyrBiasFailure();
-    bool detectTranslationFailure(const Vector3d& last_P_end);
-    bool detectZTranslationFailure(const Vector3d& last_P_end);
-    bool detectRotationFailure(const Matrix3d& last_R_end);
-    
-    // Threshold setters
-    void setFeatureThreshold(int threshold) { feature_threshold_ = threshold; }
-    void setAccBiasThreshold(double threshold) { acc_bias_threshold_ = threshold; }
-    void setGyrBiasThreshold(double threshold) { gyr_bias_threshold_ = threshold; }
-    void setTranslationThreshold(double threshold) { translation_threshold_ = threshold; }
-    void setZTranslationThreshold(double threshold) { z_translation_threshold_ = threshold; }
-    void setRotationThreshold(double threshold) { rotation_threshold_ = threshold; }
+  FailureDetector(backend::SlidingWindow* sliding_window, FeatureManager* feature_manager);
+
+  // Main failure detection method
+  bool detectFailure(const Vector3d& last_P_end, const Matrix3d& last_R_end);
+
+  // Individual failure detection methods
+  bool detectFeatureFailure();
+  bool detectIMUAccBiasFailure();
+  bool detectIMUGyrBiasFailure();
+  bool detectTranslationFailure(const Vector3d& last_P_end);
+  bool detectZTranslationFailure(const Vector3d& last_P_end);
+  bool detectRotationFailure(const Matrix3d& last_R_end);
+
+  // Threshold setters
+  void setFeatureThreshold(int threshold) { feature_threshold_ = threshold; }
+  void setAccBiasThreshold(double threshold) { acc_bias_threshold_ = threshold; }
+  void setGyrBiasThreshold(double threshold) { gyr_bias_threshold_ = threshold; }
+  void setTranslationThreshold(double threshold) { translation_threshold_ = threshold; }
+  void setZTranslationThreshold(double threshold) { z_translation_threshold_ = threshold; }
+  void setRotationThreshold(double threshold) { rotation_threshold_ = threshold; }
 
 private:
-    // Member variables
-    backend::SlidingWindow* sliding_window_;
-    FeatureManager* feature_manager_;
-    
-    // Threshold parameters
-    int feature_threshold_;
-    double acc_bias_threshold_;
-    double gyr_bias_threshold_;
-    double translation_threshold_;
-    double z_translation_threshold_;
-    double rotation_threshold_;
+  // Member variables
+  backend::SlidingWindow* sliding_window_;
+  FeatureManager* feature_manager_;
+
+  // Threshold parameters
+  int feature_threshold_;
+  double acc_bias_threshold_;
+  double gyr_bias_threshold_;
+  double translation_threshold_;
+  double z_translation_threshold_;
+  double rotation_threshold_;
 };
 
-#endif // FAILURE_DETECTOR_H 
+#endif  // FAILURE_DETECTOR_H

--- a/include/frontend/feature_manager.h
+++ b/include/frontend/feature_manager.h
@@ -10,79 +10,84 @@ using namespace std;
 #include <eigen3/Eigen/Dense>
 using namespace Eigen;
 
-#include "utility/config.h"
-#include "common/image_frame.h"
 #include "backend/sliding_window.h"
+#include "common/image_frame.h"
+#include "utility/config.h"
 
 class FeaturePerFrame {
-  public:
-    FeaturePerFrame(const Eigen::Matrix<double, 7, 1> &_point) {
-        point.x() = _point(0);
-        point.y() = _point(1);
-        point.z() = _point(2);
-        uv.x() = _point(3);
-        uv.y() = _point(4);
-        velocity.x() = _point(5);
-        velocity.y() = _point(6);
-    }
-    Vector3d point;
-    Vector2d uv;
-    Vector2d velocity;
-    double z;
-    bool is_used;
-    double parallax;
-    MatrixXd A;
-    VectorXd b;
-    double dep_gradient;
+public:
+  FeaturePerFrame(const Eigen::Matrix<double, 7, 1> &_point) {
+    point.x() = _point(0);
+    point.y() = _point(1);
+    point.z() = _point(2);
+    uv.x() = _point(3);
+    uv.y() = _point(4);
+    velocity.x() = _point(5);
+    velocity.y() = _point(6);
+  }
+  Vector3d point;
+  Vector2d uv;
+  Vector2d velocity;
+  double z;
+  bool is_used;
+  double parallax;
+  MatrixXd A;
+  VectorXd b;
+  double dep_gradient;
 };
 
 class FeaturePerId {
-  public:
-    const int feature_id;
-    int start_frame;
-    vector<FeaturePerFrame> feature_per_frame;
+public:
+  const int feature_id;
+  int start_frame;
+  vector<FeaturePerFrame> feature_per_frame;
 
-    int used_num;
-    bool is_outlier;
-    bool is_margin;
-    double estimated_depth;
-    int solve_flag; // 0 haven't solve yet; 1 solve succ; 2 solve fail;
+  int used_num;
+  bool is_outlier;
+  bool is_margin;
+  double estimated_depth;
+  int solve_flag;  // 0 haven't solve yet; 1 solve succ; 2 solve fail;
 
-    Vector3d gt_p;
+  Vector3d gt_p;
 
-    FeaturePerId(int _feature_id, int _start_frame)
-        : feature_id(_feature_id), start_frame(_start_frame), used_num(0), estimated_depth(-1.0), solve_flag(0) {}
+  FeaturePerId(int _feature_id, int _start_frame)
+      : feature_id(_feature_id),
+        start_frame(_start_frame),
+        used_num(0),
+        estimated_depth(-1.0),
+        solve_flag(0) {}
 
-    int endFrame();
+  int endFrame();
 };
 
 class FeatureManager {
-  public:
-    FeatureManager();
+public:
+  FeatureManager();
 
-    void clearState();
+  void clearState();
 
-    int getFeatureCount();
+  int getFeatureCount();
 
-    bool addFeatureCheckParallax(int frame_count, const ImageData &image);
-    vector<pair<Vector3d, Vector3d>> getCorresponding(int frame_count_l, int frame_count_r);
+  bool addFeatureCheckParallax(int frame_count, const ImageData &image);
+  vector<pair<Vector3d, Vector3d>> getCorresponding(int frame_count_l, int frame_count_r);
 
-    // void updateDepth(const VectorXd &x);
-    void setDepth(const VectorXd &x);
-    void removeFailures();
-    void clearDepth(const VectorXd &x);
-    VectorXd getDepthVector();
-    void triangulate(const backend::SlidingWindow &sliding_window, const Vector3d &t_ic, const Matrix3d &r_ic);
-    void removeBackShiftDepth(Eigen::Matrix3d marg_R, Eigen::Vector3d marg_P, Eigen::Matrix3d new_R,
-                              Eigen::Vector3d new_P);
-    void removeBack();
-    void removeFront(int frame_count);
-    void removeOutlier();
-    list<FeaturePerId> feature;
-    int last_track_num;
+  // void updateDepth(const VectorXd &x);
+  void setDepth(const VectorXd &x);
+  void removeFailures();
+  void clearDepth(const VectorXd &x);
+  VectorXd getDepthVector();
+  void triangulate(const backend::SlidingWindow &sliding_window, const Vector3d &t_ic,
+                   const Matrix3d &r_ic);
+  void removeBackShiftDepth(Eigen::Matrix3d marg_R, Eigen::Vector3d marg_P, Eigen::Matrix3d new_R,
+                            Eigen::Vector3d new_P);
+  void removeBack();
+  void removeFront(int frame_count);
+  void removeOutlier();
+  list<FeaturePerId> feature;
+  int last_track_num;
 
-  private:
-    double compensatedParallax2(const FeaturePerId &it_per_id, int frame_count);
+private:
+  double compensatedParallax2(const FeaturePerId &it_per_id, int frame_count);
 };
 
 #endif

--- a/include/frontend/feature_tracker.h
+++ b/include/frontend/feature_tracker.h
@@ -1,19 +1,18 @@
 #ifndef FEATURE_TRACKER_H
 #define FEATURE_TRACKER_H
 
-#include <cstdio>
-#include <iostream>
-#include <queue>
 #include <execinfo.h>
-#include <csignal>
 
-#include <opencv2/opencv.hpp>
+#include <csignal>
+#include <cstdio>
 #include <eigen3/Eigen/Dense>
+#include <iostream>
+#include <opencv2/opencv.hpp>
+#include <queue>
 
 #include "frontend/camodocal/camera_models/CameraFactory.h"
 #include "frontend/camodocal/camera_models/CataCamera.h"
 #include "frontend/camodocal/camera_models/PinholeCamera.h"
-
 #include "utility/config.h"
 
 using namespace std;
@@ -21,48 +20,47 @@ using namespace camodocal;
 using namespace Eigen;
 
 namespace feature_tracker {
-  
+
 bool inBorder(const cv::Point2f &pt);
 
 void reduceVector(vector<cv::Point2f> &v, vector<uchar> status);
 void reduceVector(vector<int> &v, vector<uchar> status);
 
-class FeatureTracker
-{
-  public:
-    FeatureTracker();
+class FeatureTracker {
+public:
+  FeatureTracker();
 
-    void readImage(const cv::Mat &_img,double _cur_time);
+  void readImage(const cv::Mat &_img, double _cur_time);
 
-    void setMask();
+  void setMask();
 
-    void addPoints();
+  void addPoints();
 
-    bool updateID(unsigned int i);
+  bool updateID(unsigned int i);
 
-    void readIntrinsicParameter(const string &calib_file);
+  void readIntrinsicParameter(const string &calib_file);
 
-    void rejectWithFundamentalMatrix();
+  void rejectWithFundamentalMatrix();
 
-    void undistortedPoints();
+  void undistortedPoints();
 
-    cv::Mat mask;
-    cv::Mat fisheye_mask;
-    cv::Mat prev_img, cur_img, next_img;
-    vector<cv::Point2f> n_pts;
-    vector<cv::Point2f> prev_pts, cur_pts, forw_pts;
-    vector<cv::Point2f> prev_un_pts, cur_un_pts;
-    vector<cv::Point2f> pts_velocity;
-    vector<int> ids;
-    vector<int> track_cnt;
-    map<int, cv::Point2f> cur_un_pts_map;
-    map<int, cv::Point2f> prev_un_pts_map;
-    camodocal::CameraPtr m_camera;
-    double cur_time;
-    double prev_time;
+  cv::Mat mask;
+  cv::Mat fisheye_mask;
+  cv::Mat prev_img, cur_img, next_img;
+  vector<cv::Point2f> n_pts;
+  vector<cv::Point2f> prev_pts, cur_pts, forw_pts;
+  vector<cv::Point2f> prev_un_pts, cur_un_pts;
+  vector<cv::Point2f> pts_velocity;
+  vector<int> ids;
+  vector<int> track_cnt;
+  map<int, cv::Point2f> cur_un_pts_map;
+  map<int, cv::Point2f> prev_un_pts_map;
+  camodocal::CameraPtr m_camera;
+  double cur_time;
+  double prev_time;
 
-    static int n_id;
+  static int n_id;
 };
 
-}
-#endif // FEATURE_TRACKER_H
+}  // namespace feature_tracker
+#endif  // FEATURE_TRACKER_H

--- a/include/frontend/initialization/initial_alignment.h
+++ b/include/frontend/initialization/initial_alignment.h
@@ -1,17 +1,19 @@
 #pragma once
-#include "backend/factor/imu_factor.h"
-#include "frontend/feature_manager.h"
-#include "common/image_frame.h"
-#include "utility/utility.h"
-#include "backend/sliding_window.h"
 #include <eigen3/Eigen/Dense>
 #include <iostream>
 #include <map>
+
+#include "backend/factor/imu_factor.h"
+#include "backend/sliding_window.h"
+#include "common/image_frame.h"
+#include "frontend/feature_manager.h"
+#include "utility/utility.h"
 
 using namespace Eigen;
 using namespace std;
 
 namespace initial_alignment {
 
-bool VisualIMUAlignment(map<double, ImageFrame> const &all_image_frame, backend::SlidingWindow &sliding_window, Vector3d &g, VectorXd &x);
+bool VisualIMUAlignment(map<double, ImageFrame> const &all_image_frame,
+                        backend::SlidingWindow &sliding_window, Vector3d &g, VectorXd &x);
 }

--- a/include/frontend/initialization/initial_sfm.h
+++ b/include/frontend/initialization/initial_sfm.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <ceres/ceres.h>
 #include <ceres/rotation.h>
+
 #include <cstdlib>
 #include <deque>
 #include <eigen3/Eigen/Dense>
@@ -12,52 +13,55 @@ using namespace Eigen;
 using namespace std;
 
 struct SFMFeature {
-    bool state;
-    int id;
-    vector<pair<int, Vector2d>> observation;
-    double position[3];
-    double depth;
+  bool state;
+  int id;
+  vector<pair<int, Vector2d>> observation;
+  double position[3];
+  double depth;
 };
 
 struct ReprojectionError3D {
-    ReprojectionError3D(double observed_u, double observed_v) : observed_u(observed_u), observed_v(observed_v) {}
+  ReprojectionError3D(double observed_u, double observed_v)
+      : observed_u(observed_u), observed_v(observed_v) {}
 
-    template <typename T>
-    bool operator()(const T *const camera_R, const T *const camera_T, const T *point, T *residuals) const {
-        T p[3];
-        ceres::QuaternionRotatePoint(camera_R, point, p);
-        p[0] += camera_T[0];
-        p[1] += camera_T[1];
-        p[2] += camera_T[2];
-        T xp = p[0] / p[2];
-        T yp = p[1] / p[2];
-        residuals[0] = xp - T(observed_u);
-        residuals[1] = yp - T(observed_v);
-        return true;
-    }
+  template <typename T>
+  bool operator()(const T *const camera_R, const T *const camera_T, const T *point,
+                  T *residuals) const {
+    T p[3];
+    ceres::QuaternionRotatePoint(camera_R, point, p);
+    p[0] += camera_T[0];
+    p[1] += camera_T[1];
+    p[2] += camera_T[2];
+    T xp = p[0] / p[2];
+    T yp = p[1] / p[2];
+    residuals[0] = xp - T(observed_u);
+    residuals[1] = yp - T(observed_v);
+    return true;
+  }
 
-    static ceres::CostFunction *Create(const double observed_x, const double observed_y) {
-        return (new ceres::AutoDiffCostFunction<ReprojectionError3D, 2, 4, 3, 3>(
-            new ReprojectionError3D(observed_x, observed_y)));
-    }
+  static ceres::CostFunction *Create(const double observed_x, const double observed_y) {
+    return (new ceres::AutoDiffCostFunction<ReprojectionError3D, 2, 4, 3, 3>(
+        new ReprojectionError3D(observed_x, observed_y)));
+  }
 
-    double observed_u;
-    double observed_v;
+  double observed_u;
+  double observed_v;
 };
 
 class GlobalSFM {
-  public:
-    GlobalSFM();
-    bool construct(int frame_num, Quaterniond *q, Vector3d *T, int l, const Matrix3d relative_R,
-                   const Vector3d relative_T, vector<SFMFeature> &sfm_f, map<int, Vector3d> &sfm_tracked_points);
+public:
+  GlobalSFM();
+  bool construct(int frame_num, Quaterniond *q, Vector3d *T, int l, const Matrix3d relative_R,
+                 const Vector3d relative_T, vector<SFMFeature> &sfm_f,
+                 map<int, Vector3d> &sfm_tracked_points);
 
-  private:
-    bool solveFrameByPnP(Matrix3d &R_initial, Vector3d &P_initial, int i, vector<SFMFeature> &sfm_f);
+private:
+  bool solveFrameByPnP(Matrix3d &R_initial, Vector3d &P_initial, int i, vector<SFMFeature> &sfm_f);
 
-    void triangulatePoint(Eigen::Matrix<double, 3, 4> &Pose0, Eigen::Matrix<double, 3, 4> &Pose1, Vector2d &point0,
-                          Vector2d &point1, Vector3d &point_3d);
-    void triangulateTwoFrames(int frame0, Eigen::Matrix<double, 3, 4> &Pose0, int frame1,
-                              Eigen::Matrix<double, 3, 4> &Pose1, vector<SFMFeature> &sfm_f);
+  void triangulatePoint(Eigen::Matrix<double, 3, 4> &Pose0, Eigen::Matrix<double, 3, 4> &Pose1,
+                        Vector2d &point0, Vector2d &point1, Vector3d &point_3d);
+  void triangulateTwoFrames(int frame0, Eigen::Matrix<double, 3, 4> &Pose0, int frame1,
+                            Eigen::Matrix<double, 3, 4> &Pose1, vector<SFMFeature> &sfm_f);
 
-    int feature_num;
+  int feature_num;
 };

--- a/include/frontend/initialization/initializer.h
+++ b/include/frontend/initialization/initializer.h
@@ -4,48 +4,43 @@
 #include <Eigen/Dense>
 #include <map>
 
-#include "common/common_types.h"
 #include "backend/sliding_window.h"
+#include "common/common_types.h"
+#include "common/image_frame.h"
 #include "frontend/feature_manager.h"
 #include "frontend/initialization/initial_sfm.h"
 #include "frontend/initialization/solve_5pts.h"
-#include "common/image_frame.h"
 
-class Estimator; // Forward declaration
+class Estimator;  // Forward declaration
 
 class Initializer {
 public:
-    Initializer(backend::SlidingWindow* sliding_window, 
-                FeatureManager* feature_manager, 
-                MotionEstimator* motion_estimator,
-                std::map<double, ImageFrame>* all_image_frame, 
-                int* frame_count,
-                MarginalizationFlag* marginalization_flag, 
-                Vector3d* g, 
-                const Matrix3d* r_ic, 
-                const Vector3d* t_ic);
+  Initializer(backend::SlidingWindow* sliding_window, FeatureManager* feature_manager,
+              MotionEstimator* motion_estimator, std::map<double, ImageFrame>* all_image_frame,
+              int* frame_count, MarginalizationFlag* marginalization_flag, Vector3d* g,
+              const Matrix3d* r_ic, const Vector3d* t_ic);
 
-    // Main initialization method
-    bool initialize();
+  // Main initialization method
+  bool initialize();
 
 private:
-    bool checkIMUExcitation(double threshold);
-    bool solveGlobalSfM();
-    bool relativePose(Matrix3d &relative_R, Vector3d &relative_T, int &index);
-    bool solvePnPForAllFrames(const Quaterniond Q[], const Vector3d T[],
-                              const std::map<int, Vector3d> &sfm_tracked_points);
-    bool visualInitialAlign();
+  bool checkIMUExcitation(double threshold);
+  bool solveGlobalSfM();
+  bool relativePose(Matrix3d& relative_R, Vector3d& relative_T, int& index);
+  bool solvePnPForAllFrames(const Quaterniond Q[], const Vector3d T[],
+                            const std::map<int, Vector3d>& sfm_tracked_points);
+  bool visualInitialAlign();
 
-    // Member pointers to Estimator's data
-    backend::SlidingWindow* sliding_window_;
-    FeatureManager* feature_manager_;
-    MotionEstimator* motion_estimator_;
-    std::map<double, ImageFrame>* all_image_frame_;
-    int* frame_count_;
-    MarginalizationFlag* marginalization_flag_;
-    Vector3d* g_;
-    const Matrix3d* r_ic_;
-    const Vector3d* t_ic_;
+  // Member pointers to Estimator's data
+  backend::SlidingWindow* sliding_window_;
+  FeatureManager* feature_manager_;
+  MotionEstimator* motion_estimator_;
+  std::map<double, ImageFrame>* all_image_frame_;
+  int* frame_count_;
+  MarginalizationFlag* marginalization_flag_;
+  Vector3d* g_;
+  const Matrix3d* r_ic_;
+  const Vector3d* t_ic_;
 };
 
-#endif // INITIALIZER_H 
+#endif  // INITIALIZER_H

--- a/include/frontend/initialization/solve_5pts.h
+++ b/include/frontend/initialization/solve_5pts.h
@@ -4,17 +4,17 @@
 using namespace std;
 
 #include <opencv2/opencv.hpp>
-//#include <opencv2/core/eigen.hpp>
+// #include <opencv2/core/eigen.hpp>
 #include <eigen3/Eigen/Dense>
 using namespace Eigen;
 
-
 class MotionEstimator {
-  public:
-    bool solveRelativeRT(const vector<pair<Vector3d, Vector3d>> &corres, Matrix3d &R, Vector3d &T);
+public:
+  bool solveRelativeRT(const vector<pair<Vector3d, Vector3d>> &corres, Matrix3d &R, Vector3d &T);
 
-  private:
-    double testTriangulation(const vector<cv::Point2f> &l, const vector<cv::Point2f> &r, cv::Mat_<double> R,
-                             cv::Mat_<double> t);
-    void decomposeE(cv::Mat E, cv::Mat_<double> &R1, cv::Mat_<double> &R2, cv::Mat_<double> &t1, cv::Mat_<double> &t2);
+private:
+  double testTriangulation(const vector<cv::Point2f> &l, const vector<cv::Point2f> &r,
+                           cv::Mat_<double> R, cv::Mat_<double> t);
+  void decomposeE(cv::Mat E, cv::Mat_<double> &R1, cv::Mat_<double> &R2, cv::Mat_<double> &t1,
+                  cv::Mat_<double> &t2);
 };

--- a/include/utility/config.h
+++ b/include/utility/config.h
@@ -1,11 +1,10 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#include <string>
-#include <vector>
-
 #include <Eigen/Dense>
 #include <opencv2/opencv.hpp>
+#include <string>
+#include <vector>
 
 namespace utility {
 
@@ -17,75 +16,75 @@ enum StateOrder { O_P = 0, O_R = 3, O_V = 6, O_BA = 9, O_BG = 12 };
 
 // Camera configuration
 struct CameraConfig {
-    double focal_length = 460.0;
-    double row = 480.0;
-    double col = 752.0;
-    Eigen::Matrix3d r_ic = Eigen::Matrix3d::Identity();
-    Eigen::Vector3d t_ic = Eigen::Vector3d::Zero();
-    
-    // Camera intrinsic parameters
-    double fx = 460.0;
-    double fy = 460.0;
-    double cx = 376.0;  // col * 0.5
-    double cy = 240.0;  // row * 0.5
+  double focal_length = 460.0;
+  double row = 480.0;
+  double col = 752.0;
+  Eigen::Matrix3d r_ic = Eigen::Matrix3d::Identity();
+  Eigen::Vector3d t_ic = Eigen::Vector3d::Zero();
+
+  // Camera intrinsic parameters
+  double fx = 460.0;
+  double fy = 460.0;
+  double cx = 376.0;  // col * 0.5
+  double cy = 240.0;  // row * 0.5
 };
 
 // Feature tracker configuration
 struct FeatureTrackerConfig {
-    int max_cnt = 150;
-    int min_dist = 30;
-    int window_size = 20;
-    double f_threshold = 1.0;
-    int show_track = 1;
-    int equalize = 1;
-    int fisheye = 0;
-    
-    // Image processing
-    std::string fisheye_mask;
+  int max_cnt = 150;
+  int min_dist = 30;
+  int window_size = 20;
+  double f_threshold = 1.0;
+  int show_track = 1;
+  int equalize = 1;
+  int fisheye = 0;
+
+  // Image processing
+  std::string fisheye_mask;
 };
 
 // Estimator configuration
 struct EstimatorConfig {
-    int window_size = 10;
-    int num_iterations = 10;
-    double solver_time = 0.05;
-    double min_parallax = 10.0;
-    double init_depth = 5.0;
-    
-    // IMU noise parameters
-    double acc_n = 0.08;
-    double acc_w = 0.00004;
-    double gyr_n = 0.004;
-    double gyr_w = 2.0e-6;
-    
-    // Gravity vector
-    Eigen::Vector3d g = Eigen::Vector3d(0.0, 0.0, 9.81007);
-    
-    // Feature parameters
-    int num_of_features = NUM_OF_FEATURES;
+  int window_size = 10;
+  int num_iterations = 10;
+  double solver_time = 0.05;
+  double min_parallax = 10.0;
+  double init_depth = 5.0;
+
+  // IMU noise parameters
+  double acc_n = 0.08;
+  double acc_w = 0.00004;
+  double gyr_n = 0.004;
+  double gyr_w = 2.0e-6;
+
+  // Gravity vector
+  Eigen::Vector3d g = Eigen::Vector3d(0.0, 0.0, 9.81007);
+
+  // Feature parameters
+  int num_of_features = NUM_OF_FEATURES;
 };
 
 // Main configuration structure
 struct Config {
-    CameraConfig camera;
-    FeatureTrackerConfig feature_tracker;
-    EstimatorConfig estimator;
-    
-    // Processing parameters
-    int frame_skip = 2;  // Skip frames for processing
-    std::string dataset_path = "";
-    std::string config_filepath = "";
-    
-    // Load configuration from YAML file
-    bool loadFromYaml(const std::string& yaml_path);
-    
-    // Print configuration for debugging
-    void print() const;
+  CameraConfig camera;
+  FeatureTrackerConfig feature_tracker;
+  EstimatorConfig estimator;
+
+  // Processing parameters
+  int frame_skip = 2;  // Skip frames for processing
+  std::string dataset_path = "";
+  std::string config_filepath = "";
+
+  // Load configuration from YAML file
+  bool loadFromYaml(const std::string& yaml_path);
+
+  // Print configuration for debugging
+  void print() const;
 };
 
 // Global configuration instance
-extern Config g_config; 
+extern Config g_config;
 
-} // namespace utility
+}  // namespace utility
 
-#endif // CONFIG_H
+#endif  // CONFIG_H

--- a/include/utility/measurement_processor.h
+++ b/include/utility/measurement_processor.h
@@ -1,69 +1,67 @@
 #ifndef MEASUREMENT_PROCESSOR_H
 #define MEASUREMENT_PROCESSOR_H
 
-#include "utility/measurement_reader.h"
-#include "frontend/feature_tracker.h"
-#include "common/image_frame.h"
-#include <vector>
 #include <string>
+#include <vector>
+
+#include "common/image_frame.h"
+#include "frontend/feature_tracker.h"
+#include "utility/measurement_reader.h"
 
 struct IMUData {
-    double timestamp;
-    double linear_acc_x, linear_acc_y, linear_acc_z;
-    double angular_vel_x, angular_vel_y, angular_vel_z;
+  double timestamp;
+  double linear_acc_x, linear_acc_y, linear_acc_z;
+  double angular_vel_x, angular_vel_y, angular_vel_z;
 };
 
 struct ImageFileData {
-    double timestamp;
-    std::string filename;
-    std::string full_path;
+  double timestamp;
+  std::string filename;
+  std::string full_path;
 };
 
 class MeasurementProcessor {
 public:
-    MeasurementProcessor();
-    ~MeasurementProcessor();
-    
-    // 초기화
-    bool initialize(const std::string& imu_filepath, 
-                   const std::string& image_csv_filepath,
-                   const std::string& image_dir,
-                   const std::string& config_filepath);
-    
-    // 데이터 로드
-    bool loadImuData(const std::string& filepath);
-    bool loadImageFileData(const std::string& csv_filepath, const std::string& image_dir);
-    
-    // MeasurementMsg 생성
-    MeasurementMsg createMeasurementMsg(int measurement_id, 
-                                       const ImageFileData& image_data);
-    
-    // 데이터 접근자
-    const std::vector<IMUData>& getIMUData() const { return imu_data_; }
-    const std::vector<ImageFileData>& getImageFileData() const { return image_file_data_; }
-    
-    // 유틸리티 함수
-    void printDataRange() const;
-    void printTimeInfo(double timestamp) const;
-    
+  MeasurementProcessor();
+  ~MeasurementProcessor();
+
+  // 초기화
+  bool initialize(const std::string& imu_filepath, const std::string& image_csv_filepath,
+                  const std::string& image_dir, const std::string& config_filepath);
+
+  // 데이터 로드
+  bool loadImuData(const std::string& filepath);
+  bool loadImageFileData(const std::string& csv_filepath, const std::string& image_dir);
+
+  // MeasurementMsg 생성
+  MeasurementMsg createMeasurementMsg(int measurement_id, const ImageFileData& image_data);
+
+  // 데이터 접근자
+  const std::vector<IMUData>& getIMUData() const { return imu_data_; }
+  const std::vector<ImageFileData>& getImageFileData() const { return image_file_data_; }
+
+  // 유틸리티 함수
+  void printDataRange() const;
+  void printTimeInfo(double timestamp) const;
+
 private:
-    // 멤버 변수
-    std::vector<IMUData> imu_data_;
-    std::vector<ImageFileData> image_file_data_;
-    std::vector<double> image_timestamps_;
-    std::vector<std::string> image_files_;
-    
-    // 이전 이미지 타임스탬프 저장
-    double prev_image_timestamp_;
-    
-    // Feature tracker 관련
-    std::unique_ptr<feature_tracker::FeatureTracker> feature_tracker_;
-    
-    // 이미지 특징점 추출
-    ImageFeatureMsg extractImageFeatures(const ImageFileData& image_data);
-    
-    // 파일명 정리 (공백, 개행 제거)
-    std::string cleanFilename(const std::string& filename);
+  // 멤버 변수
+  std::vector<IMUData> imu_data_;
+  std::vector<ImageFileData> image_file_data_;
+  std::vector<double> image_timestamps_;
+  std::vector<std::string> image_files_;
+
+  // 이전 이미지 타임스탬프 저장
+  double prev_image_timestamp_;
+
+  // Feature tracker 관련
+  std::unique_ptr<feature_tracker::FeatureTracker> feature_tracker_;
+
+  // 이미지 특징점 추출
+  ImageFeatureMsg extractImageFeatures(const ImageFileData& image_data);
+
+  // 파일명 정리 (공백, 개행 제거)
+  std::string cleanFilename(const std::string& filename);
 };
 
-#endif // MEASUREMENT_PROCESSOR_H 
+#endif  // MEASUREMENT_PROCESSOR_H

--- a/include/utility/measurement_reader.h
+++ b/include/utility/measurement_reader.h
@@ -1,40 +1,40 @@
 #ifndef MEASUREMENT_READER_H
 #define MEASUREMENT_READER_H
 
-#include <vector>
-#include <string>
 #include <array>
+#include <string>
+#include <vector>
 
 struct IMUMsg {
-    double timestamp;
-    double linear_acc_x, linear_acc_y, linear_acc_z;
-    double angular_vel_x, angular_vel_y, angular_vel_z;
+  double timestamp;
+  double linear_acc_x, linear_acc_y, linear_acc_z;
+  double angular_vel_x, angular_vel_y, angular_vel_z;
 };
 
 struct Point3D {
-    int index;
-    double x, y, z;
+  int index;
+  double x, y, z;
 };
 
 using ChannelData = std::vector<double>;
 
 struct ImageFeatureMsg {
-    double timestamp;
-    std::string frame_id;
-    int points_count;
-    int channels_count;
-    std::vector<Point3D> feature_points;
-    std::array<ChannelData, 5> channel_data;
+  double timestamp;
+  std::string frame_id;
+  int points_count;
+  int channels_count;
+  std::vector<Point3D> feature_points;
+  std::array<ChannelData, 5> channel_data;
 };
 
 struct MeasurementMsg {
-    int measurement_id;
-    std::vector<IMUMsg> imu_msg;
-    ImageFeatureMsg image_feature_msg;
+  int measurement_id;
+  std::vector<IMUMsg> imu_msg;
+  ImageFeatureMsg image_feature_msg;
 };
 
 bool readMeasurementFile(const std::string& filepath, MeasurementMsg& measurement);
 
 void printMeasurementMsg(const MeasurementMsg& measurement);
 
-#endif // MEASUREMENT_READER_H 
+#endif  // MEASUREMENT_READER_H

--- a/include/utility/test_result_logger.h
+++ b/include/utility/test_result_logger.h
@@ -1,55 +1,55 @@
 #ifndef TEST_RESULT_LOGGER_H
 #define TEST_RESULT_LOGGER_H
 
-#include <vector>
-#include <mutex>
-#include <string>
 #include <Eigen/Dense>
 #include <chrono>
 #include <experimental/filesystem>
+#include <mutex>
+#include <string>
+#include <vector>
 
 namespace utility {
 
 class TestResultLogger {
 public:
-    TestResultLogger();
-    ~TestResultLogger();
-    
-    // Initialize logger with config file path
-    bool initialize(const std::string& config_path);
-    
-    // Add pose data to trajectory
-    void addPose(const Eigen::Vector3d& position, const Eigen::Matrix3d& rotation, double timestamp);
-    
-    // Save trajectory to file
-    void saveTrajectoryToFile();
-    
-    // Get current trajectory data
-    size_t getPoseCount() const;
-    
-    // Check if logger is initialized
-    bool isInitialized() const { return !log_dir_.empty(); }
-    
-    // Get log directory path
-    std::string getLogDirectory() const { return log_dir_; }
+  TestResultLogger();
+  ~TestResultLogger();
+
+  // Initialize logger with config file path
+  bool initialize(const std::string& config_path);
+
+  // Add pose data to trajectory
+  void addPose(const Eigen::Vector3d& position, const Eigen::Matrix3d& rotation, double timestamp);
+
+  // Save trajectory to file
+  void saveTrajectoryToFile();
+
+  // Get current trajectory data
+  size_t getPoseCount() const;
+
+  // Check if logger is initialized
+  bool isInitialized() const { return !log_dir_.empty(); }
+
+  // Get log directory path
+  std::string getLogDirectory() const { return log_dir_; }
 
 private:
-    // Trajectory data
-    std::vector<Eigen::Vector3d> camera_poses_;
-    std::vector<Eigen::Matrix3d> camera_rotations_;
-    std::vector<double> trajectory_timestamps_;
-    
-    // Thread safety
-    mutable std::mutex pose_mutex_;
-    
-    // Log directory
-    std::string log_dir_;
-    
-    // Helper functions
-    std::string getTimestampString() const;
-    void copyConfigFile(const std::string& config_path);
+  // Trajectory data
+  std::vector<Eigen::Vector3d> camera_poses_;
+  std::vector<Eigen::Matrix3d> camera_rotations_;
+  std::vector<double> trajectory_timestamps_;
+
+  // Thread safety
+  mutable std::mutex pose_mutex_;
+
+  // Log directory
+  std::string log_dir_;
+
+  // Helper functions
+  std::string getTimestampString() const;
+  void copyConfigFile(const std::string& config_path);
 };
 
-} // namespace utility
+}  // namespace utility
 
-#endif // TEST_RESULT_LOGGER_H 
+#endif  // TEST_RESULT_LOGGER_H

--- a/include/utility/utility.h
+++ b/include/utility/utility.h
@@ -1,167 +1,180 @@
 #pragma once
-#include <cassert>
-#include <cmath>
-#include <cstring>
-#include <eigen3/Eigen/Dense>
 #include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <vector>
-#include <string>
+
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <eigen3/Eigen/Dense>
 #include <iostream>
+#include <string>
+#include <vector>
 
 class Utility {
-  public:
-    template <typename Derived>
-    static Eigen::Quaternion<typename Derived::Scalar> deltaQ(const Eigen::MatrixBase<Derived> &theta) {
-        typedef typename Derived::Scalar Scalar_t;
+public:
+  template <typename Derived>
+  static Eigen::Quaternion<typename Derived::Scalar> deltaQ(
+      const Eigen::MatrixBase<Derived> &theta) {
+    typedef typename Derived::Scalar Scalar_t;
 
-        Eigen::Quaternion<Scalar_t> dq;
-        Eigen::Matrix<Scalar_t, 3, 1> half_theta = theta;
-        half_theta /= static_cast<Scalar_t>(2.0);
-        dq.w() = static_cast<Scalar_t>(1.0);
-        dq.x() = half_theta.x();
-        dq.y() = half_theta.y();
-        dq.z() = half_theta.z();
-        return dq;
-    }
+    Eigen::Quaternion<Scalar_t> dq;
+    Eigen::Matrix<Scalar_t, 3, 1> half_theta = theta;
+    half_theta /= static_cast<Scalar_t>(2.0);
+    dq.w() = static_cast<Scalar_t>(1.0);
+    dq.x() = half_theta.x();
+    dq.y() = half_theta.y();
+    dq.z() = half_theta.z();
+    return dq;
+  }
 
-    template <typename Derived>
-    static Eigen::Matrix<typename Derived::Scalar, 3, 3> skewSymmetric(const Eigen::MatrixBase<Derived> &q) {
-        Eigen::Matrix<typename Derived::Scalar, 3, 3> ans;
-        ans << typename Derived::Scalar(0), -q(2), q(1), q(2), typename Derived::Scalar(0), -q(0), -q(1), q(0),
-            typename Derived::Scalar(0);
-        return ans;
-    }
+  template <typename Derived>
+  static Eigen::Matrix<typename Derived::Scalar, 3, 3> skewSymmetric(
+      const Eigen::MatrixBase<Derived> &q) {
+    Eigen::Matrix<typename Derived::Scalar, 3, 3> ans;
+    ans << typename Derived::Scalar(0), -q(2), q(1), q(2), typename Derived::Scalar(0), -q(0),
+        -q(1), q(0), typename Derived::Scalar(0);
+    return ans;
+  }
 
-    template <typename Derived>
-    static Eigen::Quaternion<typename Derived::Scalar> positify(const Eigen::QuaternionBase<Derived> &q) {
-        // printf("a: %f %f %f %f", q.w(), q.x(), q.y(), q.z());
-        // Eigen::Quaternion<typename Derived::Scalar> p(-q.w(), -q.x(), -q.y(),
-        // -q.z()); printf("b: %f %f %f %f", p.w(), p.x(), p.y(), p.z()); return
-        // q.template w() >= (typename Derived::Scalar)(0.0) ? q :
-        // Eigen::Quaternion<typename Derived::Scalar>(-q.w(), -q.x(), -q.y(),
-        // -q.z());
-        return q;
-    }
+  template <typename Derived>
+  static Eigen::Quaternion<typename Derived::Scalar> positify(
+      const Eigen::QuaternionBase<Derived> &q) {
+    // printf("a: %f %f %f %f", q.w(), q.x(), q.y(), q.z());
+    // Eigen::Quaternion<typename Derived::Scalar> p(-q.w(), -q.x(), -q.y(),
+    // -q.z()); printf("b: %f %f %f %f", p.w(), p.x(), p.y(), p.z()); return
+    // q.template w() >= (typename Derived::Scalar)(0.0) ? q :
+    // Eigen::Quaternion<typename Derived::Scalar>(-q.w(), -q.x(), -q.y(),
+    // -q.z());
+    return q;
+  }
 
-    template <typename Derived>
-    static Eigen::Matrix<typename Derived::Scalar, 4, 4> Qleft(const Eigen::QuaternionBase<Derived> &q) {
-        Eigen::Quaternion<typename Derived::Scalar> qq = positify(q);
-        Eigen::Matrix<typename Derived::Scalar, 4, 4> ans;
-        ans(0, 0) = qq.w(), ans.template block<1, 3>(0, 1) = -qq.vec().transpose();
-        ans.template block<3, 1>(1, 0) = qq.vec(),
-                                    ans.template block<3, 3>(1, 1) =
-                                        qq.w() * Eigen::Matrix<typename Derived::Scalar, 3, 3>::Identity() +
-                                        skewSymmetric(qq.vec());
-        return ans;
-    }
+  template <typename Derived>
+  static Eigen::Matrix<typename Derived::Scalar, 4, 4> Qleft(
+      const Eigen::QuaternionBase<Derived> &q) {
+    Eigen::Quaternion<typename Derived::Scalar> qq = positify(q);
+    Eigen::Matrix<typename Derived::Scalar, 4, 4> ans;
+    ans(0, 0) = qq.w(), ans.template block<1, 3>(0, 1) = -qq.vec().transpose();
+    ans.template block<3, 1>(1, 0) = qq.vec(),
+                                ans.template block<3, 3>(1, 1) =
+                                    qq.w() *
+                                        Eigen::Matrix<typename Derived::Scalar, 3, 3>::Identity() +
+                                    skewSymmetric(qq.vec());
+    return ans;
+  }
 
-    template <typename Derived>
-    static Eigen::Matrix<typename Derived::Scalar, 4, 4> Qright(const Eigen::QuaternionBase<Derived> &p) {
-        Eigen::Quaternion<typename Derived::Scalar> pp = positify(p);
-        Eigen::Matrix<typename Derived::Scalar, 4, 4> ans;
-        ans(0, 0) = pp.w(), ans.template block<1, 3>(0, 1) = -pp.vec().transpose();
-        ans.template block<3, 1>(1, 0) = pp.vec(),
-                                    ans.template block<3, 3>(1, 1) =
-                                        pp.w() * Eigen::Matrix<typename Derived::Scalar, 3, 3>::Identity() -
-                                        skewSymmetric(pp.vec());
-        return ans;
-    }
+  template <typename Derived>
+  static Eigen::Matrix<typename Derived::Scalar, 4, 4> Qright(
+      const Eigen::QuaternionBase<Derived> &p) {
+    Eigen::Quaternion<typename Derived::Scalar> pp = positify(p);
+    Eigen::Matrix<typename Derived::Scalar, 4, 4> ans;
+    ans(0, 0) = pp.w(), ans.template block<1, 3>(0, 1) = -pp.vec().transpose();
+    ans.template block<3, 1>(1, 0) = pp.vec(),
+                                ans.template block<3, 3>(1, 1) =
+                                    pp.w() *
+                                        Eigen::Matrix<typename Derived::Scalar, 3, 3>::Identity() -
+                                    skewSymmetric(pp.vec());
+    return ans;
+  }
 
-    static Eigen::Vector3d R2ypr(const Eigen::Matrix3d &R) {
-        Eigen::Vector3d n = R.col(0);
-        Eigen::Vector3d o = R.col(1);
-        Eigen::Vector3d a = R.col(2);
+  static Eigen::Vector3d R2ypr(const Eigen::Matrix3d &R) {
+    Eigen::Vector3d n = R.col(0);
+    Eigen::Vector3d o = R.col(1);
+    Eigen::Vector3d a = R.col(2);
 
-        Eigen::Vector3d ypr(3);
-        double y = atan2(n(1), n(0));
-        double p = atan2(-n(2), n(0) * cos(y) + n(1) * sin(y));
-        double r = atan2(a(0) * sin(y) - a(1) * cos(y), -o(0) * sin(y) + o(1) * cos(y));
-        ypr(0) = y;
-        ypr(1) = p;
-        ypr(2) = r;
+    Eigen::Vector3d ypr(3);
+    double y = atan2(n(1), n(0));
+    double p = atan2(-n(2), n(0) * cos(y) + n(1) * sin(y));
+    double r = atan2(a(0) * sin(y) - a(1) * cos(y), -o(0) * sin(y) + o(1) * cos(y));
+    ypr(0) = y;
+    ypr(1) = p;
+    ypr(2) = r;
 
-        return ypr / M_PI * 180.0;
-    }
+    return ypr / M_PI * 180.0;
+  }
 
-    template <typename Derived>
-    static Eigen::Matrix<typename Derived::Scalar, 3, 3> ypr2R(const Eigen::MatrixBase<Derived> &ypr) {
-        typedef typename Derived::Scalar Scalar_t;
+  template <typename Derived>
+  static Eigen::Matrix<typename Derived::Scalar, 3, 3> ypr2R(
+      const Eigen::MatrixBase<Derived> &ypr) {
+    typedef typename Derived::Scalar Scalar_t;
 
-        Scalar_t y = ypr(0) / 180.0 * M_PI;
-        Scalar_t p = ypr(1) / 180.0 * M_PI;
-        Scalar_t r = ypr(2) / 180.0 * M_PI;
+    Scalar_t y = ypr(0) / 180.0 * M_PI;
+    Scalar_t p = ypr(1) / 180.0 * M_PI;
+    Scalar_t r = ypr(2) / 180.0 * M_PI;
 
-        Eigen::Matrix<Scalar_t, 3, 3> Rz;
-        Rz << cos(y), -sin(y), 0, sin(y), cos(y), 0, 0, 0, 1;
+    Eigen::Matrix<Scalar_t, 3, 3> Rz;
+    Rz << cos(y), -sin(y), 0, sin(y), cos(y), 0, 0, 0, 1;
 
-        Eigen::Matrix<Scalar_t, 3, 3> Ry;
-        Ry << cos(p), 0., sin(p), 0., 1., 0., -sin(p), 0., cos(p);
+    Eigen::Matrix<Scalar_t, 3, 3> Ry;
+    Ry << cos(p), 0., sin(p), 0., 1., 0., -sin(p), 0., cos(p);
 
-        Eigen::Matrix<Scalar_t, 3, 3> Rx;
-        Rx << 1., 0., 0., 0., cos(r), -sin(r), 0., sin(r), cos(r);
+    Eigen::Matrix<Scalar_t, 3, 3> Rx;
+    Rx << 1., 0., 0., 0., cos(r), -sin(r), 0., sin(r), cos(r);
 
-        return Rz * Ry * Rx;
-    }
+    return Rz * Ry * Rx;
+  }
 
-    static Eigen::Matrix3d g2R(const Eigen::Vector3d &g);
+  static Eigen::Matrix3d g2R(const Eigen::Vector3d &g);
 
-    template <size_t N> struct uint_ {};
+  template <size_t N>
+  struct uint_ {};
 
-    template <size_t N, typename Lambda, typename IterT> void unroller(const Lambda &f, const IterT &iter, uint_<N>) {
-        unroller(f, iter, uint_<N - 1>());
-        f(iter + N);
-    }
+  template <size_t N, typename Lambda, typename IterT>
+  void unroller(const Lambda &f, const IterT &iter, uint_<N>) {
+    unroller(f, iter, uint_<N - 1>());
+    f(iter + N);
+  }
 
-    template <typename Lambda, typename IterT> void unroller(const Lambda &f, const IterT &iter, uint_<0>) {
-        f(iter);
-    }
+  template <typename Lambda, typename IterT>
+  void unroller(const Lambda &f, const IterT &iter, uint_<0>) {
+    f(iter);
+  }
 
-    template <typename T> static T normalizeAngle(const T &angle_degrees) {
-        T two_pi(2.0 * 180);
-        if (angle_degrees > 0)
-            return angle_degrees - two_pi * std::floor((angle_degrees + T(180)) / two_pi);
-        else
-            return angle_degrees + two_pi * std::floor((-angle_degrees + T(180)) / two_pi);
-    };
+  template <typename T>
+  static T normalizeAngle(const T &angle_degrees) {
+    T two_pi(2.0 * 180);
+    if (angle_degrees > 0)
+      return angle_degrees - two_pi * std::floor((angle_degrees + T(180)) / two_pi);
+    else
+      return angle_degrees + two_pi * std::floor((-angle_degrees + T(180)) / two_pi);
+  };
 };
 
 class FileSystemHelper {
-  public:
-    /******************************************************************************
-     * Recursively create directory if `path` not exists.
-     * Return 0 if success.
-     *****************************************************************************/
-    static int createDirectoryIfNotExists(const char *path) {
-        struct stat info;
-        int statRC = stat(path, &info);
-        if (statRC != 0) {
-            if (errno == ENOENT) {
-                printf("%s not exists, trying to create it \n", path);
-                if (!createDirectoryIfNotExists(dirname(strdupa(path)))) {
-                    if (mkdir(path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) != 0) {
-                        fprintf(stderr, "Failed to create folder %s \n", path);
-                        return 1;
-                    } else
-                        return 0;
-                } else
-                    return 1;
-            } // directory not exists
-            if (errno == ENOTDIR) {
-                fprintf(stderr, "%s is not a directory path \n", path);
-                return 1;
-            } // something in path prefix is not a dir
+public:
+  /******************************************************************************
+   * Recursively create directory if `path` not exists.
+   * Return 0 if success.
+   *****************************************************************************/
+  static int createDirectoryIfNotExists(const char *path) {
+    struct stat info;
+    int statRC = stat(path, &info);
+    if (statRC != 0) {
+      if (errno == ENOENT) {
+        printf("%s not exists, trying to create it \n", path);
+        if (!createDirectoryIfNotExists(dirname(strdupa(path)))) {
+          if (mkdir(path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) != 0) {
+            fprintf(stderr, "Failed to create folder %s \n", path);
             return 1;
-        }
-        return (info.st_mode & S_IFDIR) ? 0 : 1;
+          } else
+            return 0;
+        } else
+          return 1;
+      }  // directory not exists
+      if (errno == ENOTDIR) {
+        fprintf(stderr, "%s is not a directory path \n", path);
+        return 1;
+      }  // something in path prefix is not a dir
+      return 1;
     }
+    return (info.st_mode & S_IFDIR) ? 0 : 1;
+  }
 };
 
 namespace utility {
 
-std::vector<std::string> getImageFilesFromDirectory(const std::string& directory_path);
+std::vector<std::string> getImageFilesFromDirectory(const std::string &directory_path);
 
 }

--- a/include/utility/visualizer.h
+++ b/include/utility/visualizer.h
@@ -1,68 +1,70 @@
 #ifndef VISUALIZER_H
 #define VISUALIZER_H
 
-#include <vector>
-#include <mutex>
-#include <thread>
-#include <Eigen/Dense>
 #include <pangolin/pangolin.h>
+
+#include <Eigen/Dense>
 #include <condition_variable>
+#include <mutex>
 #include <string>
+#include <thread>
+#include <vector>
 
 class Visualizer {
 public:
-    Visualizer();
-    ~Visualizer();
-    
-    // Initialize and start the viewer
-    bool initialize();
-    bool start();
-    void stop();
-    
-    // Update camera pose and trajectory
-    void updateCameraPose(const Eigen::Vector3d& position, const Eigen::Matrix3d& rotation, double timestamp);
-    
-    // Update 3D feature points
-    void updateFeaturePoints3D(const std::vector<Eigen::Vector3d>& points);
-    
-    // Check if viewer is running
-    bool isRunning() const { return running_; }
-    
-    // Test function for debugging
-    void testWithSimpleData();
+  Visualizer();
+  ~Visualizer();
 
-    void waitUntilRenderReady();
+  // Initialize and start the viewer
+  bool initialize();
+  bool start();
+  void stop();
 
-    void pangolinViewerThread();
+  // Update camera pose and trajectory
+  void updateCameraPose(const Eigen::Vector3d& position, const Eigen::Matrix3d& rotation,
+                        double timestamp);
+
+  // Update 3D feature points
+  void updateFeaturePoints3D(const std::vector<Eigen::Vector3d>& points);
+
+  // Check if viewer is running
+  bool isRunning() const { return running_; }
+
+  // Test function for debugging
+  void testWithSimpleData();
+
+  void waitUntilRenderReady();
+
+  void pangolinViewerThread();
 
 private:
-    // Pangolin viewer variables
-    std::vector<Eigen::Vector3d> camera_poses_;
-    std::vector<Eigen::Matrix3d> camera_rotations_;
-    std::vector<double> trajectory_timestamps_;
-    std::vector<Eigen::Vector3d> feature_points_3d_;
-    
-    // Threading
-    std::thread viewer_thread_;
-    std::mutex pose_mutex_;
-    std::mutex points_mutex_;
-    bool running_;
-    
-    // Pangolin objects
-    pangolin::OpenGlRenderState* g_s_cam_;
-    pangolin::View* g_d_cam_;
-    
-    // Private methods
-    void setupPangolinViewer();
-    void drawCameraTrajectory();
-    void drawFeaturePoints3D();
-    void drawCoordinateFrame();
-    void drawGrid();
-    void drawCameraFrustum(const Eigen::Vector3d& pos, const Eigen::Matrix3d& rot, double size = 0.1);
+  // Pangolin viewer variables
+  std::vector<Eigen::Vector3d> camera_poses_;
+  std::vector<Eigen::Matrix3d> camera_rotations_;
+  std::vector<double> trajectory_timestamps_;
+  std::vector<Eigen::Vector3d> feature_points_3d_;
 
-    std::condition_variable render_ready_cv_;
-    std::mutex render_ready_mutex_;
-    bool render_ready_ = false;
+  // Threading
+  std::thread viewer_thread_;
+  std::mutex pose_mutex_;
+  std::mutex points_mutex_;
+  bool running_;
+
+  // Pangolin objects
+  pangolin::OpenGlRenderState* g_s_cam_;
+  pangolin::View* g_d_cam_;
+
+  // Private methods
+  void setupPangolinViewer();
+  void drawCameraTrajectory();
+  void drawFeaturePoints3D();
+  void drawCoordinateFrame();
+  void drawGrid();
+  void drawCameraFrustum(const Eigen::Vector3d& pos, const Eigen::Matrix3d& rot, double size = 0.1);
+
+  std::condition_variable render_ready_cv_;
+  std::mutex render_ready_mutex_;
+  bool render_ready_ = false;
 };
 
-#endif // VISUALIZER_H 
+#endif  // VISUALIZER_H

--- a/src/backend/estimator.cpp
+++ b/src/backend/estimator.cpp
@@ -1,8 +1,9 @@
+#include "backend/estimator.h"
+
 #include <fstream>
 #include <iostream>
 #include <mutex>
 
-#include "backend/estimator.h"
 #include "utility/config.h"
 
 namespace backend {
@@ -11,280 +12,283 @@ Estimator::Estimator()
     : feature_manager_(),
       optimizer_(&sliding_window_, &feature_manager_),
       failure_detector_(&sliding_window_, &feature_manager_),
-      initializer_(&sliding_window_, &feature_manager_, &motion_estimator_, &all_image_frame_, &frame_count_,
-                   &marginalization_flag_, &g_, &r_ic_, &t_ic_) {
-    clearState();
+      initializer_(&sliding_window_, &feature_manager_, &motion_estimator_, &all_image_frame_,
+                   &frame_count_, &marginalization_flag_, &g_, &r_ic_, &t_ic_) {
+  clearState();
 }
 
 void Estimator::setParameter() {
-    t_ic_ = g_config.camera.t_ic;
-    r_ic_ = g_config.camera.r_ic;
-    backend::factor::ProjectionFactor::sqrt_info = (g_config.camera.focal_length / 1.5) * Matrix2d::Identity();
+  t_ic_ = g_config.camera.t_ic;
+  r_ic_ = g_config.camera.r_ic;
+  backend::factor::ProjectionFactor::sqrt_info =
+      (g_config.camera.focal_length / 1.5) * Matrix2d::Identity();
 
-    // Set extrinsic parameters in optimizer
-    optimizer_.setExtrinsicParameters(t_ic_, r_ic_);
+  // Set extrinsic parameters in optimizer
+  optimizer_.setExtrinsicParameters(t_ic_, r_ic_);
 }
 
 void Estimator::clearState() {
-    for (int i = 0; i < WINDOW_SIZE + 1; i++) {
-        sliding_window_.clearSlidingWindow();
+  for (int i = 0; i < WINDOW_SIZE + 1; i++) {
+    sliding_window_.clearSlidingWindow();
+  }
+
+  t_ic_ = Vector3d::Zero();
+  r_ic_ = Matrix3d::Identity();
+
+  for (auto& it : all_image_frame_) {
+    if (it.second.pre_integration != nullptr) {
+      delete it.second.pre_integration;
+      it.second.pre_integration = nullptr;
     }
+  }
+  all_image_frame_.clear();
 
-    t_ic_ = Vector3d::Zero();
-    r_ic_ = Matrix3d::Identity();
+  solver_flag_ = SolverFlag::INITIAL;
+  first_imu_ = false;
+  frame_count_ = 0;
+  initial_timestamp_ = 0;
 
-    for (auto& it : all_image_frame_) {
-        if (it.second.pre_integration != nullptr) {
-            delete it.second.pre_integration;
-            it.second.pre_integration = nullptr;
-        }
-    }
-    all_image_frame_.clear();
+  if (tmp_pre_integration_ != nullptr) delete tmp_pre_integration_;
 
-    solver_flag_ = SolverFlag::INITIAL;
-    first_imu_ = false;
-    frame_count_ = 0;
-    initial_timestamp_ = 0;
+  tmp_pre_integration_ = nullptr;
 
-    if (tmp_pre_integration_ != nullptr)
-        delete tmp_pre_integration_;
+  feature_manager_.clearState();
 
-    tmp_pre_integration_ = nullptr;
-
-    feature_manager_.clearState();
-
-    failure_occur_ = 0;
+  failure_occur_ = 0;
 }
 
 void Estimator::propagateIMUState(int frame_index, double dt, const Vector3d& linear_acceleration,
                                   const Vector3d& angular_velocity) {
-    // Store IMU data in buffers
-    sliding_window_.pushBackBuffer(frame_index, dt, linear_acceleration, angular_velocity);
+  // Store IMU data in buffers
+  sliding_window_.pushBackBuffer(frame_index, dt, linear_acceleration, angular_velocity);
 
-    // Bias-corrected measurements
-    Vector3d bias_corrected_prev_acc =
-        sliding_window_[frame_index].R * (prev_acc_ - sliding_window_[frame_index].Ba) - g_;
-    Vector3d bias_corrected_gyro = 0.5 * (prev_gyro_ + angular_velocity) - sliding_window_[frame_index].Bg;
+  // Bias-corrected measurements
+  Vector3d bias_corrected_prev_acc =
+      sliding_window_[frame_index].R * (prev_acc_ - sliding_window_[frame_index].Ba) - g_;
+  Vector3d bias_corrected_gyro =
+      0.5 * (prev_gyro_ + angular_velocity) - sliding_window_[frame_index].Bg;
 
-    // update rotation: R = R * exp(gyro*dt)
-    sliding_window_[frame_index].R *= Utility::deltaQ(bias_corrected_gyro * dt).toRotationMatrix();
+  // update rotation: R = R * exp(gyro*dt)
+  sliding_window_[frame_index].R *= Utility::deltaQ(bias_corrected_gyro * dt).toRotationMatrix();
 
-    // Propagate position and velocity using trapezoidal integration
-    Vector3d bias_corrected_curr_acc =
-        sliding_window_[frame_index].R * (linear_acceleration - sliding_window_[frame_index].Ba) - g_;
-    Vector3d bias_corrected_acc = 0.5 * (bias_corrected_prev_acc + bias_corrected_curr_acc);
+  // Propagate position and velocity using trapezoidal integration
+  Vector3d bias_corrected_curr_acc =
+      sliding_window_[frame_index].R * (linear_acceleration - sliding_window_[frame_index].Ba) - g_;
+  Vector3d bias_corrected_acc = 0.5 * (bias_corrected_prev_acc + bias_corrected_curr_acc);
 
-    // Update position: P = P + V*dt + 0.5*a*dt^2
-    // Update velocity: V = V + a*dt
-    sliding_window_[frame_index].P += dt * sliding_window_[frame_index].V + 0.5 * dt * dt * bias_corrected_acc;
-    sliding_window_[frame_index].V += dt * bias_corrected_acc;
+  // Update position: P = P + V*dt + 0.5*a*dt^2
+  // Update velocity: V = V + a*dt
+  sliding_window_[frame_index].P +=
+      dt * sliding_window_[frame_index].V + 0.5 * dt * dt * bias_corrected_acc;
+  sliding_window_[frame_index].V += dt * bias_corrected_acc;
 }
 
 void Estimator::processIMU(double dt, const Eigen::Vector3d& linear_acceleration,
                            const Eigen::Vector3d& angular_velocity) {
-    std::lock_guard<std::mutex> lock(estimator_mutex_);
-    // check initial IMU data
-    if (!first_imu_) {
-        first_imu_ = true;
-        prev_acc_ = linear_acceleration;
-        prev_gyro_ = angular_velocity;
-    }
-
-    // if pre_integrations[frame_count_] is not initialized, initialize it
-    // this is generated at every new image frame
-    if (sliding_window_[frame_count_].pre_integration == nullptr) {
-        sliding_window_[frame_count_].pre_integration = new backend::factor::IntegrationBase{
-            prev_acc_, prev_gyro_, sliding_window_[frame_count_].Ba, sliding_window_[frame_count_].Bg};
-    }
-
-    if (frame_count_ != 0) {
-        sliding_window_.pushBackPreintegration(frame_count_, dt, linear_acceleration, angular_velocity);
-        tmp_pre_integration_->push_back(dt, linear_acceleration, angular_velocity);
-        propagateIMUState(frame_count_, dt, linear_acceleration, angular_velocity);
-    }
-
+  std::lock_guard<std::mutex> lock(estimator_mutex_);
+  // check initial IMU data
+  if (!first_imu_) {
+    first_imu_ = true;
     prev_acc_ = linear_acceleration;
     prev_gyro_ = angular_velocity;
+  }
+
+  // if pre_integrations[frame_count_] is not initialized, initialize it
+  // this is generated at every new image frame
+  if (sliding_window_[frame_count_].pre_integration == nullptr) {
+    sliding_window_[frame_count_].pre_integration = new backend::factor::IntegrationBase{
+        prev_acc_, prev_gyro_, sliding_window_[frame_count_].Ba, sliding_window_[frame_count_].Bg};
+  }
+
+  if (frame_count_ != 0) {
+    sliding_window_.pushBackPreintegration(frame_count_, dt, linear_acceleration, angular_velocity);
+    tmp_pre_integration_->push_back(dt, linear_acceleration, angular_velocity);
+    propagateIMUState(frame_count_, dt, linear_acceleration, angular_velocity);
+  }
+
+  prev_acc_ = linear_acceleration;
+  prev_gyro_ = angular_velocity;
 }
 
 void Estimator::processImage(const ImageData& image, double timestamp) {
-    std::lock_guard<std::mutex> lock(estimator_mutex_);
-    if (feature_manager_.addFeatureCheckParallax(frame_count_, image)) {
-        marginalization_flag_ = MarginalizationFlag::MARGIN_OLD_KEYFRAME;
-    } else {
-        marginalization_flag_ = MarginalizationFlag::MARGIN_NEW_GENERAL_FRAME;
-    }
+  std::lock_guard<std::mutex> lock(estimator_mutex_);
+  if (feature_manager_.addFeatureCheckParallax(frame_count_, image)) {
+    marginalization_flag_ = MarginalizationFlag::MARGIN_OLD_KEYFRAME;
+  } else {
+    marginalization_flag_ = MarginalizationFlag::MARGIN_NEW_GENERAL_FRAME;
+  }
 
-    sliding_window_[frame_count_].timestamp = timestamp;
+  sliding_window_[frame_count_].timestamp = timestamp;
 
-    ImageFrame imageframe(image, timestamp);
-    imageframe.pre_integration = tmp_pre_integration_;
-    all_image_frame_.insert(make_pair(timestamp, imageframe));
-    tmp_pre_integration_ =
-        new backend::factor::IntegrationBase{prev_acc_, prev_gyro_, sliding_window_[frame_count_].Ba, sliding_window_[frame_count_].Bg};
+  ImageFrame imageframe(image, timestamp);
+  imageframe.pre_integration = tmp_pre_integration_;
+  all_image_frame_.insert(make_pair(timestamp, imageframe));
+  tmp_pre_integration_ = new backend::factor::IntegrationBase{
+      prev_acc_, prev_gyro_, sliding_window_[frame_count_].Ba, sliding_window_[frame_count_].Bg};
 
-    if (solver_flag_ == SolverFlag::INITIAL) {
-        if (frame_count_ == WINDOW_SIZE) {
-            bool visual_map_init_result = false;
-            if (timestamp - initial_timestamp_ > 0.1) {
-                visual_map_init_result = initializer_.initialize();
-                initial_timestamp_ = timestamp;
-            }
+  if (solver_flag_ == SolverFlag::INITIAL) {
+    if (frame_count_ == WINDOW_SIZE) {
+      bool visual_map_init_result = false;
+      if (timestamp - initial_timestamp_ > 0.1) {
+        visual_map_init_result = initializer_.initialize();
+        initial_timestamp_ = timestamp;
+      }
 
-            if (visual_map_init_result) {
-                solver_flag_ = SolverFlag::NON_LINEAR;
-                solveOdometry();
-                slideWindow();
-                feature_manager_.removeFailures();
-
-                storeLastPoseInSlidingWindow();
-            } else {
-                slideWindow();
-            }
-        } else {
-            frame_count_++;
-        }
-    } else if (solver_flag_ == SolverFlag::NON_LINEAR) {
+      if (visual_map_init_result) {
+        solver_flag_ = SolverFlag::NON_LINEAR;
         solveOdometry();
-
-        if (failure_detector_.detectFailure(last_P_end_, last_R_end_)) {
-            failure_occur_ = 1;
-            clearState();
-            setParameter();
-            return;
-        }
-
         slideWindow();
         feature_manager_.removeFailures();
 
         storeLastPoseInSlidingWindow();
+      } else {
+        slideWindow();
+      }
+    } else {
+      frame_count_++;
     }
+  } else if (solver_flag_ == SolverFlag::NON_LINEAR) {
+    solveOdometry();
+
+    if (failure_detector_.detectFailure(last_P_end_, last_R_end_)) {
+      failure_occur_ = 1;
+      clearState();
+      setParameter();
+      return;
+    }
+
+    slideWindow();
+    feature_manager_.removeFailures();
+
+    storeLastPoseInSlidingWindow();
+  }
 }
 
 void Estimator::storeLastPoseInSlidingWindow() {
-    last_R_end_ = sliding_window_.back().R;
-    last_P_end_ = sliding_window_.back().P;
+  last_R_end_ = sliding_window_.back().R;
+  last_P_end_ = sliding_window_.back().P;
 }
 
 void Estimator::cleanupOldImageFrames(double timestamp) {
-    auto it_0 = all_image_frame_.find(timestamp);
-    if (it_0 == all_image_frame_.end()) {
-        return;
-    }
+  auto it_0 = all_image_frame_.find(timestamp);
+  if (it_0 == all_image_frame_.end()) {
+    return;
+  }
 
-    // 1. 현재 프레임의 pre_integration 정리
-    cleanupPreIntegration(it_0->second);
+  // 1. 현재 프레임의 pre_integration 정리
+  cleanupPreIntegration(it_0->second);
 
-    // 2. 이전 프레임들의 pre_integration 정리
-    for (auto it = all_image_frame_.begin(); it != it_0; ++it) {
-        cleanupPreIntegration(it->second);
-    }
+  // 2. 이전 프레임들의 pre_integration 정리
+  for (auto it = all_image_frame_.begin(); it != it_0; ++it) {
+    cleanupPreIntegration(it->second);
+  }
 
-    // 3. 프레임 제거
-    all_image_frame_.erase(all_image_frame_.begin(), it_0);
-    all_image_frame_.erase(timestamp);
+  // 3. 프레임 제거
+  all_image_frame_.erase(all_image_frame_.begin(), it_0);
+  all_image_frame_.erase(timestamp);
 }
 
 void Estimator::cleanupPreIntegration(ImageFrame& frame) {
-    if (frame.pre_integration) {
-        delete frame.pre_integration;
-        frame.pre_integration = nullptr;
-    }
+  if (frame.pre_integration) {
+    delete frame.pre_integration;
+    frame.pre_integration = nullptr;
+  }
 }
 
 void Estimator::slideWindow() {
-    if (frame_count_ == WINDOW_SIZE) {
-        if (marginalization_flag_ == MarginalizationFlag::MARGIN_OLD_KEYFRAME) {
-            slideWindowOldKeyframe();
-        } else if (marginalization_flag_ == MarginalizationFlag::MARGIN_NEW_GENERAL_FRAME) {
-            slideWindowNewGeneralFrame();
-        }
+  if (frame_count_ == WINDOW_SIZE) {
+    if (marginalization_flag_ == MarginalizationFlag::MARGIN_OLD_KEYFRAME) {
+      slideWindowOldKeyframe();
+    } else if (marginalization_flag_ == MarginalizationFlag::MARGIN_NEW_GENERAL_FRAME) {
+      slideWindowNewGeneralFrame();
     }
+  }
 }
 
 void Estimator::slideWindowNewGeneralFrame() {
-    // preintegrate new general frame onto the last keyframe
-    for (unsigned int i = 0; i < sliding_window_[WINDOW_SIZE].dt_buf.size(); i++) {
-        double tmp_dt = sliding_window_[WINDOW_SIZE].dt_buf[i];
-        Vector3d tmp_linear_acceleration = sliding_window_[WINDOW_SIZE].linear_acceleration_buf[i];
-        Vector3d tmp_angular_velocity = sliding_window_[WINDOW_SIZE].angular_velocity_buf[i];
+  // preintegrate new general frame onto the last keyframe
+  for (unsigned int i = 0; i < sliding_window_[WINDOW_SIZE].dt_buf.size(); i++) {
+    double tmp_dt = sliding_window_[WINDOW_SIZE].dt_buf[i];
+    Vector3d tmp_linear_acceleration = sliding_window_[WINDOW_SIZE].linear_acceleration_buf[i];
+    Vector3d tmp_angular_velocity = sliding_window_[WINDOW_SIZE].angular_velocity_buf[i];
 
-        sliding_window_.pushBackPreintegration(WINDOW_SIZE - 1, tmp_dt, tmp_linear_acceleration, tmp_angular_velocity);
-        sliding_window_.pushBackBuffer(WINDOW_SIZE - 1, tmp_dt, tmp_linear_acceleration, tmp_angular_velocity);
-    }
-    sliding_window_.copyFrame(WINDOW_SIZE - 1, WINDOW_SIZE);
-    sliding_window_.createNewPreintegration(WINDOW_SIZE, prev_acc_, prev_gyro_);
-    sliding_window_.clearBuffer(WINDOW_SIZE);
-    feature_manager_.removeFront(frame_count_);
+    sliding_window_.pushBackPreintegration(WINDOW_SIZE - 1, tmp_dt, tmp_linear_acceleration,
+                                           tmp_angular_velocity);
+    sliding_window_.pushBackBuffer(WINDOW_SIZE - 1, tmp_dt, tmp_linear_acceleration,
+                                   tmp_angular_velocity);
+  }
+  sliding_window_.copyFrame(WINDOW_SIZE - 1, WINDOW_SIZE);
+  sliding_window_.createNewPreintegration(WINDOW_SIZE, prev_acc_, prev_gyro_);
+  sliding_window_.clearBuffer(WINDOW_SIZE);
+  feature_manager_.removeFront(frame_count_);
 }
 
 void Estimator::slideWindowOldKeyframe() {
-    Matrix3d back_R0 = sliding_window_.front().R;
-    Vector3d back_P0 = sliding_window_.front().P;
+  Matrix3d back_R0 = sliding_window_.front().R;
+  Vector3d back_P0 = sliding_window_.front().P;
 
-    double t_0 = sliding_window_.front().timestamp;
-    for (int i = 0; i < WINDOW_SIZE; i++) {
-        sliding_window_.swapBuffer(i, i + 1);
-        sliding_window_.swapFrame(i, i + 1);
-    }
-    sliding_window_.copyFrame(WINDOW_SIZE, WINDOW_SIZE - 1);
-    sliding_window_.createNewPreintegration(WINDOW_SIZE, prev_acc_, prev_gyro_);
-    sliding_window_.clearBuffer(WINDOW_SIZE);
+  double t_0 = sliding_window_.front().timestamp;
+  for (int i = 0; i < WINDOW_SIZE; i++) {
+    sliding_window_.swapBuffer(i, i + 1);
+    sliding_window_.swapFrame(i, i + 1);
+  }
+  sliding_window_.copyFrame(WINDOW_SIZE, WINDOW_SIZE - 1);
+  sliding_window_.createNewPreintegration(WINDOW_SIZE, prev_acc_, prev_gyro_);
+  sliding_window_.clearBuffer(WINDOW_SIZE);
 
-    cleanupOldImageFrames(t_0);
+  cleanupOldImageFrames(t_0);
 
-    bool shift_depth = (solver_flag_ == SolverFlag::NON_LINEAR) ? true : false;
-    if (shift_depth) {
-        Matrix3d R0, R1;
-        Vector3d P0, P1;
-        R0 = back_R0 * r_ic_;
-        R1 = sliding_window_.front().R * r_ic_;
-        P0 = back_P0 + back_R0 * t_ic_;
-        P1 = sliding_window_.front().P + sliding_window_.front().R * t_ic_;
-        feature_manager_.removeBackShiftDepth(R0, P0, R1, P1);
-    } else
-        feature_manager_.removeBack();
+  bool shift_depth = (solver_flag_ == SolverFlag::NON_LINEAR) ? true : false;
+  if (shift_depth) {
+    Matrix3d R0, R1;
+    Vector3d P0, P1;
+    R0 = back_R0 * r_ic_;
+    R1 = sliding_window_.front().R * r_ic_;
+    P0 = back_P0 + back_R0 * t_ic_;
+    P1 = sliding_window_.front().P + sliding_window_.front().R * t_ic_;
+    feature_manager_.removeBackShiftDepth(R0, P0, R1, P1);
+  } else
+    feature_manager_.removeBack();
 }
 
 void Estimator::solveOdometry() {
-    if (frame_count_ < WINDOW_SIZE)
-        return;
+  if (frame_count_ < WINDOW_SIZE) return;
 
-    if (solver_flag_ == SolverFlag::NON_LINEAR) {
-        feature_manager_.triangulate(sliding_window_, t_ic_, r_ic_);
+  if (solver_flag_ == SolverFlag::NON_LINEAR) {
+    feature_manager_.triangulate(sliding_window_, t_ic_, r_ic_);
 
-        // Use optimizer for optimization
-        optimizer_.optimize(marginalization_flag_);
+    // Use optimizer for optimization
+    optimizer_.optimize(marginalization_flag_);
 
-        // Update extrinsic parameters from optimizer
-        t_ic_ = optimizer_.getTic();
-        r_ic_ = optimizer_.getRic();
-    }
+    // Update extrinsic parameters from optimizer
+    t_ic_ = optimizer_.getTic();
+    r_ic_ = optimizer_.getRic();
+  }
 }
 
 std::vector<Eigen::Vector3d> Estimator::getSlidingWindowMapPoints() const {
-    std::lock_guard<std::mutex> lock(estimator_mutex_);
-    std::vector<Eigen::Vector3d> new_points;
-    if (solver_flag_ == SolverFlag::NON_LINEAR) {
-        for (const auto& it_per_id : feature_manager_.feature) {
-            if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2))
-                continue;
-            if (it_per_id.estimated_depth > 0 && it_per_id.solve_flag == 1) {
-                Eigen::Vector3d point_normalized = it_per_id.feature_per_frame[0].point;
-                Eigen::Vector3d point_3d = point_normalized * it_per_id.estimated_depth;
-                int frame_idx = it_per_id.start_frame;
-                if (frame_idx < WINDOW_SIZE) {
-                    Eigen::Matrix3d R_wc = sliding_window_[frame_idx].R * r_ic_;
-                    Eigen::Vector3d t_wc = sliding_window_[frame_idx].P + sliding_window_[frame_idx].R * t_ic_;
-                    Eigen::Vector3d point_world = R_wc * point_3d + t_wc;
-                    if (point_world.norm() < 50.0 && point_world.allFinite()) {
-                        new_points.push_back(point_world);
-                    }
-                }
-            }
+  std::lock_guard<std::mutex> lock(estimator_mutex_);
+  std::vector<Eigen::Vector3d> new_points;
+  if (solver_flag_ == SolverFlag::NON_LINEAR) {
+    for (const auto& it_per_id : feature_manager_.feature) {
+      if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2)) continue;
+      if (it_per_id.estimated_depth > 0 && it_per_id.solve_flag == 1) {
+        Eigen::Vector3d point_normalized = it_per_id.feature_per_frame[0].point;
+        Eigen::Vector3d point_3d = point_normalized * it_per_id.estimated_depth;
+        int frame_idx = it_per_id.start_frame;
+        if (frame_idx < WINDOW_SIZE) {
+          Eigen::Matrix3d R_wc = sliding_window_[frame_idx].R * r_ic_;
+          Eigen::Vector3d t_wc =
+              sliding_window_[frame_idx].P + sliding_window_[frame_idx].R * t_ic_;
+          Eigen::Vector3d point_world = R_wc * point_3d + t_wc;
+          if (point_world.norm() < 50.0 && point_world.allFinite()) {
+            new_points.push_back(point_world);
+          }
         }
+      }
     }
-    return new_points;
+  }
+  return new_points;
 }
 
-} // namespace backend
+}  // namespace backend

--- a/src/backend/factor/marginalization_factor.cpp
+++ b/src/backend/factor/marginalization_factor.cpp
@@ -1,304 +1,307 @@
 #include "backend/factor/marginalization_factor.h"
+
 #include <thread>
 
 namespace backend {
 namespace factor {
 
 void ResidualBlockInfo::Evaluate() {
-    residuals.resize(cost_function->num_residuals());
+  residuals.resize(cost_function->num_residuals());
 
-    std::vector<int> block_sizes = cost_function->parameter_block_sizes();
-    raw_jacobians = new double *[block_sizes.size()];
-    jacobians.resize(block_sizes.size());
+  std::vector<int> block_sizes = cost_function->parameter_block_sizes();
+  raw_jacobians = new double *[block_sizes.size()];
+  jacobians.resize(block_sizes.size());
 
-    for (int i = 0; i < static_cast<int>(block_sizes.size()); i++) {
-        jacobians[i].resize(cost_function->num_residuals(), block_sizes[i]);
-        raw_jacobians[i] = jacobians[i].data();
-        // dim += block_sizes[i] == 7 ? 6 : block_sizes[i];
+  for (int i = 0; i < static_cast<int>(block_sizes.size()); i++) {
+    jacobians[i].resize(cost_function->num_residuals(), block_sizes[i]);
+    raw_jacobians[i] = jacobians[i].data();
+    // dim += block_sizes[i] == 7 ? 6 : block_sizes[i];
+  }
+  cost_function->Evaluate(parameter_blocks.data(), residuals.data(), raw_jacobians);
+
+  if (loss_function) {
+    double residual_scaling_, alpha_sq_norm_;
+
+    double sq_norm, rho[3];
+
+    sq_norm = residuals.squaredNorm();
+    loss_function->Evaluate(sq_norm, rho);
+    // printf("sq_norm: %f, rho[0]: %f, rho[1]: %f, rho[2]: %f\n", sq_norm,
+    // rho[0], rho[1], rho[2]);
+
+    double sqrt_rho1_ = sqrt(rho[1]);
+
+    if ((sq_norm == 0.0) || (rho[2] <= 0.0)) {
+      residual_scaling_ = sqrt_rho1_;
+      alpha_sq_norm_ = 0.0;
+    } else {
+      const double D = 1.0 + 2.0 * sq_norm * rho[2] / rho[1];
+      const double alpha = 1.0 - sqrt(D);
+      residual_scaling_ = sqrt_rho1_ / (1 - alpha);
+      alpha_sq_norm_ = alpha / sq_norm;
     }
-    cost_function->Evaluate(parameter_blocks.data(), residuals.data(), raw_jacobians);
 
-    if (loss_function) {
-        double residual_scaling_, alpha_sq_norm_;
-
-        double sq_norm, rho[3];
-
-        sq_norm = residuals.squaredNorm();
-        loss_function->Evaluate(sq_norm, rho);
-        // printf("sq_norm: %f, rho[0]: %f, rho[1]: %f, rho[2]: %f\n", sq_norm,
-        // rho[0], rho[1], rho[2]);
-
-        double sqrt_rho1_ = sqrt(rho[1]);
-
-        if ((sq_norm == 0.0) || (rho[2] <= 0.0)) {
-            residual_scaling_ = sqrt_rho1_;
-            alpha_sq_norm_ = 0.0;
-        } else {
-            const double D = 1.0 + 2.0 * sq_norm * rho[2] / rho[1];
-            const double alpha = 1.0 - sqrt(D);
-            residual_scaling_ = sqrt_rho1_ / (1 - alpha);
-            alpha_sq_norm_ = alpha / sq_norm;
-        }
-
-        for (int i = 0; i < static_cast<int>(parameter_blocks.size()); i++) {
-            jacobians[i] =
-                sqrt_rho1_ * (jacobians[i] - alpha_sq_norm_ * residuals * (residuals.transpose() * jacobians[i]));
-        }
-
-        residuals *= residual_scaling_;
+    for (int i = 0; i < static_cast<int>(parameter_blocks.size()); i++) {
+      jacobians[i] = sqrt_rho1_ * (jacobians[i] - alpha_sq_norm_ * residuals *
+                                                      (residuals.transpose() * jacobians[i]));
     }
+
+    residuals *= residual_scaling_;
+  }
 }
 
 MarginalizationInfo::~MarginalizationInfo() {
+  for (auto it = parameter_block_data.begin(); it != parameter_block_data.end(); ++it)
+    delete[] it->second;
 
-    for (auto it = parameter_block_data.begin(); it != parameter_block_data.end(); ++it)
-        delete[] it->second;
+  for (int i = 0; i < (int)factors.size(); i++) {
+    delete[] factors[i]->raw_jacobians;
 
-    for (int i = 0; i < (int)factors.size(); i++) {
-        delete[] factors[i]->raw_jacobians;
+    delete factors[i]->cost_function;
 
-        delete factors[i]->cost_function;
-
-        delete factors[i];
-    }
+    delete factors[i];
+  }
 }
 
 void MarginalizationInfo::addResidualBlockInfo(ResidualBlockInfo *residual_block_info) {
-    factors.emplace_back(residual_block_info);
+  factors.emplace_back(residual_block_info);
 
-    std::vector<double *> &parameter_blocks = residual_block_info->parameter_blocks;
-    std::vector<int> parameter_block_sizes = residual_block_info->cost_function->parameter_block_sizes();
+  std::vector<double *> &parameter_blocks = residual_block_info->parameter_blocks;
+  std::vector<int> parameter_block_sizes =
+      residual_block_info->cost_function->parameter_block_sizes();
 
-    for (int i = 0; i < static_cast<int>(residual_block_info->parameter_blocks.size()); i++) {
-        double *addr = parameter_blocks[i];
-        int size = parameter_block_sizes[i];
-        parameter_block_size[reinterpret_cast<long>(addr)] = size;
-    }
+  for (int i = 0; i < static_cast<int>(residual_block_info->parameter_blocks.size()); i++) {
+    double *addr = parameter_blocks[i];
+    int size = parameter_block_sizes[i];
+    parameter_block_size[reinterpret_cast<long>(addr)] = size;
+  }
 
-    for (int i = 0; i < static_cast<int>(residual_block_info->drop_set.size()); i++) {
-        double *addr = parameter_blocks[residual_block_info->drop_set[i]];
-        parameter_block_idx[reinterpret_cast<long>(addr)] = 0;
-    }
+  for (int i = 0; i < static_cast<int>(residual_block_info->drop_set.size()); i++) {
+    double *addr = parameter_blocks[residual_block_info->drop_set[i]];
+    parameter_block_idx[reinterpret_cast<long>(addr)] = 0;
+  }
 }
 
 void MarginalizationInfo::preMarginalize() {
-    for (auto it : factors) {
-        it->Evaluate();
+  for (auto it : factors) {
+    it->Evaluate();
 
-        std::vector<int> block_sizes = it->cost_function->parameter_block_sizes();
-        for (int i = 0; i < static_cast<int>(block_sizes.size()); i++) {
-            long addr = reinterpret_cast<long>(it->parameter_blocks[i]);
-            int size = block_sizes[i];
-            if (parameter_block_data.find(addr) == parameter_block_data.end()) {
-                double *data = new double[size];
-                memcpy(data, it->parameter_blocks[i], sizeof(double) * size);
-                parameter_block_data[addr] = data;
-            }
-        }
+    std::vector<int> block_sizes = it->cost_function->parameter_block_sizes();
+    for (int i = 0; i < static_cast<int>(block_sizes.size()); i++) {
+      long addr = reinterpret_cast<long>(it->parameter_blocks[i]);
+      int size = block_sizes[i];
+      if (parameter_block_data.find(addr) == parameter_block_data.end()) {
+        double *data = new double[size];
+        memcpy(data, it->parameter_blocks[i], sizeof(double) * size);
+        parameter_block_data[addr] = data;
+      }
     }
+  }
 }
 
-int MarginalizationInfo::localSize(int size) const {
-    return size == 7 ? 6 : size;
-}
+int MarginalizationInfo::localSize(int size) const { return size == 7 ? 6 : size; }
 
-int MarginalizationInfo::globalSize(int size) const {
-    return size == 6 ? 7 : size;
-}
+int MarginalizationInfo::globalSize(int size) const { return size == 6 ? 7 : size; }
 
 void *ThreadsConstructA(void *threadsstruct) {
-    ThreadsStruct *p = ((ThreadsStruct *)threadsstruct);
-    for (auto it : p->sub_factors) {
-        for (int i = 0; i < static_cast<int>(it->parameter_blocks.size()); i++) {
-            int idx_i = p->parameter_block_idx[reinterpret_cast<long>(it->parameter_blocks[i])];
-            int size_i = p->parameter_block_size[reinterpret_cast<long>(it->parameter_blocks[i])];
-            if (size_i == 7)
-                size_i = 6;
-            Eigen::MatrixXd jacobian_i = it->jacobians[i].leftCols(size_i);
-            for (int j = i; j < static_cast<int>(it->parameter_blocks.size()); j++) {
-                int idx_j = p->parameter_block_idx[reinterpret_cast<long>(it->parameter_blocks[j])];
-                int size_j = p->parameter_block_size[reinterpret_cast<long>(it->parameter_blocks[j])];
-                if (size_j == 7)
-                    size_j = 6;
-                Eigen::MatrixXd jacobian_j = it->jacobians[j].leftCols(size_j);
-                if (i == j)
-                    p->A.block(idx_i, idx_j, size_i, size_j) += jacobian_i.transpose() * jacobian_j;
-                else {
-                    p->A.block(idx_i, idx_j, size_i, size_j) += jacobian_i.transpose() * jacobian_j;
-                    p->A.block(idx_j, idx_i, size_j, size_i) = p->A.block(idx_i, idx_j, size_i, size_j).transpose();
-                }
-            }
-            p->b.segment(idx_i, size_i) += jacobian_i.transpose() * it->residuals;
+  ThreadsStruct *p = ((ThreadsStruct *)threadsstruct);
+  for (auto it : p->sub_factors) {
+    for (int i = 0; i < static_cast<int>(it->parameter_blocks.size()); i++) {
+      int idx_i = p->parameter_block_idx[reinterpret_cast<long>(it->parameter_blocks[i])];
+      int size_i = p->parameter_block_size[reinterpret_cast<long>(it->parameter_blocks[i])];
+      if (size_i == 7) size_i = 6;
+      Eigen::MatrixXd jacobian_i = it->jacobians[i].leftCols(size_i);
+      for (int j = i; j < static_cast<int>(it->parameter_blocks.size()); j++) {
+        int idx_j = p->parameter_block_idx[reinterpret_cast<long>(it->parameter_blocks[j])];
+        int size_j = p->parameter_block_size[reinterpret_cast<long>(it->parameter_blocks[j])];
+        if (size_j == 7) size_j = 6;
+        Eigen::MatrixXd jacobian_j = it->jacobians[j].leftCols(size_j);
+        if (i == j)
+          p->A.block(idx_i, idx_j, size_i, size_j) += jacobian_i.transpose() * jacobian_j;
+        else {
+          p->A.block(idx_i, idx_j, size_i, size_j) += jacobian_i.transpose() * jacobian_j;
+          p->A.block(idx_j, idx_i, size_j, size_i) =
+              p->A.block(idx_i, idx_j, size_i, size_j).transpose();
         }
+      }
+      p->b.segment(idx_i, size_i) += jacobian_i.transpose() * it->residuals;
     }
-    return threadsstruct;
+  }
+  return threadsstruct;
 }
 
 void MarginalizationInfo::marginalize() {
-    int pos = 0;
-    for (auto &it : parameter_block_idx) {
-        it.second = pos;
-        pos += localSize(parameter_block_size[it.first]);
+  int pos = 0;
+  for (auto &it : parameter_block_idx) {
+    it.second = pos;
+    pos += localSize(parameter_block_size[it.first]);
+  }
+
+  m = pos;
+
+  for (const auto &it : parameter_block_size) {
+    if (parameter_block_idx.find(it.first) == parameter_block_idx.end()) {
+      parameter_block_idx[it.first] = pos;
+      pos += localSize(it.second);
     }
+  }
 
-    m = pos;
+  n = pos - m;
 
-    for (const auto &it : parameter_block_size) {
-        if (parameter_block_idx.find(it.first) == parameter_block_idx.end()) {
-            parameter_block_idx[it.first] = pos;
-            pos += localSize(it.second);
-        }
+  // ROS_DEBUG("marginalization, pos: %d, m: %d, n: %d, size: %d", pos, m, n,
+  // (int)parameter_block_idx.size());
+
+  Eigen::MatrixXd A(pos, pos);
+  Eigen::VectorXd b(pos);
+  A.setZero();
+  b.setZero();
+
+  pthread_t tids[NUM_THREADS];
+  ThreadsStruct threadsstruct[NUM_THREADS];
+  int i = 0;
+  for (auto it : factors) {
+    threadsstruct[i].sub_factors.push_back(it);
+    i++;
+    i = i % NUM_THREADS;
+  }
+  for (int i = 0; i < NUM_THREADS; i++) {
+    threadsstruct[i].A = Eigen::MatrixXd::Zero(pos, pos);
+    threadsstruct[i].b = Eigen::VectorXd::Zero(pos);
+    threadsstruct[i].parameter_block_size = parameter_block_size;
+    threadsstruct[i].parameter_block_idx = parameter_block_idx;
+    int ret = pthread_create(&tids[i], NULL, ThreadsConstructA, (void *)&(threadsstruct[i]));
+    if (ret != 0) {
+      std::cout << "pthread_create error" << std::endl;
+      // ROS_BREAK();
     }
+  }
+  for (int i = NUM_THREADS - 1; i >= 0; i--) {
+    pthread_join(tids[i], NULL);
+    A += threadsstruct[i].A;
+    b += threadsstruct[i].b;
+  }
 
-    n = pos - m;
+  // TODO
+  Eigen::MatrixXd Amm = 0.5 * (A.block(0, 0, m, m) + A.block(0, 0, m, m).transpose());
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> saes(Amm);
 
-    // ROS_DEBUG("marginalization, pos: %d, m: %d, n: %d, size: %d", pos, m, n,
-    // (int)parameter_block_idx.size());
+  // ROS_ASSERT_MSG(saes.eigenvalues().minCoeff() >= -1e-4, "min eigenvalue %f",
+  // saes.eigenvalues().minCoeff());
 
-    Eigen::MatrixXd A(pos, pos);
-    Eigen::VectorXd b(pos);
-    A.setZero();
-    b.setZero();
+  Eigen::MatrixXd Amm_inv =
+      saes.eigenvectors() *
+      Eigen::VectorXd(
+          (saes.eigenvalues().array() > eps).select(saes.eigenvalues().array().inverse(), 0))
+          .asDiagonal() *
+      saes.eigenvectors().transpose();
+  // printf("error1: %f\n", (Amm * Amm_inv - Eigen::MatrixXd::Identity(m,
+  // m)).sum());
 
-    pthread_t tids[NUM_THREADS];
-    ThreadsStruct threadsstruct[NUM_THREADS];
-    int i = 0;
-    for (auto it : factors) {
-        threadsstruct[i].sub_factors.push_back(it);
-        i++;
-        i = i % NUM_THREADS;
-    }
-    for (int i = 0; i < NUM_THREADS; i++) {
-        threadsstruct[i].A = Eigen::MatrixXd::Zero(pos, pos);
-        threadsstruct[i].b = Eigen::VectorXd::Zero(pos);
-        threadsstruct[i].parameter_block_size = parameter_block_size;
-        threadsstruct[i].parameter_block_idx = parameter_block_idx;
-        int ret = pthread_create(&tids[i], NULL, ThreadsConstructA, (void *)&(threadsstruct[i]));
-        if (ret != 0) {
-            std::cout << "pthread_create error" << std::endl;
-            // ROS_BREAK();
-        }
-    }
-    for (int i = NUM_THREADS - 1; i >= 0; i--) {
-        pthread_join(tids[i], NULL);
-        A += threadsstruct[i].A;
-        b += threadsstruct[i].b;
-    }
+  Eigen::VectorXd bmm = b.segment(0, m);
+  Eigen::MatrixXd Amr = A.block(0, m, m, n);
+  Eigen::MatrixXd Arm = A.block(m, 0, n, m);
+  Eigen::MatrixXd Arr = A.block(m, m, n, n);
+  Eigen::VectorXd brr = b.segment(m, n);
+  A = Arr - Arm * Amm_inv * Amr;
+  b = brr - Arm * Amm_inv * bmm;
 
-    // TODO
-    Eigen::MatrixXd Amm = 0.5 * (A.block(0, 0, m, m) + A.block(0, 0, m, m).transpose());
-    Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> saes(Amm);
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> saes2(A);
+  Eigen::VectorXd S =
+      Eigen::VectorXd((saes2.eigenvalues().array() > eps).select(saes2.eigenvalues().array(), 0));
+  Eigen::VectorXd S_inv = Eigen::VectorXd(
+      (saes2.eigenvalues().array() > eps).select(saes2.eigenvalues().array().inverse(), 0));
 
-    // ROS_ASSERT_MSG(saes.eigenvalues().minCoeff() >= -1e-4, "min eigenvalue %f",
-    // saes.eigenvalues().minCoeff());
+  Eigen::VectorXd S_sqrt = S.cwiseSqrt();
+  Eigen::VectorXd S_inv_sqrt = S_inv.cwiseSqrt();
 
-    Eigen::MatrixXd Amm_inv =
-        saes.eigenvectors() *
-        Eigen::VectorXd((saes.eigenvalues().array() > eps).select(saes.eigenvalues().array().inverse(), 0))
-            .asDiagonal() *
-        saes.eigenvectors().transpose();
-    // printf("error1: %f\n", (Amm * Amm_inv - Eigen::MatrixXd::Identity(m,
-    // m)).sum());
-
-    Eigen::VectorXd bmm = b.segment(0, m);
-    Eigen::MatrixXd Amr = A.block(0, m, m, n);
-    Eigen::MatrixXd Arm = A.block(m, 0, n, m);
-    Eigen::MatrixXd Arr = A.block(m, m, n, n);
-    Eigen::VectorXd brr = b.segment(m, n);
-    A = Arr - Arm * Amm_inv * Amr;
-    b = brr - Arm * Amm_inv * bmm;
-
-    Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> saes2(A);
-    Eigen::VectorXd S = Eigen::VectorXd((saes2.eigenvalues().array() > eps).select(saes2.eigenvalues().array(), 0));
-    Eigen::VectorXd S_inv =
-        Eigen::VectorXd((saes2.eigenvalues().array() > eps).select(saes2.eigenvalues().array().inverse(), 0));
-
-    Eigen::VectorXd S_sqrt = S.cwiseSqrt();
-    Eigen::VectorXd S_inv_sqrt = S_inv.cwiseSqrt();
-
-    linearized_jacobians = S_sqrt.asDiagonal() * saes2.eigenvectors().transpose();
-    linearized_residuals = S_inv_sqrt.asDiagonal() * saes2.eigenvectors().transpose() * b;
-    // std::cout << A << std::endl
-    //          << std::endl;
-    // std::cout << linearized_jacobians << std::endl;
-    // printf("error2: %f %f\n", (linearized_jacobians.transpose() *
-    // linearized_jacobians - A).sum(),
-    //      (linearized_jacobians.transpose() * linearized_residuals - b).sum());
+  linearized_jacobians = S_sqrt.asDiagonal() * saes2.eigenvectors().transpose();
+  linearized_residuals = S_inv_sqrt.asDiagonal() * saes2.eigenvectors().transpose() * b;
+  // std::cout << A << std::endl
+  //          << std::endl;
+  // std::cout << linearized_jacobians << std::endl;
+  // printf("error2: %f %f\n", (linearized_jacobians.transpose() *
+  // linearized_jacobians - A).sum(),
+  //      (linearized_jacobians.transpose() * linearized_residuals - b).sum());
 }
 
-std::vector<double *> MarginalizationInfo::getParameterBlocks(std::unordered_map<long, double *> &addr_shift) {
-    std::vector<double *> keep_block_addr;
-    keep_block_size.clear();
-    keep_block_idx.clear();
-    keep_block_data.clear();
+std::vector<double *> MarginalizationInfo::getParameterBlocks(
+    std::unordered_map<long, double *> &addr_shift) {
+  std::vector<double *> keep_block_addr;
+  keep_block_size.clear();
+  keep_block_idx.clear();
+  keep_block_data.clear();
 
-    for (const auto &it : parameter_block_idx) {
-        if (it.second >= m) {
-            keep_block_size.push_back(parameter_block_size[it.first]);
-            keep_block_idx.push_back(parameter_block_idx[it.first]);
-            keep_block_data.push_back(parameter_block_data[it.first]);
-            keep_block_addr.push_back(addr_shift[it.first]);
-        }
+  for (const auto &it : parameter_block_idx) {
+    if (it.second >= m) {
+      keep_block_size.push_back(parameter_block_size[it.first]);
+      keep_block_idx.push_back(parameter_block_idx[it.first]);
+      keep_block_data.push_back(parameter_block_data[it.first]);
+      keep_block_addr.push_back(addr_shift[it.first]);
     }
-    sum_block_size = std::accumulate(std::begin(keep_block_size), std::end(keep_block_size), 0);
+  }
+  sum_block_size = std::accumulate(std::begin(keep_block_size), std::end(keep_block_size), 0);
 
-    return keep_block_addr;
+  return keep_block_addr;
 }
 
 MarginalizationFactor::MarginalizationFactor(MarginalizationInfo *_marginalization_info)
     : marginalization_info(_marginalization_info) {
-    int cnt = 0;
-    for (auto it : marginalization_info->keep_block_size) {
-        mutable_parameter_block_sizes()->push_back(it);
-        cnt += it;
-    }
-    // printf("residual size: %d, %d\n", cnt, n);
-    set_num_residuals(marginalization_info->n);
+  int cnt = 0;
+  for (auto it : marginalization_info->keep_block_size) {
+    mutable_parameter_block_sizes()->push_back(it);
+    cnt += it;
+  }
+  // printf("residual size: %d, %d\n", cnt, n);
+  set_num_residuals(marginalization_info->n);
 };
 
-bool MarginalizationFactor::Evaluate(double const *const *parameters, double *residuals, double **jacobians) const {
-
-    int n = marginalization_info->n;
-    int m = marginalization_info->m;
-    Eigen::VectorXd dx(n);
+bool MarginalizationFactor::Evaluate(double const *const *parameters, double *residuals,
+                                     double **jacobians) const {
+  int n = marginalization_info->n;
+  int m = marginalization_info->m;
+  Eigen::VectorXd dx(n);
+  for (int i = 0; i < static_cast<int>(marginalization_info->keep_block_size.size()); i++) {
+    int size = marginalization_info->keep_block_size[i];
+    int idx = marginalization_info->keep_block_idx[i] - m;
+    Eigen::VectorXd x = Eigen::Map<const Eigen::VectorXd>(parameters[i], size);
+    Eigen::VectorXd x0 =
+        Eigen::Map<const Eigen::VectorXd>(marginalization_info->keep_block_data[i], size);
+    if (size != 7)
+      dx.segment(idx, size) = x - x0;
+    else {
+      dx.segment<3>(idx + 0) = x.head<3>() - x0.head<3>();
+      dx.segment<3>(idx + 3) =
+          2.0 * Utility::positify(Eigen::Quaterniond(x0(6), x0(3), x0(4), x0(5)).inverse() *
+                                  Eigen::Quaterniond(x(6), x(3), x(4), x(5)))
+                    .vec();
+      if (!((Eigen::Quaterniond(x0(6), x0(3), x0(4), x0(5)).inverse() *
+             Eigen::Quaterniond(x(6), x(3), x(4), x(5)))
+                .w() >= 0)) {
+        dx.segment<3>(idx + 3) =
+            2.0 * -Utility::positify(Eigen::Quaterniond(x0(6), x0(3), x0(4), x0(5)).inverse() *
+                                     Eigen::Quaterniond(x(6), x(3), x(4), x(5)))
+                       .vec();
+      }
+    }
+  }
+  Eigen::Map<Eigen::VectorXd>(residuals, n) =
+      marginalization_info->linearized_residuals + marginalization_info->linearized_jacobians * dx;
+  if (jacobians) {
     for (int i = 0; i < static_cast<int>(marginalization_info->keep_block_size.size()); i++) {
-        int size = marginalization_info->keep_block_size[i];
+      if (jacobians[i]) {
+        int size = marginalization_info->keep_block_size[i],
+            local_size = marginalization_info->localSize(size);
         int idx = marginalization_info->keep_block_idx[i] - m;
-        Eigen::VectorXd x = Eigen::Map<const Eigen::VectorXd>(parameters[i], size);
-        Eigen::VectorXd x0 = Eigen::Map<const Eigen::VectorXd>(marginalization_info->keep_block_data[i], size);
-        if (size != 7)
-            dx.segment(idx, size) = x - x0;
-        else {
-            dx.segment<3>(idx + 0) = x.head<3>() - x0.head<3>();
-            dx.segment<3>(idx + 3) = 2.0 * Utility::positify(Eigen::Quaterniond(x0(6), x0(3), x0(4), x0(5)).inverse() *
-                                                             Eigen::Quaterniond(x(6), x(3), x(4), x(5)))
-                                               .vec();
-            if (!((Eigen::Quaterniond(x0(6), x0(3), x0(4), x0(5)).inverse() *
-                   Eigen::Quaterniond(x(6), x(3), x(4), x(5)))
-                      .w() >= 0)) {
-                dx.segment<3>(idx + 3) =
-                    2.0 * -Utility::positify(Eigen::Quaterniond(x0(6), x0(3), x0(4), x0(5)).inverse() *
-                                             Eigen::Quaterniond(x(6), x(3), x(4), x(5)))
-                               .vec();
-            }
-        }
+        Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> jacobian(
+            jacobians[i], n, size);
+        jacobian.setZero();
+        jacobian.leftCols(local_size) =
+            marginalization_info->linearized_jacobians.middleCols(idx, local_size);
+      }
     }
-    Eigen::Map<Eigen::VectorXd>(residuals, n) =
-        marginalization_info->linearized_residuals + marginalization_info->linearized_jacobians * dx;
-    if (jacobians) {
-        for (int i = 0; i < static_cast<int>(marginalization_info->keep_block_size.size()); i++) {
-            if (jacobians[i]) {
-                int size = marginalization_info->keep_block_size[i], local_size = marginalization_info->localSize(size);
-                int idx = marginalization_info->keep_block_idx[i] - m;
-                Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> jacobian(
-                    jacobians[i], n, size);
-                jacobian.setZero();
-                jacobian.leftCols(local_size) = marginalization_info->linearized_jacobians.middleCols(idx, local_size);
-            }
-        }
-    }
-    return true;
+  }
+  return true;
 }
 
-} // namespace factor
-} // namespace backend
+}  // namespace factor
+}  // namespace backend

--- a/src/backend/factor/pose_local_parameterization.cpp
+++ b/src/backend/factor/pose_local_parameterization.cpp
@@ -3,29 +3,30 @@
 namespace backend {
 namespace factor {
 
-bool PoseLocalParameterization::Plus(const double *x, const double *delta, double *x_plus_delta) const {
-    Eigen::Map<const Eigen::Vector3d> _p(x);
-    Eigen::Map<const Eigen::Quaterniond> _q(x + 3);
+bool PoseLocalParameterization::Plus(const double *x, const double *delta,
+                                     double *x_plus_delta) const {
+  Eigen::Map<const Eigen::Vector3d> _p(x);
+  Eigen::Map<const Eigen::Quaterniond> _q(x + 3);
 
-    Eigen::Map<const Eigen::Vector3d> dp(delta);
+  Eigen::Map<const Eigen::Vector3d> dp(delta);
 
-    Eigen::Quaterniond dq = Utility::deltaQ(Eigen::Map<const Eigen::Vector3d>(delta + 3));
+  Eigen::Quaterniond dq = Utility::deltaQ(Eigen::Map<const Eigen::Vector3d>(delta + 3));
 
-    Eigen::Map<Eigen::Vector3d> p(x_plus_delta);
-    Eigen::Map<Eigen::Quaterniond> q(x_plus_delta + 3);
+  Eigen::Map<Eigen::Vector3d> p(x_plus_delta);
+  Eigen::Map<Eigen::Quaterniond> q(x_plus_delta + 3);
 
-    p = _p + dp;
-    q = (_q * dq).normalized();
+  p = _p + dp;
+  q = (_q * dq).normalized();
 
-    return true;
+  return true;
 }
 bool PoseLocalParameterization::ComputeJacobian(const double *x, double *jacobian) const {
-    Eigen::Map<Eigen::Matrix<double, 7, 6, Eigen::RowMajor>> j(jacobian);
-    j.topRows<6>().setIdentity();
-    j.bottomRows<1>().setZero();
+  Eigen::Map<Eigen::Matrix<double, 7, 6, Eigen::RowMajor>> j(jacobian);
+  j.topRows<6>().setIdentity();
+  j.bottomRows<1>().setZero();
 
-    return true;
+  return true;
 }
 
-} // namespace factor
-} // namespace backend
+}  // namespace factor
+}  // namespace backend

--- a/src/backend/factor/projection_factor.cpp
+++ b/src/backend/factor/projection_factor.cpp
@@ -1,6 +1,6 @@
 #include "backend/factor/projection_factor.h"
-#include "utility/utility.h"
 
+#include "utility/utility.h"
 
 namespace backend {
 namespace factor {
@@ -8,102 +8,137 @@ namespace factor {
 Eigen::Matrix2d ProjectionFactor::sqrt_info;
 
 ProjectionFactor::ProjectionFactor(const Eigen::Vector3d &_pts_i, const Eigen::Vector3d &_pts_j)
-    : pts_i(_pts_i), pts_j(_pts_j) {
-};
+    : pts_i(_pts_i), pts_j(_pts_j) {};
 
-bool ProjectionFactor::Evaluate(double const *const *parameters, double *residuals, double **jacobians) const {
-    Eigen::Vector3d Pi(parameters[0][0], parameters[0][1], parameters[0][2]);
-    Eigen::Quaterniond Qi(parameters[0][6], parameters[0][3], parameters[0][4], parameters[0][5]);
+bool ProjectionFactor::Evaluate(double const *const *parameters, double *residuals,
+                                double **jacobians) const {
+  Eigen::Vector3d Pi(parameters[0][0], parameters[0][1], parameters[0][2]);
+  Eigen::Quaterniond Qi(parameters[0][6], parameters[0][3], parameters[0][4], parameters[0][5]);
 
-    Eigen::Vector3d Pj(parameters[1][0], parameters[1][1], parameters[1][2]);
-    Eigen::Quaterniond Qj(parameters[1][6], parameters[1][3], parameters[1][4], parameters[1][5]);
+  Eigen::Vector3d Pj(parameters[1][0], parameters[1][1], parameters[1][2]);
+  Eigen::Quaterniond Qj(parameters[1][6], parameters[1][3], parameters[1][4], parameters[1][5]);
 
-    Eigen::Vector3d t_ic(parameters[2][0], parameters[2][1], parameters[2][2]);
-    Eigen::Quaterniond q_ic(parameters[2][6], parameters[2][3], parameters[2][4], parameters[2][5]);
+  Eigen::Vector3d t_ic(parameters[2][0], parameters[2][1], parameters[2][2]);
+  Eigen::Quaterniond q_ic(parameters[2][6], parameters[2][3], parameters[2][4], parameters[2][5]);
 
-    double inv_dep_i = parameters[3][0];
+  double inv_dep_i = parameters[3][0];
 
-    Eigen::Vector3d pts_camera_i = pts_i / inv_dep_i;
-    Eigen::Vector3d pts_imu_i = q_ic * pts_camera_i + t_ic;
-    Eigen::Vector3d pts_w = Qi * pts_imu_i + Pi;
-    Eigen::Vector3d pts_imu_j = Qj.inverse() * (pts_w - Pj);
-    Eigen::Vector3d pts_camera_j = q_ic.inverse() * (pts_imu_j - t_ic);
-    Eigen::Map<Eigen::Vector2d> residual(residuals);
+  Eigen::Vector3d pts_camera_i = pts_i / inv_dep_i;
+  Eigen::Vector3d pts_imu_i = q_ic * pts_camera_i + t_ic;
+  Eigen::Vector3d pts_w = Qi * pts_imu_i + Pi;
+  Eigen::Vector3d pts_imu_j = Qj.inverse() * (pts_w - Pj);
+  Eigen::Vector3d pts_camera_j = q_ic.inverse() * (pts_imu_j - t_ic);
+  Eigen::Map<Eigen::Vector2d> residual(residuals);
 
-    double dep_j = pts_camera_j.z();
-    residual = (pts_camera_j / dep_j).head<2>() - pts_j.head<2>();
+  double dep_j = pts_camera_j.z();
+  residual = (pts_camera_j / dep_j).head<2>() - pts_j.head<2>();
 
-    residual = sqrt_info * residual;
+  residual = sqrt_info * residual;
 
-    if (jacobians) {
-        Eigen::Matrix3d Ri = Qi.toRotationMatrix();
-        Eigen::Matrix3d Rj = Qj.toRotationMatrix();
-        Eigen::Matrix3d r_ic = q_ic.toRotationMatrix();
-        Eigen::Matrix<double, 2, 3> reduce(2, 3);
+  if (jacobians) {
+    Eigen::Matrix3d Ri = Qi.toRotationMatrix();
+    Eigen::Matrix3d Rj = Qj.toRotationMatrix();
+    Eigen::Matrix3d r_ic = q_ic.toRotationMatrix();
+    Eigen::Matrix<double, 2, 3> reduce(2, 3);
 
-        reduce << 1. / dep_j, 0, -pts_camera_j(0) / (dep_j * dep_j), 0, 1. / dep_j, -pts_camera_j(1) / (dep_j * dep_j);
-        reduce = sqrt_info * reduce;
+    reduce << 1. / dep_j, 0, -pts_camera_j(0) / (dep_j * dep_j), 0, 1. / dep_j,
+        -pts_camera_j(1) / (dep_j * dep_j);
+    reduce = sqrt_info * reduce;
 
-        if (jacobians[0]) {
-            Eigen::Map<Eigen::Matrix<double, 2, 7, Eigen::RowMajor>> jacobian_pose_i(jacobians[0]);
+    if (jacobians[0]) {
+      Eigen::Map<Eigen::Matrix<double, 2, 7, Eigen::RowMajor>> jacobian_pose_i(jacobians[0]);
 
-            Eigen::Matrix<double, 3, 6> jaco_i;
-            jaco_i.leftCols<3>() = r_ic.transpose() * Rj.transpose();
-            jaco_i.rightCols<3>() = r_ic.transpose() * Rj.transpose() * Ri * -Utility::skewSymmetric(pts_imu_i);
+      Eigen::Matrix<double, 3, 6> jaco_i;
+      jaco_i.leftCols<3>() = r_ic.transpose() * Rj.transpose();
+      jaco_i.rightCols<3>() =
+          r_ic.transpose() * Rj.transpose() * Ri * -Utility::skewSymmetric(pts_imu_i);
 
-            jacobian_pose_i.leftCols<6>() = reduce * jaco_i;
-            jacobian_pose_i.rightCols<1>().setZero();
-        }
-
-        if (jacobians[1]) {
-            Eigen::Map<Eigen::Matrix<double, 2, 7, Eigen::RowMajor>> jacobian_pose_j(jacobians[1]);
-
-            Eigen::Matrix<double, 3, 6> jaco_j;
-            jaco_j.leftCols<3>() = r_ic.transpose() * -Rj.transpose();
-            jaco_j.rightCols<3>() = r_ic.transpose() * Utility::skewSymmetric(pts_imu_j);
-
-            jacobian_pose_j.leftCols<6>() = reduce * jaco_j;
-            jacobian_pose_j.rightCols<1>().setZero();
-        }
-        if (jacobians[2]) {
-            Eigen::Map<Eigen::Matrix<double, 2, 7, Eigen::RowMajor>> jacobian_ex_pose(jacobians[2]);
-            Eigen::Matrix<double, 3, 6> jaco_ex;
-            jaco_ex.leftCols<3>() = r_ic.transpose() * (Rj.transpose() * Ri - Eigen::Matrix3d::Identity());
-            Eigen::Matrix3d tmp_r = r_ic.transpose() * Rj.transpose() * Ri * r_ic;
-            jaco_ex.rightCols<3>() =
-                -tmp_r * Utility::skewSymmetric(pts_camera_i) + Utility::skewSymmetric(tmp_r * pts_camera_i) +
-                Utility::skewSymmetric(r_ic.transpose() * (Rj.transpose() * (Ri * t_ic + Pi - Pj) - t_ic));
-            jacobian_ex_pose.leftCols<6>() = reduce * jaco_ex;
-            jacobian_ex_pose.rightCols<1>().setZero();
-        }
-        if (jacobians[3]) {
-            Eigen::Map<Eigen::Vector2d> jacobian_feature(jacobians[3]);
-            jacobian_feature =
-                reduce * r_ic.transpose() * Rj.transpose() * Ri * r_ic * pts_i * -1.0 / (inv_dep_i * inv_dep_i);
-        }
+      jacobian_pose_i.leftCols<6>() = reduce * jaco_i;
+      jacobian_pose_i.rightCols<1>().setZero();
     }
 
-    return true;
+    if (jacobians[1]) {
+      Eigen::Map<Eigen::Matrix<double, 2, 7, Eigen::RowMajor>> jacobian_pose_j(jacobians[1]);
+
+      Eigen::Matrix<double, 3, 6> jaco_j;
+      jaco_j.leftCols<3>() = r_ic.transpose() * -Rj.transpose();
+      jaco_j.rightCols<3>() = r_ic.transpose() * Utility::skewSymmetric(pts_imu_j);
+
+      jacobian_pose_j.leftCols<6>() = reduce * jaco_j;
+      jacobian_pose_j.rightCols<1>().setZero();
+    }
+    if (jacobians[2]) {
+      Eigen::Map<Eigen::Matrix<double, 2, 7, Eigen::RowMajor>> jacobian_ex_pose(jacobians[2]);
+      Eigen::Matrix<double, 3, 6> jaco_ex;
+      jaco_ex.leftCols<3>() =
+          r_ic.transpose() * (Rj.transpose() * Ri - Eigen::Matrix3d::Identity());
+      Eigen::Matrix3d tmp_r = r_ic.transpose() * Rj.transpose() * Ri * r_ic;
+      jaco_ex.rightCols<3>() =
+          -tmp_r * Utility::skewSymmetric(pts_camera_i) +
+          Utility::skewSymmetric(tmp_r * pts_camera_i) +
+          Utility::skewSymmetric(r_ic.transpose() *
+                                 (Rj.transpose() * (Ri * t_ic + Pi - Pj) - t_ic));
+      jacobian_ex_pose.leftCols<6>() = reduce * jaco_ex;
+      jacobian_ex_pose.rightCols<1>().setZero();
+    }
+    if (jacobians[3]) {
+      Eigen::Map<Eigen::Vector2d> jacobian_feature(jacobians[3]);
+      jacobian_feature = reduce * r_ic.transpose() * Rj.transpose() * Ri * r_ic * pts_i * -1.0 /
+                         (inv_dep_i * inv_dep_i);
+    }
+  }
+
+  return true;
 }
 
 void ProjectionFactor::check(double **parameters) {
-    double *res = new double[15];
-    double **jaco = new double *[4];
-    jaco[0] = new double[2 * 7];
-    jaco[1] = new double[2 * 7];
-    jaco[2] = new double[2 * 7];
-    jaco[3] = new double[2 * 1];
-    Evaluate(parameters, res, jaco);
-    puts("check begins");
+  double *res = new double[15];
+  double **jaco = new double *[4];
+  jaco[0] = new double[2 * 7];
+  jaco[1] = new double[2 * 7];
+  jaco[2] = new double[2 * 7];
+  jaco[3] = new double[2 * 1];
+  Evaluate(parameters, res, jaco);
+  puts("check begins");
 
-    puts("my");
+  puts("my");
 
-    std::cout << Eigen::Map<Eigen::Matrix<double, 2, 1>>(res).transpose() << std::endl << std::endl;
-    std::cout << Eigen::Map<Eigen::Matrix<double, 2, 7, Eigen::RowMajor>>(jaco[0]) << std::endl << std::endl;
-    std::cout << Eigen::Map<Eigen::Matrix<double, 2, 7, Eigen::RowMajor>>(jaco[1]) << std::endl << std::endl;
-    std::cout << Eigen::Map<Eigen::Matrix<double, 2, 7, Eigen::RowMajor>>(jaco[2]) << std::endl << std::endl;
-    std::cout << Eigen::Map<Eigen::Vector2d>(jaco[3]) << std::endl << std::endl;
+  std::cout << Eigen::Map<Eigen::Matrix<double, 2, 1>>(res).transpose() << std::endl << std::endl;
+  std::cout << Eigen::Map<Eigen::Matrix<double, 2, 7, Eigen::RowMajor>>(jaco[0]) << std::endl
+            << std::endl;
+  std::cout << Eigen::Map<Eigen::Matrix<double, 2, 7, Eigen::RowMajor>>(jaco[1]) << std::endl
+            << std::endl;
+  std::cout << Eigen::Map<Eigen::Matrix<double, 2, 7, Eigen::RowMajor>>(jaco[2]) << std::endl
+            << std::endl;
+  std::cout << Eigen::Map<Eigen::Vector2d>(jaco[3]) << std::endl << std::endl;
 
+  Eigen::Vector3d Pi(parameters[0][0], parameters[0][1], parameters[0][2]);
+  Eigen::Quaterniond Qi(parameters[0][6], parameters[0][3], parameters[0][4], parameters[0][5]);
+
+  Eigen::Vector3d Pj(parameters[1][0], parameters[1][1], parameters[1][2]);
+  Eigen::Quaterniond Qj(parameters[1][6], parameters[1][3], parameters[1][4], parameters[1][5]);
+
+  Eigen::Vector3d t_ic(parameters[2][0], parameters[2][1], parameters[2][2]);
+  Eigen::Quaterniond q_ic(parameters[2][6], parameters[2][3], parameters[2][4], parameters[2][5]);
+  double inv_dep_i = parameters[3][0];
+
+  Eigen::Vector3d pts_camera_i = pts_i / inv_dep_i;
+  Eigen::Vector3d pts_imu_i = q_ic * pts_camera_i + t_ic;
+  Eigen::Vector3d pts_w = Qi * pts_imu_i + Pi;
+  Eigen::Vector3d pts_imu_j = Qj.inverse() * (pts_w - Pj);
+  Eigen::Vector3d pts_camera_j = q_ic.inverse() * (pts_imu_j - t_ic);
+
+  Eigen::Vector2d residual;
+  double dep_j = pts_camera_j.z();
+  residual = (pts_camera_j / dep_j).head<2>() - pts_j.head<2>();
+  residual = sqrt_info * residual;
+
+  puts("num");
+  std::cout << residual.transpose() << std::endl;
+
+  const double eps = 1e-6;
+  Eigen::Matrix<double, 2, 19> num_jacobian;
+  for (int k = 0; k < 19; k++) {
     Eigen::Vector3d Pi(parameters[0][0], parameters[0][1], parameters[0][2]);
     Eigen::Quaterniond Qi(parameters[0][6], parameters[0][3], parameters[0][4], parameters[0][5]);
 
@@ -114,65 +149,38 @@ void ProjectionFactor::check(double **parameters) {
     Eigen::Quaterniond q_ic(parameters[2][6], parameters[2][3], parameters[2][4], parameters[2][5]);
     double inv_dep_i = parameters[3][0];
 
+    int a = k / 3, b = k % 3;
+    Eigen::Vector3d delta = Eigen::Vector3d(b == 0, b == 1, b == 2) * eps;
+
+    if (a == 0)
+      Pi += delta;
+    else if (a == 1)
+      Qi = Qi * Utility::deltaQ(delta);
+    else if (a == 2)
+      Pj += delta;
+    else if (a == 3)
+      Qj = Qj * Utility::deltaQ(delta);
+    else if (a == 4)
+      t_ic += delta;
+    else if (a == 5)
+      q_ic = q_ic * Utility::deltaQ(delta);
+    else if (a == 6)
+      inv_dep_i += delta.x();
+
     Eigen::Vector3d pts_camera_i = pts_i / inv_dep_i;
     Eigen::Vector3d pts_imu_i = q_ic * pts_camera_i + t_ic;
     Eigen::Vector3d pts_w = Qi * pts_imu_i + Pi;
     Eigen::Vector3d pts_imu_j = Qj.inverse() * (pts_w - Pj);
     Eigen::Vector3d pts_camera_j = q_ic.inverse() * (pts_imu_j - t_ic);
 
-    Eigen::Vector2d residual;
+    Eigen::Vector2d tmp_residual;
     double dep_j = pts_camera_j.z();
-    residual = (pts_camera_j / dep_j).head<2>() - pts_j.head<2>();
-    residual = sqrt_info * residual;
-
-    puts("num");
-    std::cout << residual.transpose() << std::endl;
-
-    const double eps = 1e-6;
-    Eigen::Matrix<double, 2, 19> num_jacobian;
-    for (int k = 0; k < 19; k++) {
-        Eigen::Vector3d Pi(parameters[0][0], parameters[0][1], parameters[0][2]);
-        Eigen::Quaterniond Qi(parameters[0][6], parameters[0][3], parameters[0][4], parameters[0][5]);
-
-        Eigen::Vector3d Pj(parameters[1][0], parameters[1][1], parameters[1][2]);
-        Eigen::Quaterniond Qj(parameters[1][6], parameters[1][3], parameters[1][4], parameters[1][5]);
-
-        Eigen::Vector3d t_ic(parameters[2][0], parameters[2][1], parameters[2][2]);
-        Eigen::Quaterniond q_ic(parameters[2][6], parameters[2][3], parameters[2][4], parameters[2][5]);
-        double inv_dep_i = parameters[3][0];
-
-        int a = k / 3, b = k % 3;
-        Eigen::Vector3d delta = Eigen::Vector3d(b == 0, b == 1, b == 2) * eps;
-
-        if (a == 0)
-            Pi += delta;
-        else if (a == 1)
-            Qi = Qi * Utility::deltaQ(delta);
-        else if (a == 2)
-            Pj += delta;
-        else if (a == 3)
-            Qj = Qj * Utility::deltaQ(delta);
-        else if (a == 4)
-            t_ic += delta;
-        else if (a == 5)
-            q_ic = q_ic * Utility::deltaQ(delta);
-        else if (a == 6)
-            inv_dep_i += delta.x();
-
-        Eigen::Vector3d pts_camera_i = pts_i / inv_dep_i;
-        Eigen::Vector3d pts_imu_i = q_ic * pts_camera_i + t_ic;
-        Eigen::Vector3d pts_w = Qi * pts_imu_i + Pi;
-        Eigen::Vector3d pts_imu_j = Qj.inverse() * (pts_w - Pj);
-        Eigen::Vector3d pts_camera_j = q_ic.inverse() * (pts_imu_j - t_ic);
-
-        Eigen::Vector2d tmp_residual;
-        double dep_j = pts_camera_j.z();
-        tmp_residual = (pts_camera_j / dep_j).head<2>() - pts_j.head<2>();
-        tmp_residual = sqrt_info * tmp_residual;
-        num_jacobian.col(k) = (tmp_residual - residual) / eps;
-    }
-    std::cout << num_jacobian << std::endl;
+    tmp_residual = (pts_camera_j / dep_j).head<2>() - pts_j.head<2>();
+    tmp_residual = sqrt_info * tmp_residual;
+    num_jacobian.col(k) = (tmp_residual - residual) / eps;
+  }
+  std::cout << num_jacobian << std::endl;
 }
 
-} // namespace factor
-} // namespace backend
+}  // namespace factor
+}  // namespace backend

--- a/src/backend/optimizer.cpp
+++ b/src/backend/optimizer.cpp
@@ -1,359 +1,367 @@
 #include "backend/optimizer.h"
 
-
 namespace backend {
 
-Optimizer::Optimizer(SlidingWindow* sliding_window, FeatureManager* feature_manager) 
-    : sliding_window_(sliding_window), feature_manager_(feature_manager), last_marginalization_info_(nullptr) {
-    t_ic_ = Vector3d::Zero();
-    r_ic_ = Matrix3d::Identity();
+Optimizer::Optimizer(SlidingWindow *sliding_window, FeatureManager *feature_manager)
+    : sliding_window_(sliding_window),
+      feature_manager_(feature_manager),
+      last_marginalization_info_(nullptr) {
+  t_ic_ = Vector3d::Zero();
+  r_ic_ = Matrix3d::Identity();
 }
 
 Optimizer::~Optimizer() {
-    if (last_marginalization_info_ != nullptr) {
-        delete last_marginalization_info_;
-        last_marginalization_info_ = nullptr;
-    }
+  if (last_marginalization_info_ != nullptr) {
+    delete last_marginalization_info_;
+    last_marginalization_info_ = nullptr;
+  }
 }
 
-void Optimizer::setExtrinsicParameters(const Vector3d& t_ic, const Matrix3d& r_ic) {
-    t_ic_ = t_ic;
-    r_ic_ = r_ic;
+void Optimizer::setExtrinsicParameters(const Vector3d &t_ic, const Matrix3d &r_ic) {
+  t_ic_ = t_ic;
+  r_ic_ = r_ic;
 }
 
 void Optimizer::optimize(MarginalizationFlag marginalization_flag) {
-    // STEP 1: Setup optimization problem and parameter blocks
-    ceres::Problem problem;
-    ceres::LossFunction *loss_function = setupOptimizationProblem(problem);
-    
-    // STEP 2: Add various constraint factors
-    addMarginalizationFactor(problem);
-    addIMUFactors(problem);
-    addFeatureFactors(problem, loss_function);
-    
-    // STEP 3: Solve the optimization problem
-    solveCeresProblem(problem);
-    
-    // STEP 4: Apply results and handle marginalization
-    applyOptimizationResults();
-    handleMarginalization(marginalization_flag);
+  // STEP 1: Setup optimization problem and parameter blocks
+  ceres::Problem problem;
+  ceres::LossFunction *loss_function = setupOptimizationProblem(problem);
+
+  // STEP 2: Add various constraint factors
+  addMarginalizationFactor(problem);
+  addIMUFactors(problem);
+  addFeatureFactors(problem, loss_function);
+
+  // STEP 3: Solve the optimization problem
+  solveCeresProblem(problem);
+
+  // STEP 4: Apply results and handle marginalization
+  applyOptimizationResults();
+  handleMarginalization(marginalization_flag);
 }
 
-ceres::LossFunction* Optimizer::setupOptimizationProblem(ceres::Problem& problem) {
-    // Setup loss function
-    ceres::LossFunction *loss_function = new ceres::CauchyLoss(1.0);
-    
-    // Add pose and speed-bias parameter blocks for sliding window
-    for (int i = 0; i < WINDOW_SIZE + 1; i++) {
-        ceres::LocalParameterization *local_parameterization = new backend::factor::PoseLocalParameterization();
-        problem.AddParameterBlock(para_Pose[i], SIZE_POSE, local_parameterization); // R, P
-        problem.AddParameterBlock(para_SpeedAndBiases[i], SIZE_SPEEDANDBIAS); // V, Ba, Bg
+ceres::LossFunction *Optimizer::setupOptimizationProblem(ceres::Problem &problem) {
+  // Setup loss function
+  ceres::LossFunction *loss_function = new ceres::CauchyLoss(1.0);
+
+  // Add pose and speed-bias parameter blocks for sliding window
+  for (int i = 0; i < WINDOW_SIZE + 1; i++) {
+    ceres::LocalParameterization *local_parameterization =
+        new backend::factor::PoseLocalParameterization();
+    problem.AddParameterBlock(para_Pose[i], SIZE_POSE, local_parameterization);  // R, P
+    problem.AddParameterBlock(para_SpeedAndBiases[i], SIZE_SPEEDANDBIAS);        // V, Ba, Bg
+  }
+
+  // Add extrinsic parameter block
+  ceres::LocalParameterization *local_parameterization =
+      new backend::factor::PoseLocalParameterization();
+  problem.AddParameterBlock(para_Ex_Pose, SIZE_POSE, local_parameterization);
+  problem.SetParameterBlockConstant(para_Ex_Pose);
+
+  // Prepare optimization parameters
+  prepareOptimizationParameters();
+
+  return loss_function;
+}
+
+void Optimizer::addMarginalizationFactor(ceres::Problem &problem) {
+  if (last_marginalization_info_) {
+    // construct new marginlization_factor
+    backend::factor::MarginalizationFactor *marginalization_factor =
+        new backend::factor::MarginalizationFactor(last_marginalization_info_);
+    problem.AddResidualBlock(marginalization_factor, NULL, last_marginalization_parameter_blocks_);
+  }
+}
+
+void Optimizer::addIMUFactors(ceres::Problem &problem) {
+  for (int i = 0; i < WINDOW_SIZE; i++) {
+    int j = i + 1;
+    if ((*sliding_window_)[j].pre_integration->sum_dt > 10.0) continue;
+    backend::factor::IMUFactor *imu_factor =
+        new backend::factor::IMUFactor((*sliding_window_)[j].pre_integration);
+    problem.AddResidualBlock(imu_factor, NULL, para_Pose[i], para_SpeedAndBiases[i], para_Pose[j],
+                             para_SpeedAndBiases[j]);
+  }
+}
+
+int Optimizer::addFeatureFactors(ceres::Problem &problem, ceres::LossFunction *loss_function) {
+  int f_m_cnt = 0;
+  int feature_index = -1;
+  for (auto &it_per_id : feature_manager_->feature) {
+    it_per_id.used_num = it_per_id.feature_per_frame.size();
+    if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2)) continue;
+
+    ++feature_index;
+
+    int imu_i = it_per_id.start_frame, imu_j = imu_i - 1;
+    Vector3d pts_i = it_per_id.feature_per_frame[0].point;
+
+    for (auto &it_per_frame : it_per_id.feature_per_frame) {
+      imu_j++;
+      if (imu_i == imu_j) {
+        continue;
+      }
+      Vector3d pts_j = it_per_frame.point;
+      backend::factor::ProjectionFactor *f = new backend::factor::ProjectionFactor(pts_i, pts_j);
+      problem.AddResidualBlock(f, loss_function, para_Pose[imu_i], para_Pose[imu_j], para_Ex_Pose,
+                               para_Feature[feature_index]);
+      f_m_cnt++;
     }
-
-    // Add extrinsic parameter block
-    ceres::LocalParameterization *local_parameterization = new backend::factor::PoseLocalParameterization();
-    problem.AddParameterBlock(para_Ex_Pose, SIZE_POSE, local_parameterization);
-    problem.SetParameterBlockConstant(para_Ex_Pose);
-
-    // Prepare optimization parameters
-    prepareOptimizationParameters();
-    
-    return loss_function;
+  }
+  return f_m_cnt;
 }
 
-void Optimizer::addMarginalizationFactor(ceres::Problem& problem) {
-    if (last_marginalization_info_) {
-        // construct new marginlization_factor
-        backend::factor::MarginalizationFactor *marginalization_factor = new backend::factor::MarginalizationFactor(last_marginalization_info_);
-        problem.AddResidualBlock(marginalization_factor, NULL, last_marginalization_parameter_blocks_);
-    }
-}
-
-void Optimizer::addIMUFactors(ceres::Problem& problem) {
-    for (int i = 0; i < WINDOW_SIZE; i++) {
-        int j = i + 1;
-        if ((*sliding_window_)[j].pre_integration->sum_dt > 10.0)
-            continue;
-        backend::factor::IMUFactor *imu_factor = new backend::factor::IMUFactor((*sliding_window_)[j].pre_integration);
-        problem.AddResidualBlock(imu_factor, NULL, para_Pose[i], para_SpeedAndBiases[i], para_Pose[j],
-                                 para_SpeedAndBiases[j]);
-    }
-}
-
-int Optimizer::addFeatureFactors(ceres::Problem& problem, ceres::LossFunction* loss_function) {
-    int f_m_cnt = 0;
-    int feature_index = -1;
-    for (auto &it_per_id : feature_manager_->feature) {
-        it_per_id.used_num = it_per_id.feature_per_frame.size();
-        if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2))
-            continue;
-
-        ++feature_index;
-
-        int imu_i = it_per_id.start_frame, imu_j = imu_i - 1;
-        Vector3d pts_i = it_per_id.feature_per_frame[0].point;
-
-        for (auto &it_per_frame : it_per_id.feature_per_frame) {
-            imu_j++;
-            if (imu_i == imu_j) {
-                continue;
-            }
-            Vector3d pts_j = it_per_frame.point;
-            backend::factor::ProjectionFactor *f = new backend::factor::ProjectionFactor(pts_i, pts_j);
-            problem.AddResidualBlock(f, loss_function, para_Pose[imu_i], para_Pose[imu_j], para_Ex_Pose,
-                                        para_Feature[feature_index]);
-            f_m_cnt++;
-        }
-    }
-    return f_m_cnt;
-}
-
-void Optimizer::solveCeresProblem(ceres::Problem& problem) {
-    ceres::Solver::Options options;
-    options.linear_solver_type = ceres::DENSE_SCHUR;
-    options.trust_region_strategy_type = ceres::DOGLEG;
-    options.max_solver_time_in_seconds = g_config.estimator.solver_time;
-    options.max_num_iterations = g_config.estimator.num_iterations;
-    ceres::Solver::Summary summary;
-    ceres::Solve(options, &problem, &summary);
+void Optimizer::solveCeresProblem(ceres::Problem &problem) {
+  ceres::Solver::Options options;
+  options.linear_solver_type = ceres::DENSE_SCHUR;
+  options.trust_region_strategy_type = ceres::DOGLEG;
+  options.max_solver_time_in_seconds = g_config.estimator.solver_time;
+  options.max_num_iterations = g_config.estimator.num_iterations;
+  ceres::Solver::Summary summary;
+  ceres::Solve(options, &problem, &summary);
 }
 
 void Optimizer::applyOptimizationResults() {
-    Vector3d origin_R0 = Utility::R2ypr((*sliding_window_).front().R);
-    Vector3d origin_P0 = (*sliding_window_).front().P;
-    
-    Vector3d origin_R00 = Utility::R2ypr(
-        Quaterniond(para_Pose[0][6], para_Pose[0][3], para_Pose[0][4], para_Pose[0][5]).toRotationMatrix());
-    double y_diff = origin_R0.x() - origin_R00.x();
-    // TODO
-    Matrix3d rot_diff = Utility::ypr2R(Vector3d(y_diff, 0, 0));
-    if (abs(abs(origin_R0.y()) - 90) < 1.0 || abs(abs(origin_R00.y()) - 90) < 1.0) {
-        std::cout << "euler singular point!" << std::endl;
-        rot_diff = (*sliding_window_).front().R * Quaterniond(para_Pose[0][6], para_Pose[0][3], para_Pose[0][4], para_Pose[0][5])
-                               .toRotationMatrix()
-                               .transpose();
-    }
+  Vector3d origin_R0 = Utility::R2ypr((*sliding_window_).front().R);
+  Vector3d origin_P0 = (*sliding_window_).front().P;
 
-    for (int i = 0; i <= WINDOW_SIZE; i++) {
-        (*sliding_window_)[i].R = rot_diff * Quaterniond(para_Pose[i][6], para_Pose[i][3], para_Pose[i][4], para_Pose[i][5])
-                               .normalized()
-                               .toRotationMatrix();
+  Vector3d origin_R00 =
+      Utility::R2ypr(Quaterniond(para_Pose[0][6], para_Pose[0][3], para_Pose[0][4], para_Pose[0][5])
+                         .toRotationMatrix());
+  double y_diff = origin_R0.x() - origin_R00.x();
+  // TODO
+  Matrix3d rot_diff = Utility::ypr2R(Vector3d(y_diff, 0, 0));
+  if (abs(abs(origin_R0.y()) - 90) < 1.0 || abs(abs(origin_R00.y()) - 90) < 1.0) {
+    std::cout << "euler singular point!" << std::endl;
+    rot_diff = (*sliding_window_).front().R *
+               Quaterniond(para_Pose[0][6], para_Pose[0][3], para_Pose[0][4], para_Pose[0][5])
+                   .toRotationMatrix()
+                   .transpose();
+  }
 
-        (*sliding_window_)[i].P = rot_diff * Vector3d(para_Pose[i][0] - para_Pose[0][0], para_Pose[i][1] - para_Pose[0][1],
-                                    para_Pose[i][2] - para_Pose[0][2]) +
-                origin_P0;
+  for (int i = 0; i <= WINDOW_SIZE; i++) {
+    (*sliding_window_)[i].R =
+        rot_diff * Quaterniond(para_Pose[i][6], para_Pose[i][3], para_Pose[i][4], para_Pose[i][5])
+                       .normalized()
+                       .toRotationMatrix();
 
-        (*sliding_window_)[i].V = rot_diff * Vector3d(para_SpeedAndBiases[i][0], para_SpeedAndBiases[i][1], para_SpeedAndBiases[i][2]);
+    (*sliding_window_)[i].P =
+        rot_diff * Vector3d(para_Pose[i][0] - para_Pose[0][0], para_Pose[i][1] - para_Pose[0][1],
+                            para_Pose[i][2] - para_Pose[0][2]) +
+        origin_P0;
 
-        (*sliding_window_)[i].Ba = Vector3d(para_SpeedAndBiases[i][3], para_SpeedAndBiases[i][4], para_SpeedAndBiases[i][5]);
+    (*sliding_window_)[i].V =
+        rot_diff *
+        Vector3d(para_SpeedAndBiases[i][0], para_SpeedAndBiases[i][1], para_SpeedAndBiases[i][2]);
 
-        (*sliding_window_)[i].Bg = Vector3d(para_SpeedAndBiases[i][6], para_SpeedAndBiases[i][7], para_SpeedAndBiases[i][8]);
-    }
+    (*sliding_window_)[i].Ba =
+        Vector3d(para_SpeedAndBiases[i][3], para_SpeedAndBiases[i][4], para_SpeedAndBiases[i][5]);
 
-    t_ic_ = Vector3d(para_Ex_Pose[0], para_Ex_Pose[1], para_Ex_Pose[2]);
-    r_ic_ = Quaterniond(para_Ex_Pose[6], para_Ex_Pose[3], para_Ex_Pose[4], para_Ex_Pose[5]).toRotationMatrix();
+    (*sliding_window_)[i].Bg =
+        Vector3d(para_SpeedAndBiases[i][6], para_SpeedAndBiases[i][7], para_SpeedAndBiases[i][8]);
+  }
 
-    VectorXd dep = feature_manager_->getDepthVector();
-    for (int i = 0; i < feature_manager_->getFeatureCount(); i++)
-        dep(i) = para_Feature[i][0];
-    feature_manager_->setDepth(dep);
+  t_ic_ = Vector3d(para_Ex_Pose[0], para_Ex_Pose[1], para_Ex_Pose[2]);
+  r_ic_ = Quaterniond(para_Ex_Pose[6], para_Ex_Pose[3], para_Ex_Pose[4], para_Ex_Pose[5])
+              .toRotationMatrix();
+
+  VectorXd dep = feature_manager_->getDepthVector();
+  for (int i = 0; i < feature_manager_->getFeatureCount(); i++) dep(i) = para_Feature[i][0];
+  feature_manager_->setDepth(dep);
 }
 
 void Optimizer::handleMarginalization(MarginalizationFlag marginalization_flag) {
-    if (marginalization_flag == MarginalizationFlag::MARGIN_OLD_KEYFRAME) {
-        marginalizeOldKeyframe();
-    } 
-    else if (marginalization_flag == MarginalizationFlag::MARGIN_NEW_GENERAL_FRAME) {
-        marginalizeNewGeneralFrame();
-    }
+  if (marginalization_flag == MarginalizationFlag::MARGIN_OLD_KEYFRAME) {
+    marginalizeOldKeyframe();
+  } else if (marginalization_flag == MarginalizationFlag::MARGIN_NEW_GENERAL_FRAME) {
+    marginalizeNewGeneralFrame();
+  }
 }
 
 void Optimizer::prepareOptimizationParameters() {
-    for (int i = 0; i <= WINDOW_SIZE; i++) {
-        // P
-        para_Pose[i][0] = (*sliding_window_)[i].P.x();
-        para_Pose[i][1] = (*sliding_window_)[i].P.y();
-        para_Pose[i][2] = (*sliding_window_)[i].P.z();
+  for (int i = 0; i <= WINDOW_SIZE; i++) {
+    // P
+    para_Pose[i][0] = (*sliding_window_)[i].P.x();
+    para_Pose[i][1] = (*sliding_window_)[i].P.y();
+    para_Pose[i][2] = (*sliding_window_)[i].P.z();
 
-        // R
-        Quaterniond q{(*sliding_window_)[i].R};
-        para_Pose[i][3] = q.x();
-        para_Pose[i][4] = q.y();
-        para_Pose[i][5] = q.z();
-        para_Pose[i][6] = q.w();
+    // R
+    Quaterniond q{(*sliding_window_)[i].R};
+    para_Pose[i][3] = q.x();
+    para_Pose[i][4] = q.y();
+    para_Pose[i][5] = q.z();
+    para_Pose[i][6] = q.w();
 
-        // V
-        para_SpeedAndBiases[i][0] = (*sliding_window_)[i].V.x();
-        para_SpeedAndBiases[i][1] = (*sliding_window_)[i].V.y();
-        para_SpeedAndBiases[i][2] = (*sliding_window_)[i].V.z();
+    // V
+    para_SpeedAndBiases[i][0] = (*sliding_window_)[i].V.x();
+    para_SpeedAndBiases[i][1] = (*sliding_window_)[i].V.y();
+    para_SpeedAndBiases[i][2] = (*sliding_window_)[i].V.z();
 
-        // Ba
-        para_SpeedAndBiases[i][3] = (*sliding_window_)[i].Ba.x();
-        para_SpeedAndBiases[i][4] = (*sliding_window_)[i].Ba.y();
-        para_SpeedAndBiases[i][5] = (*sliding_window_)[i].Ba.z();
+    // Ba
+    para_SpeedAndBiases[i][3] = (*sliding_window_)[i].Ba.x();
+    para_SpeedAndBiases[i][4] = (*sliding_window_)[i].Ba.y();
+    para_SpeedAndBiases[i][5] = (*sliding_window_)[i].Ba.z();
 
-        // Bg
-        para_SpeedAndBiases[i][6] = (*sliding_window_)[i].Bg.x();
-        para_SpeedAndBiases[i][7] = (*sliding_window_)[i].Bg.y();
-        para_SpeedAndBiases[i][8] = (*sliding_window_)[i].Bg.z();
-    }
+    // Bg
+    para_SpeedAndBiases[i][6] = (*sliding_window_)[i].Bg.x();
+    para_SpeedAndBiases[i][7] = (*sliding_window_)[i].Bg.y();
+    para_SpeedAndBiases[i][8] = (*sliding_window_)[i].Bg.z();
+  }
 
-    // Camera-IMU Extrinsic
-    para_Ex_Pose[0] = t_ic_.x(); // translation
-    para_Ex_Pose[1] = t_ic_.y();
-    para_Ex_Pose[2] = t_ic_.z();
+  // Camera-IMU Extrinsic
+  para_Ex_Pose[0] = t_ic_.x();  // translation
+  para_Ex_Pose[1] = t_ic_.y();
+  para_Ex_Pose[2] = t_ic_.z();
 
-    Quaterniond q{r_ic_}; // rotation
-    para_Ex_Pose[3] = q.x();
-    para_Ex_Pose[4] = q.y();
-    para_Ex_Pose[5] = q.z();
-    para_Ex_Pose[6] = q.w();
+  Quaterniond q{r_ic_};  // rotation
+  para_Ex_Pose[3] = q.x();
+  para_Ex_Pose[4] = q.y();
+  para_Ex_Pose[5] = q.z();
+  para_Ex_Pose[6] = q.w();
 
-    // Feature point depth
-    VectorXd dep = feature_manager_->getDepthVector();
-    for (int i = 0; i < feature_manager_->getFeatureCount(); i++)
-        para_Feature[i][0] = dep(i);
+  // Feature point depth
+  VectorXd dep = feature_manager_->getDepthVector();
+  for (int i = 0; i < feature_manager_->getFeatureCount(); i++) para_Feature[i][0] = dep(i);
 }
 
 void Optimizer::marginalizeOldKeyframe() {
+  factor::MarginalizationInfo *marginalization_info = new factor::MarginalizationInfo();
+  prepareOptimizationParameters();
+
+  if (last_marginalization_info_) {
+    vector<int> drop_set;
+    for (int i = 0; i < static_cast<int>(last_marginalization_parameter_blocks_.size()); i++) {
+      bool does_last_margin_param_block_contain_the_old_keyframe_pose_and_speed_bias =
+          last_marginalization_parameter_blocks_[i] == para_Pose[0] ||
+          last_marginalization_parameter_blocks_[i] == para_SpeedAndBiases[0];
+
+      if (does_last_margin_param_block_contain_the_old_keyframe_pose_and_speed_bias)
+        drop_set.push_back(i);
+    }
+    factor::MarginalizationFactor *marginalization_factor =
+        new factor::MarginalizationFactor(last_marginalization_info_);
+    factor::ResidualBlockInfo *residual_block_info = new factor::ResidualBlockInfo(
+        marginalization_factor, NULL, last_marginalization_parameter_blocks_, drop_set);
+    marginalization_info->addResidualBlockInfo(residual_block_info);
+  }
+
+  addIMUFactorForMarginalization(marginalization_info);
+  addFeatureFactorsForMarginalization(marginalization_info);
+
+  performMarginalizationForOldKeyframe(marginalization_info);
+}
+
+void Optimizer::marginalizeNewGeneralFrame() {
+  bool does_last_margin_param_block_contain_the_new_general_frame_pose =
+      std::count(std::begin(last_marginalization_parameter_blocks_),
+                 std::end(last_marginalization_parameter_blocks_), para_Pose[WINDOW_SIZE - 1]);
+
+  if (does_last_margin_param_block_contain_the_new_general_frame_pose) {
     factor::MarginalizationInfo *marginalization_info = new factor::MarginalizationInfo();
     prepareOptimizationParameters();
 
     if (last_marginalization_info_) {
-        vector<int> drop_set;
-        for (int i = 0; i < static_cast<int>(last_marginalization_parameter_blocks_.size()); i++) {
-            bool does_last_margin_param_block_contain_the_old_keyframe_pose_and_speed_bias = 
-                last_marginalization_parameter_blocks_[i] == para_Pose[0] ||
-                last_marginalization_parameter_blocks_[i] == para_SpeedAndBiases[0];
-
-            if (does_last_margin_param_block_contain_the_old_keyframe_pose_and_speed_bias)
-                drop_set.push_back(i);
-        }
-        factor::MarginalizationFactor *marginalization_factor = new factor::MarginalizationFactor(last_marginalization_info_);
-        factor::ResidualBlockInfo *residual_block_info =
-            new factor::ResidualBlockInfo(marginalization_factor, NULL, last_marginalization_parameter_blocks_, drop_set);
-        marginalization_info->addResidualBlockInfo(residual_block_info);
+      vector<int> drop_set;
+      for (int i = 0; i < static_cast<int>(last_marginalization_parameter_blocks_.size()); i++) {
+        assert(last_marginalization_parameter_blocks_[i] != para_SpeedAndBiases[WINDOW_SIZE - 1]);
+        if (last_marginalization_parameter_blocks_[i] == para_Pose[WINDOW_SIZE - 1])
+          drop_set.push_back(i);
+      }
+      factor::MarginalizationFactor *marginalization_factor =
+          new factor::MarginalizationFactor(last_marginalization_info_);
+      factor::ResidualBlockInfo *residual_block_info = new factor::ResidualBlockInfo(
+          marginalization_factor, NULL, last_marginalization_parameter_blocks_, drop_set);
+      marginalization_info->addResidualBlockInfo(residual_block_info);
     }
 
-    addIMUFactorForMarginalization(marginalization_info);
-    addFeatureFactorsForMarginalization(marginalization_info);
-
-    performMarginalizationForOldKeyframe(marginalization_info);
+    performMarginalizationForNewGeneralFrame(marginalization_info);
+  }
 }
 
-void Optimizer::marginalizeNewGeneralFrame() {
-    bool does_last_margin_param_block_contain_the_new_general_frame_pose = 
-        std::count(std::begin(last_marginalization_parameter_blocks_),
-                   std::end(last_marginalization_parameter_blocks_), 
-                   para_Pose[WINDOW_SIZE - 1]);
+void Optimizer::addIMUFactorForMarginalization(factor::MarginalizationInfo *marginalization_info) {
+  if ((*sliding_window_)[1].pre_integration->sum_dt < 10.0) {
+    factor::IMUFactor *imu_factor = new factor::IMUFactor((*sliding_window_)[1].pre_integration);
+    factor::ResidualBlockInfo *residual_block_info =
+        new factor::ResidualBlockInfo(imu_factor, NULL,
+                                      vector<double *>{para_Pose[0], para_SpeedAndBiases[0],
+                                                       para_Pose[1], para_SpeedAndBiases[1]},
+                                      vector<int>{0, 1});
+    marginalization_info->addResidualBlockInfo(residual_block_info);
+  }
+}
 
-    if (does_last_margin_param_block_contain_the_new_general_frame_pose) 
-    {
-        factor::MarginalizationInfo *marginalization_info = new factor::MarginalizationInfo();
-        prepareOptimizationParameters();
+void Optimizer::addFeatureFactorsForMarginalization(
+    factor::MarginalizationInfo *marginalization_info) {
+  ceres::LossFunction *loss_function = new ceres::CauchyLoss(1.0);
+  int feature_index = -1;
+  for (auto &it_per_id : feature_manager_->feature) {
+    it_per_id.used_num = it_per_id.feature_per_frame.size();
+    if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2)) continue;
 
-        if (last_marginalization_info_) {
-            vector<int> drop_set;
-            for (int i = 0; i < static_cast<int>(last_marginalization_parameter_blocks_.size()); i++) {
-                assert(last_marginalization_parameter_blocks_[i] != para_SpeedAndBiases[WINDOW_SIZE - 1]);
-                if (last_marginalization_parameter_blocks_[i] == para_Pose[WINDOW_SIZE - 1])
-                    drop_set.push_back(i);
-            }
-            factor::MarginalizationFactor *marginalization_factor = new factor::MarginalizationFactor(last_marginalization_info_);
-            factor::ResidualBlockInfo *residual_block_info = new factor::ResidualBlockInfo(
-                marginalization_factor, NULL, last_marginalization_parameter_blocks_, drop_set);
-            marginalization_info->addResidualBlockInfo(residual_block_info);
-        }
+    ++feature_index;
 
-        performMarginalizationForNewGeneralFrame(marginalization_info);
+    int imu_i = it_per_id.start_frame, imu_j = imu_i - 1;
+    if (imu_i != 0) continue;
+
+    Vector3d pts_i = it_per_id.feature_per_frame[0].point;
+
+    for (auto &it_per_frame : it_per_id.feature_per_frame) {
+      imu_j++;
+      if (imu_i == imu_j) continue;
+
+      Vector3d pts_j = it_per_frame.point;
+      factor::ProjectionFactor *f = new factor::ProjectionFactor(pts_i, pts_j);
+      factor::ResidualBlockInfo *residual_block_info =
+          new factor::ResidualBlockInfo(f, loss_function,
+                                        vector<double *>{para_Pose[imu_i], para_Pose[imu_j],
+                                                         para_Ex_Pose, para_Feature[feature_index]},
+                                        vector<int>{0, 3});
+      marginalization_info->addResidualBlockInfo(residual_block_info);
     }
+  }
 }
 
-void Optimizer::addIMUFactorForMarginalization(factor::MarginalizationInfo* marginalization_info) {
-    if ((*sliding_window_)[1].pre_integration->sum_dt < 10.0) {
-        factor::IMUFactor *imu_factor = new factor::IMUFactor((*sliding_window_)[1].pre_integration);
-        factor::ResidualBlockInfo *residual_block_info = new factor::ResidualBlockInfo(
-            imu_factor, NULL,
-            vector<double *>{para_Pose[0], para_SpeedAndBiases[0], para_Pose[1], para_SpeedAndBiases[1]},
-            vector<int>{0, 1});
-        marginalization_info->addResidualBlockInfo(residual_block_info);
+void Optimizer::performMarginalizationForOldKeyframe(
+    factor::MarginalizationInfo *marginalization_info) {
+  marginalization_info->preMarginalize();
+  marginalization_info->marginalize();
+
+  std::unordered_map<long, double *> addr_shift;
+  for (int i = 1; i <= WINDOW_SIZE; i++) {
+    addr_shift[reinterpret_cast<long>(para_Pose[i])] = para_Pose[i - 1];
+    addr_shift[reinterpret_cast<long>(para_SpeedAndBiases[i])] = para_SpeedAndBiases[i - 1];
+  }
+  addr_shift[reinterpret_cast<long>(para_Ex_Pose)] = para_Ex_Pose;
+  vector<double *> parameter_blocks = marginalization_info->getParameterBlocks(addr_shift);
+
+  if (last_marginalization_info_) delete last_marginalization_info_;
+  last_marginalization_info_ = marginalization_info;
+  last_marginalization_parameter_blocks_ = parameter_blocks;
+}
+
+void Optimizer::performMarginalizationForNewGeneralFrame(
+    factor::MarginalizationInfo *marginalization_info) {
+  marginalization_info->preMarginalize();
+  marginalization_info->marginalize();
+
+  std::unordered_map<long, double *> addr_shift;
+  for (int i = 0; i <= WINDOW_SIZE; i++) {
+    if (i == WINDOW_SIZE - 1)
+      continue;
+    else if (i == WINDOW_SIZE) {
+      addr_shift[reinterpret_cast<long>(para_Pose[i])] = para_Pose[i - 1];
+      addr_shift[reinterpret_cast<long>(para_SpeedAndBiases[i])] = para_SpeedAndBiases[i - 1];
+    } else {
+      addr_shift[reinterpret_cast<long>(para_Pose[i])] = para_Pose[i];
+      addr_shift[reinterpret_cast<long>(para_SpeedAndBiases[i])] = para_SpeedAndBiases[i];
     }
+  }
+  addr_shift[reinterpret_cast<long>(para_Ex_Pose)] = para_Ex_Pose;
+
+  vector<double *> parameter_blocks = marginalization_info->getParameterBlocks(addr_shift);
+  if (last_marginalization_info_) delete last_marginalization_info_;
+  last_marginalization_info_ = marginalization_info;
+  last_marginalization_parameter_blocks_ = parameter_blocks;
 }
 
-void Optimizer::addFeatureFactorsForMarginalization(factor::MarginalizationInfo* marginalization_info) {
-    ceres::LossFunction *loss_function = new ceres::CauchyLoss(1.0);
-    int feature_index = -1;
-    for (auto &it_per_id : feature_manager_->feature) {
-        it_per_id.used_num = it_per_id.feature_per_frame.size();
-        if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2))
-            continue;
-
-        ++feature_index;
-
-        int imu_i = it_per_id.start_frame, imu_j = imu_i - 1;
-        if (imu_i != 0)
-            continue;
-
-        Vector3d pts_i = it_per_id.feature_per_frame[0].point;
-
-        for (auto &it_per_frame : it_per_id.feature_per_frame) {
-            imu_j++;
-            if (imu_i == imu_j)
-                continue;
-
-            Vector3d pts_j = it_per_frame.point;
-            factor::ProjectionFactor *f = new factor::ProjectionFactor(pts_i, pts_j);
-            factor::ResidualBlockInfo *residual_block_info =
-                new factor::ResidualBlockInfo(f, loss_function,
-                                      vector<double *>{para_Pose[imu_i], para_Pose[imu_j], para_Ex_Pose,
-                                                       para_Feature[feature_index]},
-                                      vector<int>{0, 3});
-            marginalization_info->addResidualBlockInfo(residual_block_info);
-        }
-    }
-}
-
-void Optimizer::performMarginalizationForOldKeyframe(factor::MarginalizationInfo* marginalization_info) {
-    marginalization_info->preMarginalize();
-    marginalization_info->marginalize();
-
-    std::unordered_map<long, double *> addr_shift;
-    for (int i = 1; i <= WINDOW_SIZE; i++) {
-        addr_shift[reinterpret_cast<long>(para_Pose[i])] = para_Pose[i - 1];
-        addr_shift[reinterpret_cast<long>(para_SpeedAndBiases[i])] = para_SpeedAndBiases[i - 1];
-    }
-    addr_shift[reinterpret_cast<long>(para_Ex_Pose)] = para_Ex_Pose;
-    vector<double *> parameter_blocks = marginalization_info->getParameterBlocks(addr_shift);
-
-    if (last_marginalization_info_)
-        delete last_marginalization_info_;
-    last_marginalization_info_ = marginalization_info;
-    last_marginalization_parameter_blocks_ = parameter_blocks;
-}
-
-void Optimizer::performMarginalizationForNewGeneralFrame(factor::MarginalizationInfo* marginalization_info) {
-    marginalization_info->preMarginalize();
-    marginalization_info->marginalize();
-
-    std::unordered_map<long, double *> addr_shift;
-    for (int i = 0; i <= WINDOW_SIZE; i++) {
-        if (i == WINDOW_SIZE - 1)
-            continue;
-        else if (i == WINDOW_SIZE) {
-            addr_shift[reinterpret_cast<long>(para_Pose[i])] = para_Pose[i - 1];
-            addr_shift[reinterpret_cast<long>(para_SpeedAndBiases[i])] = para_SpeedAndBiases[i - 1];
-        } else {
-            addr_shift[reinterpret_cast<long>(para_Pose[i])] = para_Pose[i];
-            addr_shift[reinterpret_cast<long>(para_SpeedAndBiases[i])] = para_SpeedAndBiases[i];
-        }
-    }
-    addr_shift[reinterpret_cast<long>(para_Ex_Pose)] = para_Ex_Pose;
-
-    vector<double *> parameter_blocks = marginalization_info->getParameterBlocks(addr_shift);
-    if (last_marginalization_info_)
-        delete last_marginalization_info_;
-    last_marginalization_info_ = marginalization_info;
-    last_marginalization_parameter_blocks_ = parameter_blocks;   
-}
-
-} // namespace backend 
+}  // namespace backend

--- a/src/backend/sliding_window copy.cpp
+++ b/src/backend/sliding_window copy.cpp
@@ -1,7 +1,7 @@
 #include "sliding_window.h"
 
 void SlidingWindow::clearSlidingWindow() {
-    for (int i = 0; i <= WINDOW_SIZE; i++) {
-        sliding_window[i].clear();
-    }
+  for (int i = 0; i <= WINDOW_SIZE; i++) {
+    sliding_window[i].clear();
+  }
 }

--- a/src/backend/sliding_window.cpp
+++ b/src/backend/sliding_window.cpp
@@ -3,9 +3,9 @@
 namespace backend {
 
 void SlidingWindow::clearSlidingWindow() {
-    for (int i = 0; i <= WINDOW_SIZE; i++) {
-        sliding_window[i].clear();
-    }
+  for (int i = 0; i <= WINDOW_SIZE; i++) {
+    sliding_window[i].clear();
+  }
 }
 
-} // namespace backend
+}  // namespace backend

--- a/src/common/frame.cpp
+++ b/src/common/frame.cpp
@@ -1,15 +1,15 @@
 #include "common/frame.h"
 
 void Frame::clear() {
-    timestamp = 0.0;
-    R = Eigen::Matrix3d::Identity();
-    P = Eigen::Vector3d::Zero();
-    V = Eigen::Vector3d::Zero();
-    Ba = Eigen::Vector3d::Zero();
-    Bg = Eigen::Vector3d::Zero();
-    pre_integration = nullptr;
+  timestamp = 0.0;
+  R = Eigen::Matrix3d::Identity();
+  P = Eigen::Vector3d::Zero();
+  V = Eigen::Vector3d::Zero();
+  Ba = Eigen::Vector3d::Zero();
+  Bg = Eigen::Vector3d::Zero();
+  pre_integration = nullptr;
 
-    dt_buf.clear();
-    linear_acceleration_buf.clear();
-    angular_velocity_buf.clear();
+  dt_buf.clear();
+  linear_acceleration_buf.clear();
+  angular_velocity_buf.clear();
 }

--- a/src/frontend/camodocal/camera_models/Camera.cc
+++ b/src/frontend/camodocal/camera_models/Camera.cc
@@ -1,252 +1,177 @@
 #include "frontend/camodocal/camera_models/Camera.h"
-#include "frontend/camodocal/camera_models/ScaramuzzaCamera.h"
 
 #include <opencv2/calib3d/calib3d.hpp>
 
-namespace camodocal
-{
+#include "frontend/camodocal/camera_models/ScaramuzzaCamera.h"
+
+namespace camodocal {
 
 Camera::Parameters::Parameters(ModelType modelType)
- : m_modelType(modelType)
- , m_imageWidth(0)
- , m_imageHeight(0)
-{
-    switch (modelType)
-    {
+    : m_modelType(modelType), m_imageWidth(0), m_imageHeight(0) {
+  switch (modelType) {
     case KANNALA_BRANDT:
-        m_nIntrinsics = 8;
-        break;
+      m_nIntrinsics = 8;
+      break;
     case PINHOLE:
-        m_nIntrinsics = 8;
-        break;
+      m_nIntrinsics = 8;
+      break;
     case SCARAMUZZA:
-        m_nIntrinsics = SCARAMUZZA_CAMERA_NUM_PARAMS;
-        break;
+      m_nIntrinsics = SCARAMUZZA_CAMERA_NUM_PARAMS;
+      break;
     case MEI:
     default:
-        m_nIntrinsics = 9;
-    }
+      m_nIntrinsics = 9;
+  }
 }
 
-Camera::Parameters::Parameters(ModelType modelType,
-                               const std::string& cameraName,
-                               int w, int h)
- : m_modelType(modelType)
- , m_cameraName(cameraName)
- , m_imageWidth(w)
- , m_imageHeight(h)
-{
-    switch (modelType)
-    {
+Camera::Parameters::Parameters(ModelType modelType, const std::string& cameraName, int w, int h)
+    : m_modelType(modelType), m_cameraName(cameraName), m_imageWidth(w), m_imageHeight(h) {
+  switch (modelType) {
     case KANNALA_BRANDT:
-        m_nIntrinsics = 8;
-        break;
+      m_nIntrinsics = 8;
+      break;
     case PINHOLE:
-        m_nIntrinsics = 8;
-        break;
+      m_nIntrinsics = 8;
+      break;
     case SCARAMUZZA:
-        m_nIntrinsics = SCARAMUZZA_CAMERA_NUM_PARAMS;
-        break;
+      m_nIntrinsics = SCARAMUZZA_CAMERA_NUM_PARAMS;
+      break;
     case MEI:
     default:
-        m_nIntrinsics = 9;
-    }
+      m_nIntrinsics = 9;
+  }
 }
 
-Camera::ModelType&
-Camera::Parameters::modelType(void)
-{
-    return m_modelType;
+Camera::ModelType& Camera::Parameters::modelType(void) { return m_modelType; }
+
+std::string& Camera::Parameters::cameraName(void) { return m_cameraName; }
+
+int& Camera::Parameters::imageWidth(void) { return m_imageWidth; }
+
+int& Camera::Parameters::imageHeight(void) { return m_imageHeight; }
+
+Camera::ModelType Camera::Parameters::modelType(void) const { return m_modelType; }
+
+const std::string& Camera::Parameters::cameraName(void) const { return m_cameraName; }
+
+int Camera::Parameters::imageWidth(void) const { return m_imageWidth; }
+
+int Camera::Parameters::imageHeight(void) const { return m_imageHeight; }
+
+int Camera::Parameters::nIntrinsics(void) const { return m_nIntrinsics; }
+
+cv::Mat& Camera::mask(void) { return m_mask; }
+
+const cv::Mat& Camera::mask(void) const { return m_mask; }
+
+void Camera::estimateExtrinsics(const std::vector<cv::Point3f>& objectPoints,
+                                const std::vector<cv::Point2f>& imagePoints, cv::Mat& rvec,
+                                cv::Mat& tvec) const {
+  std::vector<cv::Point2f> Ms(imagePoints.size());
+  for (size_t i = 0; i < Ms.size(); ++i) {
+    Eigen::Vector3d P;
+    liftProjective(Eigen::Vector2d(imagePoints.at(i).x, imagePoints.at(i).y), P);
+
+    P /= P(2);
+
+    Ms.at(i).x = P(0);
+    Ms.at(i).y = P(1);
+  }
+
+  // assume unit focal length, zero principal point, and zero distortion
+  cv::solvePnP(objectPoints, Ms, cv::Mat::eye(3, 3, CV_64F), cv::noArray(), rvec, tvec);
 }
 
-std::string&
-Camera::Parameters::cameraName(void)
-{
-    return m_cameraName;
+double Camera::reprojectionDist(const Eigen::Vector3d& P1, const Eigen::Vector3d& P2) const {
+  Eigen::Vector2d p1, p2;
+
+  spaceToPlane(P1, p1);
+  spaceToPlane(P2, p2);
+
+  return (p1 - p2).norm();
 }
 
-int&
-Camera::Parameters::imageWidth(void)
-{
-    return m_imageWidth;
-}
+double Camera::reprojectionError(const std::vector<std::vector<cv::Point3f> >& objectPoints,
+                                 const std::vector<std::vector<cv::Point2f> >& imagePoints,
+                                 const std::vector<cv::Mat>& rvecs,
+                                 const std::vector<cv::Mat>& tvecs,
+                                 cv::OutputArray _perViewErrors) const {
+  int imageCount = objectPoints.size();
+  size_t pointsSoFar = 0;
+  double totalErr = 0.0;
 
-int&
-Camera::Parameters::imageHeight(void)
-{
-    return m_imageHeight;
-}
+  bool computePerViewErrors = _perViewErrors.needed();
+  cv::Mat perViewErrors;
+  if (computePerViewErrors) {
+    _perViewErrors.create(imageCount, 1, CV_64F);
+    perViewErrors = _perViewErrors.getMat();
+  }
 
-Camera::ModelType
-Camera::Parameters::modelType(void) const
-{
-    return m_modelType;
-}
+  for (int i = 0; i < imageCount; ++i) {
+    size_t pointCount = imagePoints.at(i).size();
 
-const std::string&
-Camera::Parameters::cameraName(void) const
-{
-    return m_cameraName;
-}
+    pointsSoFar += pointCount;
 
-int
-Camera::Parameters::imageWidth(void) const
-{
-    return m_imageWidth;
-}
+    std::vector<cv::Point2f> estImagePoints;
+    projectPoints(objectPoints.at(i), rvecs.at(i), tvecs.at(i), estImagePoints);
 
-int
-Camera::Parameters::imageHeight(void) const
-{
-    return m_imageHeight;
-}
-
-int
-Camera::Parameters::nIntrinsics(void) const
-{
-    return m_nIntrinsics;
-}
-
-cv::Mat&
-Camera::mask(void)
-{
-    return m_mask;
-}
-
-const cv::Mat&
-Camera::mask(void) const
-{
-    return m_mask;
-}
-
-void
-Camera::estimateExtrinsics(const std::vector<cv::Point3f>& objectPoints,
-                           const std::vector<cv::Point2f>& imagePoints,
-                           cv::Mat& rvec, cv::Mat& tvec) const
-{
-    std::vector<cv::Point2f> Ms(imagePoints.size());
-    for (size_t i = 0; i < Ms.size(); ++i)
-    {
-        Eigen::Vector3d P;
-        liftProjective(Eigen::Vector2d(imagePoints.at(i).x, imagePoints.at(i).y), P);
-
-        P /= P(2);
-
-        Ms.at(i).x = P(0);
-        Ms.at(i).y = P(1);
+    double err = 0.0;
+    for (size_t j = 0; j < imagePoints.at(i).size(); ++j) {
+      err += cv::norm(imagePoints.at(i).at(j) - estImagePoints.at(j));
     }
 
-    // assume unit focal length, zero principal point, and zero distortion
-    cv::solvePnP(objectPoints, Ms, cv::Mat::eye(3, 3, CV_64F), cv::noArray(), rvec, tvec);
-}
-
-double
-Camera::reprojectionDist(const Eigen::Vector3d& P1, const Eigen::Vector3d& P2) const
-{
-    Eigen::Vector2d p1, p2;
-
-    spaceToPlane(P1, p1);
-    spaceToPlane(P2, p2);
-
-    return (p1 - p2).norm();
-}
-
-double
-Camera::reprojectionError(const std::vector< std::vector<cv::Point3f> >& objectPoints,
-                          const std::vector< std::vector<cv::Point2f> >& imagePoints,
-                          const std::vector<cv::Mat>& rvecs,
-                          const std::vector<cv::Mat>& tvecs,
-                          cv::OutputArray _perViewErrors) const
-{
-    int imageCount = objectPoints.size();
-    size_t pointsSoFar = 0;
-    double totalErr = 0.0;
-
-    bool computePerViewErrors = _perViewErrors.needed();
-    cv::Mat perViewErrors;
-    if (computePerViewErrors)
-    {
-        _perViewErrors.create(imageCount, 1, CV_64F);
-        perViewErrors = _perViewErrors.getMat();
+    if (computePerViewErrors) {
+      perViewErrors.at<double>(i) = err / pointCount;
     }
 
-    for (int i = 0; i < imageCount; ++i)
-    {
-        size_t pointCount = imagePoints.at(i).size();
+    totalErr += err;
+  }
 
-        pointsSoFar += pointCount;
-
-        std::vector<cv::Point2f> estImagePoints;
-        projectPoints(objectPoints.at(i), rvecs.at(i), tvecs.at(i),
-                      estImagePoints);
-
-        double err = 0.0;
-        for (size_t j = 0; j < imagePoints.at(i).size(); ++j)
-        {
-            err += cv::norm(imagePoints.at(i).at(j) - estImagePoints.at(j));
-        }
-
-        if (computePerViewErrors)
-        {
-            perViewErrors.at<double>(i) = err / pointCount;
-        }
-
-        totalErr += err;
-    }
-
-    return totalErr / pointsSoFar;
+  return totalErr / pointsSoFar;
 }
 
-double
-Camera::reprojectionError(const Eigen::Vector3d& P,
-                          const Eigen::Quaterniond& camera_q,
-                          const Eigen::Vector3d& camera_t,
-                          const Eigen::Vector2d& observed_p) const
-{
-    Eigen::Vector3d P_cam = camera_q.toRotationMatrix() * P + camera_t;
+double Camera::reprojectionError(const Eigen::Vector3d& P, const Eigen::Quaterniond& camera_q,
+                                 const Eigen::Vector3d& camera_t,
+                                 const Eigen::Vector2d& observed_p) const {
+  Eigen::Vector3d P_cam = camera_q.toRotationMatrix() * P + camera_t;
+
+  Eigen::Vector2d p;
+  spaceToPlane(P_cam, p);
+
+  return (p - observed_p).norm();
+}
+
+void Camera::projectPoints(const std::vector<cv::Point3f>& objectPoints, const cv::Mat& rvec,
+                           const cv::Mat& tvec, std::vector<cv::Point2f>& imagePoints) const {
+  // project 3D object points to the image plane
+  imagePoints.reserve(objectPoints.size());
+
+  // double
+  cv::Mat R0;
+  cv::Rodrigues(rvec, R0);
+
+  Eigen::MatrixXd R(3, 3);
+  R << R0.at<double>(0, 0), R0.at<double>(0, 1), R0.at<double>(0, 2), R0.at<double>(1, 0),
+      R0.at<double>(1, 1), R0.at<double>(1, 2), R0.at<double>(2, 0), R0.at<double>(2, 1),
+      R0.at<double>(2, 2);
+
+  Eigen::Vector3d t;
+  t << tvec.at<double>(0), tvec.at<double>(1), tvec.at<double>(2);
+
+  for (size_t i = 0; i < objectPoints.size(); ++i) {
+    const cv::Point3f& objectPoint = objectPoints.at(i);
+
+    // Rotate and translate
+    Eigen::Vector3d P;
+    P << objectPoint.x, objectPoint.y, objectPoint.z;
+
+    P = R * P + t;
 
     Eigen::Vector2d p;
-    spaceToPlane(P_cam, p);
+    spaceToPlane(P, p);
 
-    return (p - observed_p).norm();
+    imagePoints.push_back(cv::Point2f(p(0), p(1)));
+  }
 }
 
-void
-Camera::projectPoints(const std::vector<cv::Point3f>& objectPoints,
-                      const cv::Mat& rvec,
-                      const cv::Mat& tvec,
-                      std::vector<cv::Point2f>& imagePoints) const
-{
-    // project 3D object points to the image plane
-    imagePoints.reserve(objectPoints.size());
-
-    //double
-    cv::Mat R0;
-    cv::Rodrigues(rvec, R0);
-
-    Eigen::MatrixXd R(3,3);
-    R << R0.at<double>(0,0), R0.at<double>(0,1), R0.at<double>(0,2),
-         R0.at<double>(1,0), R0.at<double>(1,1), R0.at<double>(1,2),
-         R0.at<double>(2,0), R0.at<double>(2,1), R0.at<double>(2,2);
-
-    Eigen::Vector3d t;
-    t << tvec.at<double>(0), tvec.at<double>(1), tvec.at<double>(2);
-
-    for (size_t i = 0; i < objectPoints.size(); ++i)
-    {
-        const cv::Point3f& objectPoint = objectPoints.at(i);
-
-        // Rotate and translate
-        Eigen::Vector3d P;
-        P << objectPoint.x, objectPoint.y, objectPoint.z;
-
-        P = R * P + t;
-
-        Eigen::Vector2d p;
-        spaceToPlane(P, p);
-
-        imagePoints.push_back(cv::Point2f(p(0), p(1)));
-    }
-}
-
-}
+}  // namespace camodocal

--- a/src/frontend/camodocal/camera_models/CameraFactory.cc
+++ b/src/frontend/camodocal/camera_models/CameraFactory.cc
@@ -2,172 +2,136 @@
 
 #include <boost/algorithm/string.hpp>
 
-
+#include "ceres/ceres.h"
 #include "frontend/camodocal/camera_models/CataCamera.h"
 #include "frontend/camodocal/camera_models/EquidistantCamera.h"
 #include "frontend/camodocal/camera_models/PinholeCamera.h"
 #include "frontend/camodocal/camera_models/ScaramuzzaCamera.h"
 
-#include "ceres/ceres.h"
-
-namespace camodocal
-{
+namespace camodocal {
 
 boost::shared_ptr<CameraFactory> CameraFactory::m_instance;
 
-CameraFactory::CameraFactory()
-{
+CameraFactory::CameraFactory() {}
 
+boost::shared_ptr<CameraFactory> CameraFactory::instance(void) {
+  if (m_instance.get() == 0) {
+    m_instance.reset(new CameraFactory);
+  }
+
+  return m_instance;
 }
 
-boost::shared_ptr<CameraFactory>
-CameraFactory::instance(void)
-{
-    if (m_instance.get() == 0)
-    {
-        m_instance.reset(new CameraFactory);
+CameraPtr CameraFactory::generateCamera(Camera::ModelType modelType, const std::string& cameraName,
+                                        cv::Size imageSize) const {
+  switch (modelType) {
+    case Camera::KANNALA_BRANDT: {
+      EquidistantCameraPtr camera(new EquidistantCamera);
+
+      EquidistantCamera::Parameters params = camera->getParameters();
+      params.cameraName() = cameraName;
+      params.imageWidth() = imageSize.width;
+      params.imageHeight() = imageSize.height;
+      camera->setParameters(params);
+      return camera;
     }
+    case Camera::PINHOLE: {
+      PinholeCameraPtr camera(new PinholeCamera);
 
-    return m_instance;
-}
-
-CameraPtr
-CameraFactory::generateCamera(Camera::ModelType modelType,
-                              const std::string& cameraName,
-                              cv::Size imageSize) const
-{
-    switch (modelType)
-    {
-    case Camera::KANNALA_BRANDT:
-    {
-        EquidistantCameraPtr camera(new EquidistantCamera);
-
-        EquidistantCamera::Parameters params = camera->getParameters();
-        params.cameraName() = cameraName;
-        params.imageWidth() = imageSize.width;
-        params.imageHeight() = imageSize.height;
-        camera->setParameters(params);
-        return camera;
+      PinholeCamera::Parameters params = camera->getParameters();
+      params.cameraName() = cameraName;
+      params.imageWidth() = imageSize.width;
+      params.imageHeight() = imageSize.height;
+      camera->setParameters(params);
+      return camera;
     }
-    case Camera::PINHOLE:
-    {
-        PinholeCameraPtr camera(new PinholeCamera);
+    case Camera::SCARAMUZZA: {
+      OCAMCameraPtr camera(new OCAMCamera);
 
-        PinholeCamera::Parameters params = camera->getParameters();
-        params.cameraName() = cameraName;
-        params.imageWidth() = imageSize.width;
-        params.imageHeight() = imageSize.height;
-        camera->setParameters(params);
-        return camera;
-    }
-    case Camera::SCARAMUZZA:
-    {
-        OCAMCameraPtr camera(new OCAMCamera);
-
-        OCAMCamera::Parameters params = camera->getParameters();
-        params.cameraName() = cameraName;
-        params.imageWidth() = imageSize.width;
-        params.imageHeight() = imageSize.height;
-        camera->setParameters(params);
-        return camera;
+      OCAMCamera::Parameters params = camera->getParameters();
+      params.cameraName() = cameraName;
+      params.imageWidth() = imageSize.width;
+      params.imageHeight() = imageSize.height;
+      camera->setParameters(params);
+      return camera;
     }
     case Camera::MEI:
-    default:
-    {
-        CataCameraPtr camera(new CataCamera);
+    default: {
+      CataCameraPtr camera(new CataCamera);
 
-        CataCamera::Parameters params = camera->getParameters();
-        params.cameraName() = cameraName;
-        params.imageWidth() = imageSize.width;
-        params.imageHeight() = imageSize.height;
-        camera->setParameters(params);
-        return camera;
+      CataCamera::Parameters params = camera->getParameters();
+      params.cameraName() = cameraName;
+      params.imageWidth() = imageSize.width;
+      params.imageHeight() = imageSize.height;
+      camera->setParameters(params);
+      return camera;
     }
-    }
+  }
 }
 
-CameraPtr
-CameraFactory::generateCameraFromYamlFile(const std::string& filename)
-{
-    cv::FileStorage fs(filename, cv::FileStorage::READ);
+CameraPtr CameraFactory::generateCameraFromYamlFile(const std::string& filename) {
+  cv::FileStorage fs(filename, cv::FileStorage::READ);
 
-    if (!fs.isOpened())
-    {
-        return CameraPtr();
-    }
-
-    Camera::ModelType modelType = Camera::MEI;
-    if (!fs["model_type"].isNone())
-    {
-        std::string sModelType;
-        fs["model_type"] >> sModelType;
-
-        if (boost::iequals(sModelType, "kannala_brandt"))
-        {
-            modelType = Camera::KANNALA_BRANDT;
-        }
-        else if (boost::iequals(sModelType, "mei"))
-        {
-            modelType = Camera::MEI;
-        }
-        else if (boost::iequals(sModelType, "scaramuzza"))
-        {
-            modelType = Camera::SCARAMUZZA;
-        }
-        else if (boost::iequals(sModelType, "pinhole"))
-        {
-            modelType = Camera::PINHOLE;
-        }
-        else
-        {
-            std::cerr << "# ERROR: Unknown camera model: " << sModelType << std::endl;
-            return CameraPtr();
-        }
-    }
-
-    switch (modelType)
-    {
-    case Camera::KANNALA_BRANDT:
-    {
-        EquidistantCameraPtr camera(new EquidistantCamera);
-
-        EquidistantCamera::Parameters params = camera->getParameters();
-        params.readFromYamlFile(filename);
-        camera->setParameters(params);
-        return camera;
-    }
-    case Camera::PINHOLE:
-    {
-        PinholeCameraPtr camera(new PinholeCamera);
-
-        PinholeCamera::Parameters params = camera->getParameters();
-        params.readFromYamlFile(filename);
-        camera->setParameters(params);
-        return camera;
-    }
-    case Camera::SCARAMUZZA:
-    {
-        OCAMCameraPtr camera(new OCAMCamera);
-
-        OCAMCamera::Parameters params = camera->getParameters();
-        params.readFromYamlFile(filename);
-        camera->setParameters(params);
-        return camera;
-    }
-    case Camera::MEI:
-    default:
-    {
-        CataCameraPtr camera(new CataCamera);
-
-        CataCamera::Parameters params = camera->getParameters();
-        params.readFromYamlFile(filename);
-        camera->setParameters(params);
-        return camera;
-    }
-    }
-
+  if (!fs.isOpened()) {
     return CameraPtr();
+  }
+
+  Camera::ModelType modelType = Camera::MEI;
+  if (!fs["model_type"].isNone()) {
+    std::string sModelType;
+    fs["model_type"] >> sModelType;
+
+    if (boost::iequals(sModelType, "kannala_brandt")) {
+      modelType = Camera::KANNALA_BRANDT;
+    } else if (boost::iequals(sModelType, "mei")) {
+      modelType = Camera::MEI;
+    } else if (boost::iequals(sModelType, "scaramuzza")) {
+      modelType = Camera::SCARAMUZZA;
+    } else if (boost::iequals(sModelType, "pinhole")) {
+      modelType = Camera::PINHOLE;
+    } else {
+      std::cerr << "# ERROR: Unknown camera model: " << sModelType << std::endl;
+      return CameraPtr();
+    }
+  }
+
+  switch (modelType) {
+    case Camera::KANNALA_BRANDT: {
+      EquidistantCameraPtr camera(new EquidistantCamera);
+
+      EquidistantCamera::Parameters params = camera->getParameters();
+      params.readFromYamlFile(filename);
+      camera->setParameters(params);
+      return camera;
+    }
+    case Camera::PINHOLE: {
+      PinholeCameraPtr camera(new PinholeCamera);
+
+      PinholeCamera::Parameters params = camera->getParameters();
+      params.readFromYamlFile(filename);
+      camera->setParameters(params);
+      return camera;
+    }
+    case Camera::SCARAMUZZA: {
+      OCAMCameraPtr camera(new OCAMCamera);
+
+      OCAMCamera::Parameters params = camera->getParameters();
+      params.readFromYamlFile(filename);
+      camera->setParameters(params);
+      return camera;
+    }
+    case Camera::MEI:
+    default: {
+      CataCameraPtr camera(new CataCamera);
+
+      CataCamera::Parameters params = camera->getParameters();
+      params.readFromYamlFile(filename);
+      camera->setParameters(params);
+      return camera;
+    }
+  }
+
+  return CameraPtr();
 }
 
-}
-
+}  // namespace camodocal

--- a/src/frontend/camodocal/camera_models/CataCamera.cc
+++ b/src/frontend/camodocal/camera_models/CataCamera.cc
@@ -11,651 +11,475 @@
 
 #include "frontend/camodocal/gpl/gpl.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
 CataCamera::Parameters::Parameters()
- : Camera::Parameters(MEI)
- , m_xi(0.0)
- , m_k1(0.0)
- , m_k2(0.0)
- , m_p1(0.0)
- , m_p2(0.0)
- , m_gamma1(0.0)
- , m_gamma2(0.0)
- , m_u0(0.0)
- , m_v0(0.0)
-{
+    : Camera::Parameters(MEI),
+      m_xi(0.0),
+      m_k1(0.0),
+      m_k2(0.0),
+      m_p1(0.0),
+      m_p2(0.0),
+      m_gamma1(0.0),
+      m_gamma2(0.0),
+      m_u0(0.0),
+      m_v0(0.0) {}
 
-}
+CataCamera::Parameters::Parameters(const std::string& cameraName, int w, int h, double xi,
+                                   double k1, double k2, double p1, double p2, double gamma1,
+                                   double gamma2, double u0, double v0)
+    : Camera::Parameters(MEI, cameraName, w, h),
+      m_xi(xi),
+      m_k1(k1),
+      m_k2(k2),
+      m_p1(p1),
+      m_p2(p2),
+      m_gamma1(gamma1),
+      m_gamma2(gamma2),
+      m_u0(u0),
+      m_v0(v0) {}
 
-CataCamera::Parameters::Parameters(const std::string& cameraName,
-                                   int w, int h,
-                                   double xi,
-                                   double k1, double k2,
-                                   double p1, double p2,
-                                   double gamma1, double gamma2,
-                                   double u0, double v0)
- : Camera::Parameters(MEI, cameraName, w, h)
- , m_xi(xi)
- , m_k1(k1)
- , m_k2(k2)
- , m_p1(p1)
- , m_p2(p2)
- , m_gamma1(gamma1)
- , m_gamma2(gamma2)
- , m_u0(u0)
- , m_v0(v0)
-{
-}
+double& CataCamera::Parameters::xi(void) { return m_xi; }
 
-double&
-CataCamera::Parameters::xi(void)
-{
-    return m_xi;
-}
+double& CataCamera::Parameters::k1(void) { return m_k1; }
 
-double&
-CataCamera::Parameters::k1(void)
-{
-    return m_k1;
-}
+double& CataCamera::Parameters::k2(void) { return m_k2; }
 
-double&
-CataCamera::Parameters::k2(void)
-{
-    return m_k2;
-}
+double& CataCamera::Parameters::p1(void) { return m_p1; }
 
-double&
-CataCamera::Parameters::p1(void)
-{
-    return m_p1;
-}
+double& CataCamera::Parameters::p2(void) { return m_p2; }
 
-double&
-CataCamera::Parameters::p2(void)
-{
-    return m_p2;
-}
+double& CataCamera::Parameters::gamma1(void) { return m_gamma1; }
 
-double&
-CataCamera::Parameters::gamma1(void)
-{
-    return m_gamma1;
-}
+double& CataCamera::Parameters::gamma2(void) { return m_gamma2; }
 
-double&
-CataCamera::Parameters::gamma2(void)
-{
-    return m_gamma2;
-}
+double& CataCamera::Parameters::u0(void) { return m_u0; }
 
-double&
-CataCamera::Parameters::u0(void)
-{
-    return m_u0;
-}
+double& CataCamera::Parameters::v0(void) { return m_v0; }
 
-double&
-CataCamera::Parameters::v0(void)
-{
-    return m_v0;
-}
+double CataCamera::Parameters::xi(void) const { return m_xi; }
 
-double
-CataCamera::Parameters::xi(void) const
-{
-    return m_xi;
-}
+double CataCamera::Parameters::k1(void) const { return m_k1; }
 
-double
-CataCamera::Parameters::k1(void) const
-{
-    return m_k1;
-}
+double CataCamera::Parameters::k2(void) const { return m_k2; }
 
-double
-CataCamera::Parameters::k2(void) const
-{
-    return m_k2;
-}
+double CataCamera::Parameters::p1(void) const { return m_p1; }
 
-double
-CataCamera::Parameters::p1(void) const
-{
-    return m_p1;
-}
+double CataCamera::Parameters::p2(void) const { return m_p2; }
 
-double
-CataCamera::Parameters::p2(void) const
-{
-    return m_p2;
-}
+double CataCamera::Parameters::gamma1(void) const { return m_gamma1; }
 
-double
-CataCamera::Parameters::gamma1(void) const
-{
-    return m_gamma1;
-}
+double CataCamera::Parameters::gamma2(void) const { return m_gamma2; }
 
-double
-CataCamera::Parameters::gamma2(void) const
-{
-    return m_gamma2;
-}
+double CataCamera::Parameters::u0(void) const { return m_u0; }
 
-double
-CataCamera::Parameters::u0(void) const
-{
-    return m_u0;
-}
+double CataCamera::Parameters::v0(void) const { return m_v0; }
 
-double
-CataCamera::Parameters::v0(void) const
-{
-    return m_v0;
-}
+bool CataCamera::Parameters::readFromYamlFile(const std::string& filename) {
+  cv::FileStorage fs(filename, cv::FileStorage::READ);
 
-bool
-CataCamera::Parameters::readFromYamlFile(const std::string& filename)
-{
-    cv::FileStorage fs(filename, cv::FileStorage::READ);
+  if (!fs.isOpened()) {
+    return false;
+  }
 
-    if (!fs.isOpened())
-    {
-        return false;
+  if (!fs["model_type"].isNone()) {
+    std::string sModelType;
+    fs["model_type"] >> sModelType;
+
+    if (sModelType.compare("MEI") != 0) {
+      return false;
     }
+  }
 
-    if (!fs["model_type"].isNone())
-    {
-        std::string sModelType;
-        fs["model_type"] >> sModelType;
+  m_modelType = MEI;
+  fs["camera_name"] >> m_cameraName;
+  m_imageWidth = static_cast<int>(fs["image_width"]);
+  m_imageHeight = static_cast<int>(fs["image_height"]);
 
-        if (sModelType.compare("MEI") != 0)
-        {
-            return false;
-        }
-    }
+  cv::FileNode n = fs["mirror_parameters"];
+  m_xi = static_cast<double>(n["xi"]);
 
-    m_modelType = MEI;
-    fs["camera_name"] >> m_cameraName;
-    m_imageWidth = static_cast<int>(fs["image_width"]);
-    m_imageHeight = static_cast<int>(fs["image_height"]);
+  n = fs["distortion_parameters"];
+  m_k1 = static_cast<double>(n["k1"]);
+  m_k2 = static_cast<double>(n["k2"]);
+  m_p1 = static_cast<double>(n["p1"]);
+  m_p2 = static_cast<double>(n["p2"]);
 
-    cv::FileNode n = fs["mirror_parameters"];
-    m_xi = static_cast<double>(n["xi"]);
+  n = fs["projection_parameters"];
+  m_gamma1 = static_cast<double>(n["gamma1"]);
+  m_gamma2 = static_cast<double>(n["gamma2"]);
+  m_u0 = static_cast<double>(n["u0"]);
+  m_v0 = static_cast<double>(n["v0"]);
 
-    n = fs["distortion_parameters"];
-    m_k1 = static_cast<double>(n["k1"]);
-    m_k2 = static_cast<double>(n["k2"]);
-    m_p1 = static_cast<double>(n["p1"]);
-    m_p2 = static_cast<double>(n["p2"]);
-
-    n = fs["projection_parameters"];
-    m_gamma1 = static_cast<double>(n["gamma1"]);
-    m_gamma2 = static_cast<double>(n["gamma2"]);
-    m_u0 = static_cast<double>(n["u0"]);
-    m_v0 = static_cast<double>(n["v0"]);
-
-    return true;
+  return true;
 }
 
-void
-CataCamera::Parameters::writeToYamlFile(const std::string& filename) const
-{
-    cv::FileStorage fs(filename, cv::FileStorage::WRITE);
+void CataCamera::Parameters::writeToYamlFile(const std::string& filename) const {
+  cv::FileStorage fs(filename, cv::FileStorage::WRITE);
 
-    fs << "model_type" << "MEI";
-    fs << "camera_name" << m_cameraName;
-    fs << "image_width" << m_imageWidth;
-    fs << "image_height" << m_imageHeight;
+  fs << "model_type" << "MEI";
+  fs << "camera_name" << m_cameraName;
+  fs << "image_width" << m_imageWidth;
+  fs << "image_height" << m_imageHeight;
 
-    // mirror: xi
-    fs << "mirror_parameters";
-    fs << "{" << "xi" << m_xi << "}";
+  // mirror: xi
+  fs << "mirror_parameters";
+  fs << "{" << "xi" << m_xi << "}";
 
-    // radial distortion: k1, k2
-    // tangential distortion: p1, p2
-    fs << "distortion_parameters";
-    fs << "{" << "k1" << m_k1
-              << "k2" << m_k2
-              << "p1" << m_p1
-              << "p2" << m_p2 << "}";
+  // radial distortion: k1, k2
+  // tangential distortion: p1, p2
+  fs << "distortion_parameters";
+  fs << "{" << "k1" << m_k1 << "k2" << m_k2 << "p1" << m_p1 << "p2" << m_p2 << "}";
 
-    // projection: gamma1, gamma2, u0, v0
-    fs << "projection_parameters";
-    fs << "{" << "gamma1" << m_gamma1
-              << "gamma2" << m_gamma2
-              << "u0" << m_u0
-              << "v0" << m_v0 << "}";
+  // projection: gamma1, gamma2, u0, v0
+  fs << "projection_parameters";
+  fs << "{" << "gamma1" << m_gamma1 << "gamma2" << m_gamma2 << "u0" << m_u0 << "v0" << m_v0 << "}";
 
-    fs.release();
+  fs.release();
 }
 
-CataCamera::Parameters&
-CataCamera::Parameters::operator=(const CataCamera::Parameters& other)
-{
-    if (this != &other)
-    {
-        m_modelType = other.m_modelType;
-        m_cameraName = other.m_cameraName;
-        m_imageWidth = other.m_imageWidth;
-        m_imageHeight = other.m_imageHeight;
-        m_xi = other.m_xi;
-        m_k1 = other.m_k1;
-        m_k2 = other.m_k2;
-        m_p1 = other.m_p1;
-        m_p2 = other.m_p2;
-        m_gamma1 = other.m_gamma1;
-        m_gamma2 = other.m_gamma2;
-        m_u0 = other.m_u0;
-        m_v0 = other.m_v0;
-    }
+CataCamera::Parameters& CataCamera::Parameters::operator=(const CataCamera::Parameters& other) {
+  if (this != &other) {
+    m_modelType = other.m_modelType;
+    m_cameraName = other.m_cameraName;
+    m_imageWidth = other.m_imageWidth;
+    m_imageHeight = other.m_imageHeight;
+    m_xi = other.m_xi;
+    m_k1 = other.m_k1;
+    m_k2 = other.m_k2;
+    m_p1 = other.m_p1;
+    m_p2 = other.m_p2;
+    m_gamma1 = other.m_gamma1;
+    m_gamma2 = other.m_gamma2;
+    m_u0 = other.m_u0;
+    m_v0 = other.m_v0;
+  }
 
-    return *this;
+  return *this;
 }
 
-std::ostream&
-operator<< (std::ostream& out, const CataCamera::Parameters& params)
-{
-    out << "Camera Parameters:" << std::endl;
-    out << "    model_type " << "MEI" << std::endl;
-    out << "   camera_name " << params.m_cameraName << std::endl;
-    out << "   image_width " << params.m_imageWidth << std::endl;
-    out << "  image_height " << params.m_imageHeight << std::endl;
+std::ostream& operator<<(std::ostream& out, const CataCamera::Parameters& params) {
+  out << "Camera Parameters:" << std::endl;
+  out << "    model_type " << "MEI" << std::endl;
+  out << "   camera_name " << params.m_cameraName << std::endl;
+  out << "   image_width " << params.m_imageWidth << std::endl;
+  out << "  image_height " << params.m_imageHeight << std::endl;
 
-    out << "Mirror Parameters" << std::endl;
-    out << std::fixed << std::setprecision(10);
-    out << "            xi " << params.m_xi << std::endl;
+  out << "Mirror Parameters" << std::endl;
+  out << std::fixed << std::setprecision(10);
+  out << "            xi " << params.m_xi << std::endl;
 
-    // radial distortion: k1, k2
-    // tangential distortion: p1, p2
-    out << "Distortion Parameters" << std::endl;
-    out << "            k1 " << params.m_k1 << std::endl
-        << "            k2 " << params.m_k2 << std::endl
-        << "            p1 " << params.m_p1 << std::endl
-        << "            p2 " << params.m_p2 << std::endl;
+  // radial distortion: k1, k2
+  // tangential distortion: p1, p2
+  out << "Distortion Parameters" << std::endl;
+  out << "            k1 " << params.m_k1 << std::endl
+      << "            k2 " << params.m_k2 << std::endl
+      << "            p1 " << params.m_p1 << std::endl
+      << "            p2 " << params.m_p2 << std::endl;
 
-    // projection: gamma1, gamma2, u0, v0
-    out << "Projection Parameters" << std::endl;
-    out << "        gamma1 " << params.m_gamma1 << std::endl
-        << "        gamma2 " << params.m_gamma2 << std::endl
-        << "            u0 " << params.m_u0 << std::endl
-        << "            v0 " << params.m_v0 << std::endl;
+  // projection: gamma1, gamma2, u0, v0
+  out << "Projection Parameters" << std::endl;
+  out << "        gamma1 " << params.m_gamma1 << std::endl
+      << "        gamma2 " << params.m_gamma2 << std::endl
+      << "            u0 " << params.m_u0 << std::endl
+      << "            v0 " << params.m_v0 << std::endl;
 
-    return out;
+  return out;
 }
 
 CataCamera::CataCamera()
- : m_inv_K11(1.0)
- , m_inv_K13(0.0)
- , m_inv_K22(1.0)
- , m_inv_K23(0.0)
- , m_noDistortion(true)
-{
+    : m_inv_K11(1.0), m_inv_K13(0.0), m_inv_K22(1.0), m_inv_K23(0.0), m_noDistortion(true) {}
 
+CataCamera::CataCamera(const std::string& cameraName, int imageWidth, int imageHeight, double xi,
+                       double k1, double k2, double p1, double p2, double gamma1, double gamma2,
+                       double u0, double v0)
+    : mParameters(cameraName, imageWidth, imageHeight, xi, k1, k2, p1, p2, gamma1, gamma2, u0, v0) {
+  if ((mParameters.k1() == 0.0) && (mParameters.k2() == 0.0) && (mParameters.p1() == 0.0) &&
+      (mParameters.p2() == 0.0)) {
+    m_noDistortion = true;
+  } else {
+    m_noDistortion = false;
+  }
+
+  // Inverse camera projection matrix parameters
+  m_inv_K11 = 1.0 / mParameters.gamma1();
+  m_inv_K13 = -mParameters.u0() / mParameters.gamma1();
+  m_inv_K22 = 1.0 / mParameters.gamma2();
+  m_inv_K23 = -mParameters.v0() / mParameters.gamma2();
 }
 
-CataCamera::CataCamera(const std::string& cameraName,
-                       int imageWidth, int imageHeight,
-                       double xi, double k1, double k2, double p1, double p2,
-                       double gamma1, double gamma2, double u0, double v0)
- : mParameters(cameraName, imageWidth, imageHeight,
-               xi, k1, k2, p1, p2, gamma1, gamma2, u0, v0)
-{
-    if ((mParameters.k1() == 0.0) &&
-        (mParameters.k2() == 0.0) &&
-        (mParameters.p1() == 0.0) &&
-        (mParameters.p2() == 0.0))
-    {
-        m_noDistortion = true;
+CataCamera::CataCamera(const CataCamera::Parameters& params) : mParameters(params) {
+  if ((mParameters.k1() == 0.0) && (mParameters.k2() == 0.0) && (mParameters.p1() == 0.0) &&
+      (mParameters.p2() == 0.0)) {
+    m_noDistortion = true;
+  } else {
+    m_noDistortion = false;
+  }
+
+  // Inverse camera projection matrix parameters
+  m_inv_K11 = 1.0 / mParameters.gamma1();
+  m_inv_K13 = -mParameters.u0() / mParameters.gamma1();
+  m_inv_K22 = 1.0 / mParameters.gamma2();
+  m_inv_K23 = -mParameters.v0() / mParameters.gamma2();
+}
+
+Camera::ModelType CataCamera::modelType(void) const { return mParameters.modelType(); }
+
+const std::string& CataCamera::cameraName(void) const { return mParameters.cameraName(); }
+
+int CataCamera::imageWidth(void) const { return mParameters.imageWidth(); }
+
+int CataCamera::imageHeight(void) const { return mParameters.imageHeight(); }
+
+void CataCamera::estimateIntrinsics(const cv::Size& boardSize,
+                                    const std::vector<std::vector<cv::Point3f> >& objectPoints,
+                                    const std::vector<std::vector<cv::Point2f> >& imagePoints) {
+  Parameters params = getParameters();
+
+  double u0 = params.imageWidth() / 2.0;
+  double v0 = params.imageHeight() / 2.0;
+
+  double gamma0 = 0.0;
+  double minReprojErr = std::numeric_limits<double>::max();
+
+  std::vector<cv::Mat> rvecs, tvecs;
+  rvecs.assign(objectPoints.size(), cv::Mat());
+  tvecs.assign(objectPoints.size(), cv::Mat());
+
+  params.xi() = 1.0;
+  params.k1() = 0.0;
+  params.k2() = 0.0;
+  params.p1() = 0.0;
+  params.p2() = 0.0;
+  params.u0() = u0;
+  params.v0() = v0;
+
+  // Initialize gamma (focal length)
+  // Use non-radial line image and xi = 1
+  for (size_t i = 0; i < imagePoints.size(); ++i) {
+    for (int r = 0; r < boardSize.height; ++r) {
+      cv::Mat P(boardSize.width, 4, CV_64F);
+      for (int c = 0; c < boardSize.width; ++c) {
+        const cv::Point2f& imagePoint = imagePoints.at(i).at(r * boardSize.width + c);
+
+        double u = imagePoint.x - u0;
+        double v = imagePoint.y - v0;
+
+        P.at<double>(c, 0) = u;
+        P.at<double>(c, 1) = v;
+        P.at<double>(c, 2) = 0.5;
+        P.at<double>(c, 3) = -0.5 * (square(u) + square(v));
+      }
+
+      cv::Mat C;
+      cv::SVD::solveZ(P, C);
+
+      double t =
+          square(C.at<double>(0)) + square(C.at<double>(1)) + C.at<double>(2) * C.at<double>(3);
+      if (t < 0.0) {
+        continue;
+      }
+
+      // check that line image is not radial
+      double d = sqrt(1.0 / t);
+      double nx = C.at<double>(0) * d;
+      double ny = C.at<double>(1) * d;
+      if (hypot(nx, ny) > 0.95) {
+        continue;
+      }
+
+      double gamma = sqrt(C.at<double>(2) / C.at<double>(3));
+
+      params.gamma1() = gamma;
+      params.gamma2() = gamma;
+      setParameters(params);
+
+      for (size_t j = 0; j < objectPoints.size(); ++j) {
+        estimateExtrinsics(objectPoints.at(j), imagePoints.at(j), rvecs.at(j), tvecs.at(j));
+      }
+
+      double reprojErr = reprojectionError(objectPoints, imagePoints, rvecs, tvecs, cv::noArray());
+
+      if (reprojErr < minReprojErr) {
+        minReprojErr = reprojErr;
+        gamma0 = gamma;
+      }
     }
-    else
-    {
-        m_noDistortion = false;
-    }
+  }
 
-    // Inverse camera projection matrix parameters
-    m_inv_K11 = 1.0 / mParameters.gamma1();
-    m_inv_K13 = -mParameters.u0() / mParameters.gamma1();
-    m_inv_K22 = 1.0 / mParameters.gamma2();
-    m_inv_K23 = -mParameters.v0() / mParameters.gamma2();
+  if (gamma0 <= 0.0 && minReprojErr >= std::numeric_limits<double>::max()) {
+    std::cout << "[" << params.cameraName() << "] "
+              << "# INFO: CataCamera model fails with given data. " << std::endl;
+
+    return;
+  }
+
+  params.gamma1() = gamma0;
+  params.gamma2() = gamma0;
+  setParameters(params);
 }
 
-CataCamera::CataCamera(const CataCamera::Parameters& params)
- : mParameters(params)
-{
-    if ((mParameters.k1() == 0.0) &&
-        (mParameters.k2() == 0.0) &&
-        (mParameters.p1() == 0.0) &&
-        (mParameters.p2() == 0.0))
-    {
-        m_noDistortion = true;
-    }
-    else
-    {
-        m_noDistortion = false;
-    }
-
-    // Inverse camera projection matrix parameters
-    m_inv_K11 = 1.0 / mParameters.gamma1();
-    m_inv_K13 = -mParameters.u0() / mParameters.gamma1();
-    m_inv_K22 = 1.0 / mParameters.gamma2();
-    m_inv_K23 = -mParameters.v0() / mParameters.gamma2();
-}
-
-Camera::ModelType
-CataCamera::modelType(void) const
-{
-    return mParameters.modelType();
-}
-
-const std::string&
-CataCamera::cameraName(void) const
-{
-    return mParameters.cameraName();
-}
-
-int
-CataCamera::imageWidth(void) const
-{
-    return mParameters.imageWidth();
-}
-
-int
-CataCamera::imageHeight(void) const
-{
-    return mParameters.imageHeight();
-}
-
-void
-CataCamera::estimateIntrinsics(const cv::Size& boardSize,
-                               const std::vector< std::vector<cv::Point3f> >& objectPoints,
-                               const std::vector< std::vector<cv::Point2f> >& imagePoints)
-{
-    Parameters params = getParameters();
-
-    double u0 = params.imageWidth() / 2.0;
-    double v0 = params.imageHeight() / 2.0;
-
-    double gamma0 = 0.0;
-    double minReprojErr = std::numeric_limits<double>::max();
-
-    std::vector<cv::Mat> rvecs, tvecs;
-    rvecs.assign(objectPoints.size(), cv::Mat());
-    tvecs.assign(objectPoints.size(), cv::Mat());
-
-    params.xi() = 1.0;
-    params.k1() = 0.0;
-    params.k2() = 0.0;
-    params.p1() = 0.0;
-    params.p2() = 0.0;
-    params.u0() = u0;
-    params.v0() = v0;
-
-    // Initialize gamma (focal length)
-    // Use non-radial line image and xi = 1
-    for (size_t i = 0; i < imagePoints.size(); ++i)
-    {
-        for (int r = 0; r < boardSize.height; ++r)
-        {
-            cv::Mat P(boardSize.width, 4, CV_64F);
-            for (int c = 0; c < boardSize.width; ++c)
-            {
-                const cv::Point2f& imagePoint = imagePoints.at(i).at(r * boardSize.width + c);
-
-                double u = imagePoint.x - u0;
-                double v = imagePoint.y - v0;
-
-                P.at<double>(c, 0) = u;
-                P.at<double>(c, 1) = v;
-                P.at<double>(c, 2) = 0.5;
-                P.at<double>(c, 3) = -0.5 * (square(u) + square(v));
-            }
-
-            cv::Mat C;
-            cv::SVD::solveZ(P, C);
-
-            double t = square(C.at<double>(0)) + square(C.at<double>(1)) + C.at<double>(2) * C.at<double>(3);
-            if (t < 0.0)
-            {
-                continue;
-            }
-
-            // check that line image is not radial
-            double d = sqrt(1.0 / t);
-            double nx = C.at<double>(0) * d;
-            double ny = C.at<double>(1) * d;
-            if (hypot(nx, ny) > 0.95)
-            {
-                continue;
-            }
-
-            double gamma = sqrt(C.at<double>(2) / C.at<double>(3));
-
-            params.gamma1() = gamma;
-            params.gamma2() = gamma;
-            setParameters(params);
-
-            for (size_t j = 0; j < objectPoints.size(); ++j)
-            {
-                estimateExtrinsics(objectPoints.at(j), imagePoints.at(j), rvecs.at(j), tvecs.at(j));
-            }
-
-            double reprojErr = reprojectionError(objectPoints, imagePoints, rvecs, tvecs, cv::noArray());
-
-            if (reprojErr < minReprojErr)
-            {
-                minReprojErr = reprojErr;
-                gamma0 = gamma;
-            }
-        }
-    }
-
-    if (gamma0 <= 0.0 && minReprojErr >= std::numeric_limits<double>::max())
-    {
-        std::cout << "[" << params.cameraName() << "] "
-                  << "# INFO: CataCamera model fails with given data. " << std::endl;
-
-        return;
-    }
-
-    params.gamma1() = gamma0;
-    params.gamma2() = gamma0;
-    setParameters(params);
-}
-
-/** 
+/**
  * \brief Lifts a point from the image plane to the unit sphere
  *
  * \param p image coordinates
  * \param P coordinates of the point on the sphere
  */
-void
-CataCamera::liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const
-{
-    double mx_d, my_d,mx2_d, mxy_d, my2_d, mx_u, my_u;
-    double rho2_d, rho4_d, radDist_d, Dx_d, Dy_d, inv_denom_d;
-    double lambda;
+void CataCamera::liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const {
+  double mx_d, my_d, mx2_d, mxy_d, my2_d, mx_u, my_u;
+  double rho2_d, rho4_d, radDist_d, Dx_d, Dy_d, inv_denom_d;
+  double lambda;
 
-    // Lift points to normalised plane
-    mx_d = m_inv_K11 * p(0) + m_inv_K13;
-    my_d = m_inv_K22 * p(1) + m_inv_K23;
+  // Lift points to normalised plane
+  mx_d = m_inv_K11 * p(0) + m_inv_K13;
+  my_d = m_inv_K22 * p(1) + m_inv_K23;
 
-    if (m_noDistortion)
-    {
-        mx_u = mx_d;
-        my_u = my_d;
+  if (m_noDistortion) {
+    mx_u = mx_d;
+    my_u = my_d;
+  } else {
+    // Apply inverse distortion model
+    if (0) {
+      double k1 = mParameters.k1();
+      double k2 = mParameters.k2();
+      double p1 = mParameters.p1();
+      double p2 = mParameters.p2();
+
+      // Inverse distortion model
+      // proposed by Heikkila
+      mx2_d = mx_d * mx_d;
+      my2_d = my_d * my_d;
+      mxy_d = mx_d * my_d;
+      rho2_d = mx2_d + my2_d;
+      rho4_d = rho2_d * rho2_d;
+      radDist_d = k1 * rho2_d + k2 * rho4_d;
+      Dx_d = mx_d * radDist_d + p2 * (rho2_d + 2 * mx2_d) + 2 * p1 * mxy_d;
+      Dy_d = my_d * radDist_d + p1 * (rho2_d + 2 * my2_d) + 2 * p2 * mxy_d;
+      inv_denom_d = 1 / (1 + 4 * k1 * rho2_d + 6 * k2 * rho4_d + 8 * p1 * my_d + 8 * p2 * mx_d);
+
+      mx_u = mx_d - inv_denom_d * Dx_d;
+      my_u = my_d - inv_denom_d * Dy_d;
+    } else {
+      // Recursive distortion model
+      int n = 6;
+      Eigen::Vector2d d_u;
+      distortion(Eigen::Vector2d(mx_d, my_d), d_u);
+      // Approximate value
+      mx_u = mx_d - d_u(0);
+      my_u = my_d - d_u(1);
+
+      for (int i = 1; i < n; ++i) {
+        distortion(Eigen::Vector2d(mx_u, my_u), d_u);
+        mx_u = mx_d - d_u(0);
+        my_u = my_d - d_u(1);
+      }
     }
-    else
-    {
-        // Apply inverse distortion model
-        if (0)
-        {
-            double k1 = mParameters.k1();
-            double k2 = mParameters.k2();
-            double p1 = mParameters.p1();
-            double p2 = mParameters.p2();
+  }
 
-            // Inverse distortion model
-            // proposed by Heikkila
-            mx2_d = mx_d*mx_d;
-            my2_d = my_d*my_d;
-            mxy_d = mx_d*my_d;
-            rho2_d = mx2_d+my2_d;
-            rho4_d = rho2_d*rho2_d;
-            radDist_d = k1*rho2_d+k2*rho4_d;
-            Dx_d = mx_d*radDist_d + p2*(rho2_d+2*mx2_d) + 2*p1*mxy_d;
-            Dy_d = my_d*radDist_d + p1*(rho2_d+2*my2_d) + 2*p2*mxy_d;
-            inv_denom_d = 1/(1+4*k1*rho2_d+6*k2*rho4_d+8*p1*my_d+8*p2*mx_d);
-
-            mx_u = mx_d - inv_denom_d*Dx_d;
-            my_u = my_d - inv_denom_d*Dy_d;
-        }
-        else
-        {
-            // Recursive distortion model
-            int n = 6;
-            Eigen::Vector2d d_u;
-            distortion(Eigen::Vector2d(mx_d, my_d), d_u);
-            // Approximate value
-            mx_u = mx_d - d_u(0);
-            my_u = my_d - d_u(1);
-
-            for (int i = 1; i < n; ++i)
-            {
-                distortion(Eigen::Vector2d(mx_u, my_u), d_u);
-                mx_u = mx_d - d_u(0);
-                my_u = my_d - d_u(1);
-            }
-        }
-    }
-
-    // Lift normalised points to the sphere (inv_hslash)
-    double xi = mParameters.xi();
-    if (xi == 1.0)
-    {
-        lambda = 2.0 / (mx_u * mx_u + my_u * my_u + 1.0);
-        P << lambda * mx_u, lambda * my_u, lambda - 1.0;
-    }
-    else
-    {
-        lambda = (xi + sqrt(1.0 + (1.0 - xi * xi) * (mx_u * mx_u + my_u * my_u))) / (1.0 + mx_u * mx_u + my_u * my_u);
-        P << lambda * mx_u, lambda * my_u, lambda - xi;
-    }
+  // Lift normalised points to the sphere (inv_hslash)
+  double xi = mParameters.xi();
+  if (xi == 1.0) {
+    lambda = 2.0 / (mx_u * mx_u + my_u * my_u + 1.0);
+    P << lambda * mx_u, lambda * my_u, lambda - 1.0;
+  } else {
+    lambda = (xi + sqrt(1.0 + (1.0 - xi * xi) * (mx_u * mx_u + my_u * my_u))) /
+             (1.0 + mx_u * mx_u + my_u * my_u);
+    P << lambda * mx_u, lambda * my_u, lambda - xi;
+  }
 }
 
-/** 
+/**
  * \brief Lifts a point from the image plane to its projective ray
  *
  * \param p image coordinates
  * \param P coordinates of the projective ray
  */
-void
-CataCamera::liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const
-{
-    double mx_d, my_d,mx2_d, mxy_d, my2_d, mx_u, my_u;
-    double rho2_d, rho4_d, radDist_d, Dx_d, Dy_d, inv_denom_d;
-    //double lambda;
+void CataCamera::liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const {
+  double mx_d, my_d, mx2_d, mxy_d, my2_d, mx_u, my_u;
+  double rho2_d, rho4_d, radDist_d, Dx_d, Dy_d, inv_denom_d;
+  // double lambda;
 
-    // Lift points to normalised plane
-    mx_d = m_inv_K11 * p(0) + m_inv_K13;
-    my_d = m_inv_K22 * p(1) + m_inv_K23;
+  // Lift points to normalised plane
+  mx_d = m_inv_K11 * p(0) + m_inv_K13;
+  my_d = m_inv_K22 * p(1) + m_inv_K23;
 
-    if (m_noDistortion)
-    {
-        mx_u = mx_d;
-        my_u = my_d;
+  if (m_noDistortion) {
+    mx_u = mx_d;
+    my_u = my_d;
+  } else {
+    if (0) {
+      double k1 = mParameters.k1();
+      double k2 = mParameters.k2();
+      double p1 = mParameters.p1();
+      double p2 = mParameters.p2();
+
+      // Apply inverse distortion model
+      // proposed by Heikkila
+      mx2_d = mx_d * mx_d;
+      my2_d = my_d * my_d;
+      mxy_d = mx_d * my_d;
+      rho2_d = mx2_d + my2_d;
+      rho4_d = rho2_d * rho2_d;
+      radDist_d = k1 * rho2_d + k2 * rho4_d;
+      Dx_d = mx_d * radDist_d + p2 * (rho2_d + 2 * mx2_d) + 2 * p1 * mxy_d;
+      Dy_d = my_d * radDist_d + p1 * (rho2_d + 2 * my2_d) + 2 * p2 * mxy_d;
+      inv_denom_d = 1 / (1 + 4 * k1 * rho2_d + 6 * k2 * rho4_d + 8 * p1 * my_d + 8 * p2 * mx_d);
+
+      mx_u = mx_d - inv_denom_d * Dx_d;
+      my_u = my_d - inv_denom_d * Dy_d;
+    } else {
+      // Recursive distortion model
+      int n = 8;
+      Eigen::Vector2d d_u;
+      distortion(Eigen::Vector2d(mx_d, my_d), d_u);
+      // Approximate value
+      mx_u = mx_d - d_u(0);
+      my_u = my_d - d_u(1);
+
+      for (int i = 1; i < n; ++i) {
+        distortion(Eigen::Vector2d(mx_u, my_u), d_u);
+        mx_u = mx_d - d_u(0);
+        my_u = my_d - d_u(1);
+      }
     }
-    else
-    {
-        if (0)
-        {
-            double k1 = mParameters.k1();
-            double k2 = mParameters.k2();
-            double p1 = mParameters.p1();
-            double p2 = mParameters.p2();
+  }
 
-            // Apply inverse distortion model
-            // proposed by Heikkila
-            mx2_d = mx_d*mx_d;
-            my2_d = my_d*my_d;
-            mxy_d = mx_d*my_d;
-            rho2_d = mx2_d+my2_d;
-            rho4_d = rho2_d*rho2_d;
-            radDist_d = k1*rho2_d+k2*rho4_d;
-            Dx_d = mx_d*radDist_d + p2*(rho2_d+2*mx2_d) + 2*p1*mxy_d;
-            Dy_d = my_d*radDist_d + p1*(rho2_d+2*my2_d) + 2*p2*mxy_d;
-            inv_denom_d = 1/(1+4*k1*rho2_d+6*k2*rho4_d+8*p1*my_d+8*p2*mx_d);
-
-            mx_u = mx_d - inv_denom_d*Dx_d;
-            my_u = my_d - inv_denom_d*Dy_d;
-        }
-        else
-        {
-            // Recursive distortion model
-            int n = 8;
-            Eigen::Vector2d d_u;
-            distortion(Eigen::Vector2d(mx_d, my_d), d_u);
-            // Approximate value
-            mx_u = mx_d - d_u(0);
-            my_u = my_d - d_u(1);
-
-            for (int i = 1; i < n; ++i)
-            {
-                distortion(Eigen::Vector2d(mx_u, my_u), d_u);
-                mx_u = mx_d - d_u(0);
-                my_u = my_d - d_u(1);
-            }
-        }
-    }
-
-    // Obtain a projective ray
-    double xi = mParameters.xi();
-    if (xi == 1.0)
-    {
-        P << mx_u, my_u, (1.0 - mx_u * mx_u - my_u * my_u) / 2.0;
-    }
-    else
-    {
-        // Reuse variable
-        rho2_d = mx_u * mx_u + my_u * my_u;
-        P << mx_u, my_u, 1.0 - xi * (rho2_d + 1.0) / (xi + sqrt(1.0 + (1.0 - xi * xi) * rho2_d));
-    }
+  // Obtain a projective ray
+  double xi = mParameters.xi();
+  if (xi == 1.0) {
+    P << mx_u, my_u, (1.0 - mx_u * mx_u - my_u * my_u) / 2.0;
+  } else {
+    // Reuse variable
+    rho2_d = mx_u * mx_u + my_u * my_u;
+    P << mx_u, my_u, 1.0 - xi * (rho2_d + 1.0) / (xi + sqrt(1.0 + (1.0 - xi * xi) * rho2_d));
+  }
 }
 
-
-/** 
+/**
  * \brief Project a 3D point (\a x,\a y,\a z) to the image plane in (\a u,\a v)
  *
  * \param P 3D point coordinates
  * \param p return value, contains the image point coordinates
  */
-void
-CataCamera::spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const
-{
-    Eigen::Vector2d p_u, p_d;
+void CataCamera::spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const {
+  Eigen::Vector2d p_u, p_d;
 
-    // Project points to the normalised plane
-    double z = P(2) + mParameters.xi() * P.norm();
-    p_u << P(0) / z, P(1) / z;
+  // Project points to the normalised plane
+  double z = P(2) + mParameters.xi() * P.norm();
+  p_u << P(0) / z, P(1) / z;
 
-    if (m_noDistortion)
-    {
-        p_d = p_u;
-    }
-    else
-    {
-        // Apply distortion
-        Eigen::Vector2d d_u;
-        distortion(p_u, d_u);
-        p_d = p_u + d_u;
-    }
+  if (m_noDistortion) {
+    p_d = p_u;
+  } else {
+    // Apply distortion
+    Eigen::Vector2d d_u;
+    distortion(p_u, d_u);
+    p_d = p_u + d_u;
+  }
 
-    // Apply generalised projection matrix
-    p << mParameters.gamma1() * p_d(0) + mParameters.u0(),
-         mParameters.gamma2() * p_d(1) + mParameters.v0();
+  // Apply generalised projection matrix
+  p << mParameters.gamma1() * p_d(0) + mParameters.u0(),
+      mParameters.gamma2() * p_d(1) + mParameters.v0();
 }
 
 #if 0
@@ -728,278 +552,228 @@ CataCamera::spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p,
 }
 #endif
 
-/** 
+/**
  * \brief Projects an undistorted 2D point p_u to the image plane
  *
  * \param p_u 2D point coordinates
  * \return image point coordinates
  */
-void
-CataCamera::undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const
-{
-    Eigen::Vector2d p_d;
+void CataCamera::undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const {
+  Eigen::Vector2d p_d;
 
-    if (m_noDistortion)
-    {
-        p_d = p_u;
-    }
-    else
-    {
-        // Apply distortion
-        Eigen::Vector2d d_u;
-        distortion(p_u, d_u);
-        p_d = p_u + d_u;
-    }
+  if (m_noDistortion) {
+    p_d = p_u;
+  } else {
+    // Apply distortion
+    Eigen::Vector2d d_u;
+    distortion(p_u, d_u);
+    p_d = p_u + d_u;
+  }
 
-    // Apply generalised projection matrix
-    p << mParameters.gamma1() * p_d(0) + mParameters.u0(),
-         mParameters.gamma2() * p_d(1) + mParameters.v0();
+  // Apply generalised projection matrix
+  p << mParameters.gamma1() * p_d(0) + mParameters.u0(),
+      mParameters.gamma2() * p_d(1) + mParameters.v0();
 }
 
-/** 
+/**
  * \brief Apply distortion to input point (from the normalised plane)
- *  
+ *
  * \param p_u undistorted coordinates of point on the normalised plane
  * \return to obtain the distorted point: p_d = p_u + d_u
  */
-void
-CataCamera::distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u) const
-{
-    double k1 = mParameters.k1();
-    double k2 = mParameters.k2();
-    double p1 = mParameters.p1();
-    double p2 = mParameters.p2();
+void CataCamera::distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u) const {
+  double k1 = mParameters.k1();
+  double k2 = mParameters.k2();
+  double p1 = mParameters.p1();
+  double p2 = mParameters.p2();
 
-    double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
+  double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
 
-    mx2_u = p_u(0) * p_u(0);
-    my2_u = p_u(1) * p_u(1);
-    mxy_u = p_u(0) * p_u(1);
-    rho2_u = mx2_u + my2_u;
-    rad_dist_u = k1 * rho2_u + k2 * rho2_u * rho2_u;
-    d_u << p_u(0) * rad_dist_u + 2.0 * p1 * mxy_u + p2 * (rho2_u + 2.0 * mx2_u),
-           p_u(1) * rad_dist_u + 2.0 * p2 * mxy_u + p1 * (rho2_u + 2.0 * my2_u);
+  mx2_u = p_u(0) * p_u(0);
+  my2_u = p_u(1) * p_u(1);
+  mxy_u = p_u(0) * p_u(1);
+  rho2_u = mx2_u + my2_u;
+  rad_dist_u = k1 * rho2_u + k2 * rho2_u * rho2_u;
+  d_u << p_u(0) * rad_dist_u + 2.0 * p1 * mxy_u + p2 * (rho2_u + 2.0 * mx2_u),
+      p_u(1) * rad_dist_u + 2.0 * p2 * mxy_u + p1 * (rho2_u + 2.0 * my2_u);
 }
 
-/** 
+/**
  * \brief Apply distortion to input point (from the normalised plane)
  *        and calculate Jacobian
  *
  * \param p_u undistorted coordinates of point on the normalised plane
  * \return to obtain the distorted point: p_d = p_u + d_u
  */
-void
-CataCamera::distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u,
-                       Eigen::Matrix2d& J) const
-{
-    double k1 = mParameters.k1();
-    double k2 = mParameters.k2();
-    double p1 = mParameters.p1();
-    double p2 = mParameters.p2();
+void CataCamera::distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u,
+                            Eigen::Matrix2d& J) const {
+  double k1 = mParameters.k1();
+  double k2 = mParameters.k2();
+  double p1 = mParameters.p1();
+  double p2 = mParameters.p2();
 
-    double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
+  double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
 
-    mx2_u = p_u(0) * p_u(0);
-    my2_u = p_u(1) * p_u(1);
-    mxy_u = p_u(0) * p_u(1);
-    rho2_u = mx2_u + my2_u;
-    rad_dist_u = k1 * rho2_u + k2 * rho2_u * rho2_u;
-    d_u << p_u(0) * rad_dist_u + 2.0 * p1 * mxy_u + p2 * (rho2_u + 2.0 * mx2_u),
-           p_u(1) * rad_dist_u + 2.0 * p2 * mxy_u + p1 * (rho2_u + 2.0 * my2_u);
+  mx2_u = p_u(0) * p_u(0);
+  my2_u = p_u(1) * p_u(1);
+  mxy_u = p_u(0) * p_u(1);
+  rho2_u = mx2_u + my2_u;
+  rad_dist_u = k1 * rho2_u + k2 * rho2_u * rho2_u;
+  d_u << p_u(0) * rad_dist_u + 2.0 * p1 * mxy_u + p2 * (rho2_u + 2.0 * mx2_u),
+      p_u(1) * rad_dist_u + 2.0 * p2 * mxy_u + p1 * (rho2_u + 2.0 * my2_u);
 
-    double dxdmx = 1.0 + rad_dist_u + k1 * 2.0 * mx2_u + k2 * rho2_u * 4.0 * mx2_u + 2.0 * p1 * p_u(1) + 6.0 * p2 * p_u(0);
-    double dydmx = k1 * 2.0 * p_u(0) * p_u(1) + k2 * 4.0 * rho2_u * p_u(0) * p_u(1) + p1 * 2.0 * p_u(0) + 2.0 * p2 * p_u(1);
-    double dxdmy = dydmx;
-    double dydmy = 1.0 + rad_dist_u + k1 * 2.0 * my2_u + k2 * rho2_u * 4.0 * my2_u + 6.0 * p1 * p_u(1) + 2.0 * p2 * p_u(0);
+  double dxdmx = 1.0 + rad_dist_u + k1 * 2.0 * mx2_u + k2 * rho2_u * 4.0 * mx2_u +
+                 2.0 * p1 * p_u(1) + 6.0 * p2 * p_u(0);
+  double dydmx = k1 * 2.0 * p_u(0) * p_u(1) + k2 * 4.0 * rho2_u * p_u(0) * p_u(1) +
+                 p1 * 2.0 * p_u(0) + 2.0 * p2 * p_u(1);
+  double dxdmy = dydmx;
+  double dydmy = 1.0 + rad_dist_u + k1 * 2.0 * my2_u + k2 * rho2_u * 4.0 * my2_u +
+                 6.0 * p1 * p_u(1) + 2.0 * p2 * p_u(0);
 
-    J << dxdmx, dxdmy,
-         dydmx, dydmy;
+  J << dxdmx, dxdmy, dydmx, dydmy;
 }
 
-void
-CataCamera::initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale) const
-{
-    cv::Size imageSize(mParameters.imageWidth(), mParameters.imageHeight());
+void CataCamera::initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale) const {
+  cv::Size imageSize(mParameters.imageWidth(), mParameters.imageHeight());
 
-    cv::Mat mapX = cv::Mat::zeros(imageSize, CV_32F);
-    cv::Mat mapY = cv::Mat::zeros(imageSize, CV_32F);
+  cv::Mat mapX = cv::Mat::zeros(imageSize, CV_32F);
+  cv::Mat mapY = cv::Mat::zeros(imageSize, CV_32F);
 
-    for (int v = 0; v < imageSize.height; ++v)
-    {
-        for (int u = 0; u < imageSize.width; ++u)
-        {
-            double mx_u = m_inv_K11 / fScale * u + m_inv_K13 / fScale;
-            double my_u = m_inv_K22 / fScale * v + m_inv_K23 / fScale;
+  for (int v = 0; v < imageSize.height; ++v) {
+    for (int u = 0; u < imageSize.width; ++u) {
+      double mx_u = m_inv_K11 / fScale * u + m_inv_K13 / fScale;
+      double my_u = m_inv_K22 / fScale * v + m_inv_K23 / fScale;
 
-            double xi = mParameters.xi();
-            double d2 = mx_u * mx_u + my_u * my_u;
+      double xi = mParameters.xi();
+      double d2 = mx_u * mx_u + my_u * my_u;
 
-            Eigen::Vector3d P;
-            P << mx_u, my_u, 1.0 - xi * (d2 + 1.0) / (xi + sqrt(1.0 + (1.0 - xi * xi) * d2));
+      Eigen::Vector3d P;
+      P << mx_u, my_u, 1.0 - xi * (d2 + 1.0) / (xi + sqrt(1.0 + (1.0 - xi * xi) * d2));
 
-            Eigen::Vector2d p;
-            spaceToPlane(P, p);
+      Eigen::Vector2d p;
+      spaceToPlane(P, p);
 
-            mapX.at<float>(v,u) = p(0);
-            mapY.at<float>(v,u) = p(1);
-        }
+      mapX.at<float>(v, u) = p(0);
+      mapY.at<float>(v, u) = p(1);
     }
+  }
 
-    cv::convertMaps(mapX, mapY, map1, map2, CV_32FC1, false);
+  cv::convertMaps(mapX, mapY, map1, map2, CV_32FC1, false);
 }
 
-cv::Mat
-CataCamera::initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2,
-                                    float fx, float fy,
-                                    cv::Size imageSize,
-                                    float cx, float cy,
-                                    cv::Mat rmat) const
-{
-    if (imageSize == cv::Size(0, 0))
-    {
-        imageSize = cv::Size(mParameters.imageWidth(), mParameters.imageHeight());
+cv::Mat CataCamera::initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2, float fx, float fy,
+                                            cv::Size imageSize, float cx, float cy,
+                                            cv::Mat rmat) const {
+  if (imageSize == cv::Size(0, 0)) {
+    imageSize = cv::Size(mParameters.imageWidth(), mParameters.imageHeight());
+  }
+
+  cv::Mat mapX = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
+  cv::Mat mapY = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
+
+  Eigen::Matrix3f K_rect;
+
+  if (cx == -1.0f && cy == -1.0f) {
+    K_rect << fx, 0, imageSize.width / 2, 0, fy, imageSize.height / 2, 0, 0, 1;
+  } else {
+    K_rect << fx, 0, cx, 0, fy, cy, 0, 0, 1;
+  }
+
+  if (fx == -1.0f || fy == -1.0f) {
+    K_rect(0, 0) = mParameters.gamma1();
+    K_rect(1, 1) = mParameters.gamma2();
+  }
+
+  Eigen::Matrix3f K_rect_inv = K_rect.inverse();
+
+  Eigen::Matrix3f R, R_inv;
+  cv::cv2eigen(rmat, R);
+  R_inv = R.inverse();
+
+  for (int v = 0; v < imageSize.height; ++v) {
+    for (int u = 0; u < imageSize.width; ++u) {
+      Eigen::Vector3f xo;
+      xo << u, v, 1;
+
+      Eigen::Vector3f uo = R_inv * K_rect_inv * xo;
+
+      Eigen::Vector2d p;
+      spaceToPlane(uo.cast<double>(), p);
+
+      mapX.at<float>(v, u) = p(0);
+      mapY.at<float>(v, u) = p(1);
     }
+  }
 
-    cv::Mat mapX = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
-    cv::Mat mapY = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
+  cv::convertMaps(mapX, mapY, map1, map2, CV_32FC1, false);
 
-    Eigen::Matrix3f K_rect;
-
-    if (cx == -1.0f && cy == -1.0f)
-    {
-        K_rect << fx, 0, imageSize.width / 2,
-                  0, fy, imageSize.height / 2,
-                  0, 0, 1;
-    }
-    else
-    {
-        K_rect << fx, 0, cx,
-                  0, fy, cy,
-                  0, 0, 1;
-    }
-
-    if (fx == -1.0f || fy == -1.0f)
-    {
-        K_rect(0,0) = mParameters.gamma1();
-        K_rect(1,1) = mParameters.gamma2();
-    }
-
-    Eigen::Matrix3f K_rect_inv = K_rect.inverse();
-
-    Eigen::Matrix3f R, R_inv;
-    cv::cv2eigen(rmat, R);
-    R_inv = R.inverse();
-
-    for (int v = 0; v < imageSize.height; ++v)
-    {
-        for (int u = 0; u < imageSize.width; ++u)
-        {
-            Eigen::Vector3f xo;
-            xo << u, v, 1;
-
-            Eigen::Vector3f uo = R_inv * K_rect_inv * xo;
-
-            Eigen::Vector2d p;
-            spaceToPlane(uo.cast<double>(), p);
-
-            mapX.at<float>(v,u) = p(0);
-            mapY.at<float>(v,u) = p(1);
-        }
-    }
-
-    cv::convertMaps(mapX, mapY, map1, map2, CV_32FC1, false);
-
-    cv::Mat K_rect_cv;
-    cv::eigen2cv(K_rect, K_rect_cv);
-    return K_rect_cv;
+  cv::Mat K_rect_cv;
+  cv::eigen2cv(K_rect, K_rect_cv);
+  return K_rect_cv;
 }
 
-int
-CataCamera::parameterCount(void) const
-{
-    return 9;
+int CataCamera::parameterCount(void) const { return 9; }
+
+const CataCamera::Parameters& CataCamera::getParameters(void) const { return mParameters; }
+
+void CataCamera::setParameters(const CataCamera::Parameters& parameters) {
+  mParameters = parameters;
+
+  if ((mParameters.k1() == 0.0) && (mParameters.k2() == 0.0) && (mParameters.p1() == 0.0) &&
+      (mParameters.p2() == 0.0)) {
+    m_noDistortion = true;
+  } else {
+    m_noDistortion = false;
+  }
+
+  m_inv_K11 = 1.0 / mParameters.gamma1();
+  m_inv_K13 = -mParameters.u0() / mParameters.gamma1();
+  m_inv_K22 = 1.0 / mParameters.gamma2();
+  m_inv_K23 = -mParameters.v0() / mParameters.gamma2();
 }
 
-const CataCamera::Parameters&
-CataCamera::getParameters(void) const
-{
-    return mParameters;
+void CataCamera::readParameters(const std::vector<double>& parameterVec) {
+  if ((int)parameterVec.size() != parameterCount()) {
+    return;
+  }
+
+  Parameters params = getParameters();
+
+  params.xi() = parameterVec.at(0);
+  params.k1() = parameterVec.at(1);
+  params.k2() = parameterVec.at(2);
+  params.p1() = parameterVec.at(3);
+  params.p2() = parameterVec.at(4);
+  params.gamma1() = parameterVec.at(5);
+  params.gamma2() = parameterVec.at(6);
+  params.u0() = parameterVec.at(7);
+  params.v0() = parameterVec.at(8);
+
+  setParameters(params);
 }
 
-void
-CataCamera::setParameters(const CataCamera::Parameters& parameters)
-{
-    mParameters = parameters;
-
-    if ((mParameters.k1() == 0.0) &&
-        (mParameters.k2() == 0.0) &&
-        (mParameters.p1() == 0.0) &&
-        (mParameters.p2() == 0.0))
-    {
-        m_noDistortion = true;
-    }
-    else
-    {
-        m_noDistortion = false;
-    }
-
-    m_inv_K11 = 1.0 / mParameters.gamma1();
-    m_inv_K13 = -mParameters.u0() / mParameters.gamma1();
-    m_inv_K22 = 1.0 / mParameters.gamma2();
-    m_inv_K23 = -mParameters.v0() / mParameters.gamma2();
+void CataCamera::writeParameters(std::vector<double>& parameterVec) const {
+  parameterVec.resize(parameterCount());
+  parameterVec.at(0) = mParameters.xi();
+  parameterVec.at(1) = mParameters.k1();
+  parameterVec.at(2) = mParameters.k2();
+  parameterVec.at(3) = mParameters.p1();
+  parameterVec.at(4) = mParameters.p2();
+  parameterVec.at(5) = mParameters.gamma1();
+  parameterVec.at(6) = mParameters.gamma2();
+  parameterVec.at(7) = mParameters.u0();
+  parameterVec.at(8) = mParameters.v0();
 }
 
-void
-CataCamera::readParameters(const std::vector<double>& parameterVec)
-{
-    if ((int)parameterVec.size() != parameterCount())
-    {
-        return;
-    }
-
-    Parameters params = getParameters();
-
-    params.xi() = parameterVec.at(0);
-    params.k1() = parameterVec.at(1);
-    params.k2() = parameterVec.at(2);
-    params.p1() = parameterVec.at(3);
-    params.p2() = parameterVec.at(4);
-    params.gamma1() = parameterVec.at(5);
-    params.gamma2() = parameterVec.at(6);
-    params.u0() = parameterVec.at(7);
-    params.v0() = parameterVec.at(8);
-
-    setParameters(params);
+void CataCamera::writeParametersToYamlFile(const std::string& filename) const {
+  mParameters.writeToYamlFile(filename);
 }
 
-void
-CataCamera::writeParameters(std::vector<double>& parameterVec) const
-{
-    parameterVec.resize(parameterCount());
-    parameterVec.at(0) = mParameters.xi();
-    parameterVec.at(1) = mParameters.k1();
-    parameterVec.at(2) = mParameters.k2();
-    parameterVec.at(3) = mParameters.p1();
-    parameterVec.at(4) = mParameters.p2();
-    parameterVec.at(5) = mParameters.gamma1();
-    parameterVec.at(6) = mParameters.gamma2();
-    parameterVec.at(7) = mParameters.u0();
-    parameterVec.at(8) = mParameters.v0();
+std::string CataCamera::parametersToString(void) const {
+  std::ostringstream oss;
+  oss << mParameters;
+
+  return oss.str();
 }
 
-void
-CataCamera::writeParametersToYamlFile(const std::string& filename) const
-{
-    mParameters.writeToYamlFile(filename);
-}
-
-std::string
-CataCamera::parametersToString(void) const
-{
-    std::ostringstream oss;
-    oss << mParameters;
-
-    return oss.str();
-}
-
-}
+}  // namespace camodocal

--- a/src/frontend/camodocal/camera_models/CostFunctionFactory.cc
+++ b/src/frontend/camodocal/camera_models/CostFunctionFactory.cc
@@ -6,1203 +6,1054 @@
 #include "frontend/camodocal/camera_models/PinholeCamera.h"
 #include "frontend/camodocal/camera_models/ScaramuzzaCamera.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
-template<typename T>
-void
-worldToCameraTransform(const T* const q_cam_odo, const T* const t_cam_odo,
-                       const T* const p_odo, const T* const att_odo,
-                       T* q, T* t, bool optimize_cam_odo_z = true)
-{
-    Eigen::Quaternion<T> q_z_inv(cos(att_odo[0] / T(2)), T(0), T(0), -sin(att_odo[0] / T(2)));
-    Eigen::Quaternion<T> q_y_inv(cos(att_odo[1] / T(2)), T(0), -sin(att_odo[1] / T(2)), T(0));
-    Eigen::Quaternion<T> q_x_inv(cos(att_odo[2] / T(2)), -sin(att_odo[2] / T(2)), T(0), T(0));
+template <typename T>
+void worldToCameraTransform(const T* const q_cam_odo, const T* const t_cam_odo,
+                            const T* const p_odo, const T* const att_odo, T* q, T* t,
+                            bool optimize_cam_odo_z = true) {
+  Eigen::Quaternion<T> q_z_inv(cos(att_odo[0] / T(2)), T(0), T(0), -sin(att_odo[0] / T(2)));
+  Eigen::Quaternion<T> q_y_inv(cos(att_odo[1] / T(2)), T(0), -sin(att_odo[1] / T(2)), T(0));
+  Eigen::Quaternion<T> q_x_inv(cos(att_odo[2] / T(2)), -sin(att_odo[2] / T(2)), T(0), T(0));
 
-    Eigen::Quaternion<T> q_zyx_inv = q_x_inv * q_y_inv * q_z_inv;
+  Eigen::Quaternion<T> q_zyx_inv = q_x_inv * q_y_inv * q_z_inv;
 
-    T q_odo[4] = {q_zyx_inv.w(), q_zyx_inv.x(), q_zyx_inv.y(), q_zyx_inv.z()};
+  T q_odo[4] = {q_zyx_inv.w(), q_zyx_inv.x(), q_zyx_inv.y(), q_zyx_inv.z()};
 
-    T q_odo_cam[4] = {q_cam_odo[3], -q_cam_odo[0], -q_cam_odo[1], -q_cam_odo[2]};
+  T q_odo_cam[4] = {q_cam_odo[3], -q_cam_odo[0], -q_cam_odo[1], -q_cam_odo[2]};
 
-    T q0[4];
-    ceres::QuaternionProduct(q_odo_cam, q_odo, q0);
+  T q0[4];
+  ceres::QuaternionProduct(q_odo_cam, q_odo, q0);
 
-    T t0[3];
-    T t_odo[3] = {p_odo[0], p_odo[1], p_odo[2]};
+  T t0[3];
+  T t_odo[3] = {p_odo[0], p_odo[1], p_odo[2]};
 
-    ceres::QuaternionRotatePoint(q_odo, t_odo, t0);
+  ceres::QuaternionRotatePoint(q_odo, t_odo, t0);
 
-    t0[0] += t_cam_odo[0];
-    t0[1] += t_cam_odo[1];
+  t0[0] += t_cam_odo[0];
+  t0[1] += t_cam_odo[1];
 
-    if (optimize_cam_odo_z)
-    {
-        t0[2] += t_cam_odo[2];
-    }
+  if (optimize_cam_odo_z) {
+    t0[2] += t_cam_odo[2];
+  }
 
-    ceres::QuaternionRotatePoint(q_odo_cam, t0, t);
-    t[0] = -t[0];
-    t[1] = -t[1];
-    t[2] = -t[2];
+  ceres::QuaternionRotatePoint(q_odo_cam, t0, t);
+  t[0] = -t[0];
+  t[1] = -t[1];
+  t[2] = -t[2];
 
-    // Convert quaternion from Ceres convention (w, x, y, z)
-    // to Eigen convention (x, y, z, w)
-    q[0] = q0[1];
-    q[1] = q0[2];
-    q[2] = q0[3];
-    q[3] = q0[0];
+  // Convert quaternion from Ceres convention (w, x, y, z)
+  // to Eigen convention (x, y, z, w)
+  q[0] = q0[1];
+  q[1] = q0[2];
+  q[2] = q0[3];
+  q[3] = q0[0];
 }
 
-template<class CameraT>
-class ReprojectionError1
-{
+template <class CameraT>
+class ReprojectionError1 {
 public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    ReprojectionError1(const Eigen::Vector3d& observed_P,
-                       const Eigen::Vector2d& observed_p)
-        : m_observed_P(observed_P), m_observed_p(observed_p)
-        , m_sqrtPrecisionMat(Eigen::Matrix2d::Identity()) {}
+  ReprojectionError1(const Eigen::Vector3d& observed_P, const Eigen::Vector2d& observed_p)
+      : m_observed_P(observed_P),
+        m_observed_p(observed_p),
+        m_sqrtPrecisionMat(Eigen::Matrix2d::Identity()) {}
 
-    ReprojectionError1(const Eigen::Vector3d& observed_P,
-                       const Eigen::Vector2d& observed_p,
-                       const Eigen::Matrix2d& sqrtPrecisionMat)
-        : m_observed_P(observed_P), m_observed_p(observed_p)
-        , m_sqrtPrecisionMat(sqrtPrecisionMat) {}
+  ReprojectionError1(const Eigen::Vector3d& observed_P, const Eigen::Vector2d& observed_p,
+                     const Eigen::Matrix2d& sqrtPrecisionMat)
+      : m_observed_P(observed_P), m_observed_p(observed_p), m_sqrtPrecisionMat(sqrtPrecisionMat) {}
 
-    ReprojectionError1(const std::vector<double>& intrinsic_params,
-                       const Eigen::Vector3d& observed_P,
-                       const Eigen::Vector2d& observed_p)
-        : m_intrinsic_params(intrinsic_params)
-        , m_observed_P(observed_P), m_observed_p(observed_p) {}
+  ReprojectionError1(const std::vector<double>& intrinsic_params, const Eigen::Vector3d& observed_P,
+                     const Eigen::Vector2d& observed_p)
+      : m_intrinsic_params(intrinsic_params), m_observed_P(observed_P), m_observed_p(observed_p) {}
 
-    // variables: camera intrinsics and camera extrinsics
-    template <typename T>
-    bool operator()(const T* const intrinsic_params,
-                    const T* const q,
-                    const T* const t,
-                    T* residuals) const
-    {
-        Eigen::Matrix<T, 3, 1> P = m_observed_P.cast<T>();
+  // variables: camera intrinsics and camera extrinsics
+  template <typename T>
+  bool operator()(const T* const intrinsic_params, const T* const q, const T* const t,
+                  T* residuals) const {
+    Eigen::Matrix<T, 3, 1> P = m_observed_P.cast<T>();
 
-        Eigen::Matrix<T, 2, 1> predicted_p;
-        CameraT::spaceToPlane(intrinsic_params, q, t, P, predicted_p);
+    Eigen::Matrix<T, 2, 1> predicted_p;
+    CameraT::spaceToPlane(intrinsic_params, q, t, P, predicted_p);
 
-        Eigen::Matrix<T, 2, 1> e = predicted_p - m_observed_p.cast<T>();
+    Eigen::Matrix<T, 2, 1> e = predicted_p - m_observed_p.cast<T>();
 
-        Eigen::Matrix<T, 2, 1> e_weighted = m_sqrtPrecisionMat.cast<T>() * e;
+    Eigen::Matrix<T, 2, 1> e_weighted = m_sqrtPrecisionMat.cast<T>() * e;
 
-        residuals[0] = e_weighted(0);
-        residuals[1] = e_weighted(1);
+    residuals[0] = e_weighted(0);
+    residuals[1] = e_weighted(1);
 
-        return true;
-    }
+    return true;
+  }
 
-    // variables: camera-odometry transforms and odometry poses
-    template <typename T>
-    bool operator()(const T* const q_cam_odo, const T* const t_cam_odo,
-                    const T* const p_odo, const T* const att_odo,
-                    T* residuals) const
-    {
-        T q[4], t[3];
-        worldToCameraTransform(q_cam_odo, t_cam_odo, p_odo, att_odo, q, t);
+  // variables: camera-odometry transforms and odometry poses
+  template <typename T>
+  bool operator()(const T* const q_cam_odo, const T* const t_cam_odo, const T* const p_odo,
+                  const T* const att_odo, T* residuals) const {
+    T q[4], t[3];
+    worldToCameraTransform(q_cam_odo, t_cam_odo, p_odo, att_odo, q, t);
 
-        Eigen::Matrix<T, 3, 1> P = m_observed_P.cast<T>();
+    Eigen::Matrix<T, 3, 1> P = m_observed_P.cast<T>();
 
-        std::vector<T> intrinsic_params(m_intrinsic_params.begin(), m_intrinsic_params.end());
+    std::vector<T> intrinsic_params(m_intrinsic_params.begin(), m_intrinsic_params.end());
 
-        // project 3D object point to the image plane
-        Eigen::Matrix<T, 2, 1> predicted_p;
-        CameraT::spaceToPlane(intrinsic_params.data(), q, t, P, predicted_p);
+    // project 3D object point to the image plane
+    Eigen::Matrix<T, 2, 1> predicted_p;
+    CameraT::spaceToPlane(intrinsic_params.data(), q, t, P, predicted_p);
 
-        residuals[0] = predicted_p(0) - T(m_observed_p(0));
-        residuals[1] = predicted_p(1) - T(m_observed_p(1));
+    residuals[0] = predicted_p(0) - T(m_observed_p(0));
+    residuals[1] = predicted_p(1) - T(m_observed_p(1));
 
-        return true;
-    }
+    return true;
+  }
 
-//private:
-    // camera intrinsics
-    std::vector<double> m_intrinsic_params;
+  // private:
+  //  camera intrinsics
+  std::vector<double> m_intrinsic_params;
 
-    // observed 3D point
-    Eigen::Vector3d m_observed_P;
+  // observed 3D point
+  Eigen::Vector3d m_observed_P;
 
-    // observed 2D point
-    Eigen::Vector2d m_observed_p;
+  // observed 2D point
+  Eigen::Vector2d m_observed_p;
 
-    // square root of precision matrix
-    Eigen::Matrix2d m_sqrtPrecisionMat;
+  // square root of precision matrix
+  Eigen::Matrix2d m_sqrtPrecisionMat;
 };
 
 // variables: camera extrinsics, 3D point
-template<class CameraT>
-class ReprojectionError2
-{
+template <class CameraT>
+class ReprojectionError2 {
 public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    ReprojectionError2(const std::vector<double>& intrinsic_params,
-                       const Eigen::Vector2d& observed_p)
-        : m_intrinsic_params(intrinsic_params), m_observed_p(observed_p) {}
+  ReprojectionError2(const std::vector<double>& intrinsic_params, const Eigen::Vector2d& observed_p)
+      : m_intrinsic_params(intrinsic_params), m_observed_p(observed_p) {}
 
-    template <typename T>
-    bool operator()(const T* const q, const T* const t,
-                    const T* const point, T* residuals) const
-    {
-        Eigen::Matrix<T, 3, 1> P;
-        P(0) = T(point[0]);
-        P(1) = T(point[1]);
-        P(2) = T(point[2]);
+  template <typename T>
+  bool operator()(const T* const q, const T* const t, const T* const point, T* residuals) const {
+    Eigen::Matrix<T, 3, 1> P;
+    P(0) = T(point[0]);
+    P(1) = T(point[1]);
+    P(2) = T(point[2]);
 
-        std::vector<T> intrinsic_params(m_intrinsic_params.begin(), m_intrinsic_params.end());
+    std::vector<T> intrinsic_params(m_intrinsic_params.begin(), m_intrinsic_params.end());
 
-        // project 3D object point to the image plane
-        Eigen::Matrix<T, 2, 1> predicted_p;
-        CameraT::spaceToPlane(intrinsic_params.data(), q, t, P, predicted_p);
+    // project 3D object point to the image plane
+    Eigen::Matrix<T, 2, 1> predicted_p;
+    CameraT::spaceToPlane(intrinsic_params.data(), q, t, P, predicted_p);
 
-        residuals[0] = predicted_p(0) - T(m_observed_p(0));
-        residuals[1] = predicted_p(1) - T(m_observed_p(1));
+    residuals[0] = predicted_p(0) - T(m_observed_p(0));
+    residuals[1] = predicted_p(1) - T(m_observed_p(1));
 
-        return true;
-    }
+    return true;
+  }
 
 private:
-    // camera intrinsics
-    std::vector<double> m_intrinsic_params;
+  // camera intrinsics
+  std::vector<double> m_intrinsic_params;
 
-    // observed 2D point
-    Eigen::Vector2d m_observed_p;
+  // observed 2D point
+  Eigen::Vector2d m_observed_p;
 };
 
-template<class CameraT>
-class ReprojectionError3
-{
+template <class CameraT>
+class ReprojectionError3 {
 public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    ReprojectionError3(const Eigen::Vector2d& observed_p)
-        : m_observed_p(observed_p)
-        , m_sqrtPrecisionMat(Eigen::Matrix2d::Identity())
-        , m_optimize_cam_odo_z(true) {}
+  ReprojectionError3(const Eigen::Vector2d& observed_p)
+      : m_observed_p(observed_p),
+        m_sqrtPrecisionMat(Eigen::Matrix2d::Identity()),
+        m_optimize_cam_odo_z(true) {}
 
-    ReprojectionError3(const Eigen::Vector2d& observed_p,
-                       const Eigen::Matrix2d& sqrtPrecisionMat)
-        : m_observed_p(observed_p)
-        , m_sqrtPrecisionMat(sqrtPrecisionMat)
-        , m_optimize_cam_odo_z(true) {}
+  ReprojectionError3(const Eigen::Vector2d& observed_p, const Eigen::Matrix2d& sqrtPrecisionMat)
+      : m_observed_p(observed_p),
+        m_sqrtPrecisionMat(sqrtPrecisionMat),
+        m_optimize_cam_odo_z(true) {}
 
-    ReprojectionError3(const std::vector<double>& intrinsic_params,
-                       const Eigen::Vector2d& observed_p)
-        : m_intrinsic_params(intrinsic_params)
-        , m_observed_p(observed_p)
-        , m_sqrtPrecisionMat(Eigen::Matrix2d::Identity())
-        , m_optimize_cam_odo_z(true) {}
+  ReprojectionError3(const std::vector<double>& intrinsic_params, const Eigen::Vector2d& observed_p)
+      : m_intrinsic_params(intrinsic_params),
+        m_observed_p(observed_p),
+        m_sqrtPrecisionMat(Eigen::Matrix2d::Identity()),
+        m_optimize_cam_odo_z(true) {}
 
-    ReprojectionError3(const std::vector<double>& intrinsic_params,
-                       const Eigen::Vector2d& observed_p,
-                       const Eigen::Matrix2d& sqrtPrecisionMat)
-        : m_intrinsic_params(intrinsic_params)
-        , m_observed_p(observed_p)
-        , m_sqrtPrecisionMat(sqrtPrecisionMat)
-        , m_optimize_cam_odo_z(true) {}
+  ReprojectionError3(const std::vector<double>& intrinsic_params, const Eigen::Vector2d& observed_p,
+                     const Eigen::Matrix2d& sqrtPrecisionMat)
+      : m_intrinsic_params(intrinsic_params),
+        m_observed_p(observed_p),
+        m_sqrtPrecisionMat(sqrtPrecisionMat),
+        m_optimize_cam_odo_z(true) {}
 
+  ReprojectionError3(const std::vector<double>& intrinsic_params, const Eigen::Vector3d& odo_pos,
+                     const Eigen::Vector3d& odo_att, const Eigen::Vector2d& observed_p,
+                     bool optimize_cam_odo_z)
+      : m_intrinsic_params(intrinsic_params),
+        m_odo_pos(odo_pos),
+        m_odo_att(odo_att),
+        m_observed_p(observed_p),
+        m_optimize_cam_odo_z(optimize_cam_odo_z) {}
 
-    ReprojectionError3(const std::vector<double>& intrinsic_params,
-                       const Eigen::Vector3d& odo_pos,
-                       const Eigen::Vector3d& odo_att,
-                       const Eigen::Vector2d& observed_p,
-                       bool optimize_cam_odo_z)
-        : m_intrinsic_params(intrinsic_params)
-        , m_odo_pos(odo_pos), m_odo_att(odo_att)
-        , m_observed_p(observed_p)
-        , m_optimize_cam_odo_z(optimize_cam_odo_z) {}
+  ReprojectionError3(const std::vector<double>& intrinsic_params,
+                     const Eigen::Quaterniond& cam_odo_q, const Eigen::Vector3d& cam_odo_t,
+                     const Eigen::Vector3d& odo_pos, const Eigen::Vector3d& odo_att,
+                     const Eigen::Vector2d& observed_p)
+      : m_intrinsic_params(intrinsic_params),
+        m_cam_odo_q(cam_odo_q),
+        m_cam_odo_t(cam_odo_t),
+        m_odo_pos(odo_pos),
+        m_odo_att(odo_att),
+        m_observed_p(observed_p),
+        m_optimize_cam_odo_z(true) {}
 
-    ReprojectionError3(const std::vector<double>& intrinsic_params,
-                       const Eigen::Quaterniond& cam_odo_q,
-                       const Eigen::Vector3d& cam_odo_t,
-                       const Eigen::Vector3d& odo_pos,
-                       const Eigen::Vector3d& odo_att,
-                       const Eigen::Vector2d& observed_p)
-        : m_intrinsic_params(intrinsic_params)
-        , m_cam_odo_q(cam_odo_q), m_cam_odo_t(cam_odo_t)
-        , m_odo_pos(odo_pos), m_odo_att(odo_att)
-        , m_observed_p(observed_p)
-        , m_optimize_cam_odo_z(true) {}
+  // variables: camera intrinsics, camera-to-odometry transform,
+  //            odometry extrinsics, 3D point
+  template <typename T>
+  bool operator()(const T* const intrinsic_params, const T* const q_cam_odo,
+                  const T* const t_cam_odo, const T* const p_odo, const T* const att_odo,
+                  const T* const point, T* residuals) const {
+    T q[4], t[3];
+    worldToCameraTransform(q_cam_odo, t_cam_odo, p_odo, att_odo, q, t, m_optimize_cam_odo_z);
 
-    // variables: camera intrinsics, camera-to-odometry transform,
-    //            odometry extrinsics, 3D point
-    template <typename T>
-    bool operator()(const T* const intrinsic_params,
-                    const T* const q_cam_odo, const T* const t_cam_odo,
-                    const T* const p_odo, const T* const att_odo,
-                    const T* const point, T* residuals) const
-    {
-        T q[4], t[3];
-        worldToCameraTransform(q_cam_odo, t_cam_odo, p_odo, att_odo, q, t, m_optimize_cam_odo_z);
+    Eigen::Matrix<T, 3, 1> P(point[0], point[1], point[2]);
 
-        Eigen::Matrix<T, 3, 1> P(point[0], point[1], point[2]);
+    // project 3D object point to the image plane
+    Eigen::Matrix<T, 2, 1> predicted_p;
+    CameraT::spaceToPlane(intrinsic_params, q, t, P, predicted_p);
 
-        // project 3D object point to the image plane
-        Eigen::Matrix<T, 2, 1> predicted_p;
-        CameraT::spaceToPlane(intrinsic_params, q, t, P, predicted_p);
+    Eigen::Matrix<T, 2, 1> err = predicted_p - m_observed_p.cast<T>();
+    Eigen::Matrix<T, 2, 1> err_weighted = m_sqrtPrecisionMat.cast<T>() * err;
 
-        Eigen::Matrix<T, 2, 1> err = predicted_p - m_observed_p.cast<T>();
-        Eigen::Matrix<T, 2, 1> err_weighted = m_sqrtPrecisionMat.cast<T>() * err;
+    residuals[0] = err_weighted(0);
+    residuals[1] = err_weighted(1);
 
-        residuals[0] = err_weighted(0);
-        residuals[1] = err_weighted(1);
+    return true;
+  }
 
-        return true;
-    }
+  // variables: camera-to-odometry transform, 3D point
+  template <typename T>
+  bool operator()(const T* const q_cam_odo, const T* const t_cam_odo, const T* const point,
+                  T* residuals) const {
+    T p_odo[3] = {T(m_odo_pos(0)), T(m_odo_pos(1)), T(m_odo_pos(2))};
+    T att_odo[3] = {T(m_odo_att(0)), T(m_odo_att(1)), T(m_odo_att(2))};
+    T q[4], t[3];
 
-    // variables: camera-to-odometry transform, 3D point
-    template <typename T>
-    bool operator()(const T* const q_cam_odo, const T* const t_cam_odo,
-                    const T* const point, T* residuals) const
-    {
-        T p_odo[3] = {T(m_odo_pos(0)), T(m_odo_pos(1)), T(m_odo_pos(2))};
-        T att_odo[3] = {T(m_odo_att(0)), T(m_odo_att(1)), T(m_odo_att(2))};
-        T q[4], t[3];
+    worldToCameraTransform(q_cam_odo, t_cam_odo, p_odo, att_odo, q, t, m_optimize_cam_odo_z);
 
-        worldToCameraTransform(q_cam_odo, t_cam_odo, p_odo, att_odo, q, t, m_optimize_cam_odo_z);
+    std::vector<T> intrinsic_params(m_intrinsic_params.begin(), m_intrinsic_params.end());
+    Eigen::Matrix<T, 3, 1> P(point[0], point[1], point[2]);
 
-        std::vector<T> intrinsic_params(m_intrinsic_params.begin(), m_intrinsic_params.end());
-        Eigen::Matrix<T, 3, 1> P(point[0], point[1], point[2]);
+    // project 3D object point to the image plane
+    Eigen::Matrix<T, 2, 1> predicted_p;
+    CameraT::spaceToPlane(intrinsic_params.data(), q, t, P, predicted_p);
 
-        // project 3D object point to the image plane
-        Eigen::Matrix<T, 2, 1> predicted_p;
-        CameraT::spaceToPlane(intrinsic_params.data(), q, t, P, predicted_p);
+    residuals[0] = predicted_p(0) - T(m_observed_p(0));
+    residuals[1] = predicted_p(1) - T(m_observed_p(1));
 
-        residuals[0] = predicted_p(0) - T(m_observed_p(0));
-        residuals[1] = predicted_p(1) - T(m_observed_p(1));
+    return true;
+  }
 
-        return true;
-    }
+  // variables: camera-to-odometry transform, odometry extrinsics, 3D point
+  template <typename T>
+  bool operator()(const T* const q_cam_odo, const T* const t_cam_odo, const T* const p_odo,
+                  const T* const att_odo, const T* const point, T* residuals) const {
+    T q[4], t[3];
+    worldToCameraTransform(q_cam_odo, t_cam_odo, p_odo, att_odo, q, t, m_optimize_cam_odo_z);
 
-    // variables: camera-to-odometry transform, odometry extrinsics, 3D point
-    template <typename T>
-    bool operator()(const T* const q_cam_odo, const T* const t_cam_odo,
-                    const T* const p_odo, const T* const att_odo,
-                    const T* const point, T* residuals) const
-    {
-        T q[4], t[3];
-        worldToCameraTransform(q_cam_odo, t_cam_odo, p_odo, att_odo, q, t, m_optimize_cam_odo_z);
+    std::vector<T> intrinsic_params(m_intrinsic_params.begin(), m_intrinsic_params.end());
+    Eigen::Matrix<T, 3, 1> P(point[0], point[1], point[2]);
 
-        std::vector<T> intrinsic_params(m_intrinsic_params.begin(), m_intrinsic_params.end());
-        Eigen::Matrix<T, 3, 1> P(point[0], point[1], point[2]);
+    // project 3D object point to the image plane
+    Eigen::Matrix<T, 2, 1> predicted_p;
+    CameraT::spaceToPlane(intrinsic_params.data(), q, t, P, predicted_p);
 
-        // project 3D object point to the image plane
-        Eigen::Matrix<T, 2, 1> predicted_p;
-        CameraT::spaceToPlane(intrinsic_params.data(), q, t, P, predicted_p);
+    Eigen::Matrix<T, 2, 1> err = predicted_p - m_observed_p.cast<T>();
+    Eigen::Matrix<T, 2, 1> err_weighted = m_sqrtPrecisionMat.cast<T>() * err;
 
-        Eigen::Matrix<T, 2, 1> err = predicted_p - m_observed_p.cast<T>();
-        Eigen::Matrix<T, 2, 1> err_weighted = m_sqrtPrecisionMat.cast<T>() * err;
+    residuals[0] = err_weighted(0);
+    residuals[1] = err_weighted(1);
 
-        residuals[0] = err_weighted(0);
-        residuals[1] = err_weighted(1);
+    return true;
+  }
 
-        return true;
-    }
+  // variables: 3D point
+  template <typename T>
+  bool operator()(const T* const point, T* residuals) const {
+    T q_cam_odo[4] = {T(m_cam_odo_q.coeffs()(0)), T(m_cam_odo_q.coeffs()(1)),
+                      T(m_cam_odo_q.coeffs()(2)), T(m_cam_odo_q.coeffs()(3))};
+    T t_cam_odo[3] = {T(m_cam_odo_t(0)), T(m_cam_odo_t(1)), T(m_cam_odo_t(2))};
+    T p_odo[3] = {T(m_odo_pos(0)), T(m_odo_pos(1)), T(m_odo_pos(2))};
+    T att_odo[3] = {T(m_odo_att(0)), T(m_odo_att(1)), T(m_odo_att(2))};
+    T q[4], t[3];
 
-    // variables: 3D point
-    template <typename T>
-    bool operator()(const T* const point, T* residuals) const
-    {
-        T q_cam_odo[4] = {T(m_cam_odo_q.coeffs()(0)), T(m_cam_odo_q.coeffs()(1)), T(m_cam_odo_q.coeffs()(2)), T(m_cam_odo_q.coeffs()(3))};
-        T t_cam_odo[3] = {T(m_cam_odo_t(0)), T(m_cam_odo_t(1)), T(m_cam_odo_t(2))};
-        T p_odo[3] = {T(m_odo_pos(0)), T(m_odo_pos(1)), T(m_odo_pos(2))};
-        T att_odo[3] = {T(m_odo_att(0)), T(m_odo_att(1)), T(m_odo_att(2))};
-        T q[4], t[3];
+    worldToCameraTransform(q_cam_odo, t_cam_odo, p_odo, att_odo, q, t, m_optimize_cam_odo_z);
 
-        worldToCameraTransform(q_cam_odo, t_cam_odo, p_odo, att_odo, q, t, m_optimize_cam_odo_z);
+    std::vector<T> intrinsic_params(m_intrinsic_params.begin(), m_intrinsic_params.end());
+    Eigen::Matrix<T, 3, 1> P(point[0], point[1], point[2]);
 
-        std::vector<T> intrinsic_params(m_intrinsic_params.begin(), m_intrinsic_params.end());
-        Eigen::Matrix<T, 3, 1> P(point[0], point[1], point[2]);
+    // project 3D object point to the image plane
+    Eigen::Matrix<T, 2, 1> predicted_p;
+    CameraT::spaceToPlane(intrinsic_params.data(), q, t, P, predicted_p);
 
-        // project 3D object point to the image plane
-        Eigen::Matrix<T, 2, 1> predicted_p;
-        CameraT::spaceToPlane(intrinsic_params.data(), q, t, P, predicted_p);
+    residuals[0] = predicted_p(0) - T(m_observed_p(0));
+    residuals[1] = predicted_p(1) - T(m_observed_p(1));
 
-        residuals[0] = predicted_p(0) - T(m_observed_p(0));
-        residuals[1] = predicted_p(1) - T(m_observed_p(1));
-
-        return true;
-    }
+    return true;
+  }
 
 private:
-    // camera intrinsics
-    std::vector<double> m_intrinsic_params;
+  // camera intrinsics
+  std::vector<double> m_intrinsic_params;
 
-    // observed camera-odometry transform
-    Eigen::Quaterniond m_cam_odo_q;
-    Eigen::Vector3d m_cam_odo_t;
+  // observed camera-odometry transform
+  Eigen::Quaterniond m_cam_odo_q;
+  Eigen::Vector3d m_cam_odo_t;
 
-    // observed odometry
-    Eigen::Vector3d m_odo_pos;
-    Eigen::Vector3d m_odo_att;
+  // observed odometry
+  Eigen::Vector3d m_odo_pos;
+  Eigen::Vector3d m_odo_att;
 
-    // observed 2D point
-    Eigen::Vector2d m_observed_p;
+  // observed 2D point
+  Eigen::Vector2d m_observed_p;
 
-    Eigen::Matrix2d m_sqrtPrecisionMat;
+  Eigen::Matrix2d m_sqrtPrecisionMat;
 
-    bool m_optimize_cam_odo_z;
+  bool m_optimize_cam_odo_z;
 };
 
 // variables: camera intrinsics and camera extrinsics
-template<class CameraT>
-class StereoReprojectionError
-{
+template <class CameraT>
+class StereoReprojectionError {
 public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    StereoReprojectionError(const Eigen::Vector3d& observed_P,
-                            const Eigen::Vector2d& observed_p_l,
-                            const Eigen::Vector2d& observed_p_r)
-        : m_observed_P(observed_P)
-        , m_observed_p_l(observed_p_l)
-        , m_observed_p_r(observed_p_r)
-    {
+  StereoReprojectionError(const Eigen::Vector3d& observed_P, const Eigen::Vector2d& observed_p_l,
+                          const Eigen::Vector2d& observed_p_r)
+      : m_observed_P(observed_P), m_observed_p_l(observed_p_l), m_observed_p_r(observed_p_r) {}
 
-    }
+  template <typename T>
+  bool operator()(const T* const intrinsic_params_l, const T* const intrinsic_params_r,
+                  const T* const q_l, const T* const t_l, const T* const q_l_r,
+                  const T* const t_l_r, T* residuals) const {
+    Eigen::Matrix<T, 3, 1> P;
+    P(0) = T(m_observed_P(0));
+    P(1) = T(m_observed_P(1));
+    P(2) = T(m_observed_P(2));
 
-    template <typename T>
-    bool operator()(const T* const intrinsic_params_l,
-                    const T* const intrinsic_params_r,
-                    const T* const q_l,
-                    const T* const t_l,
-                    const T* const q_l_r,
-                    const T* const t_l_r,
-                    T* residuals) const
-    {
-        Eigen::Matrix<T, 3, 1> P;
-        P(0) = T(m_observed_P(0));
-        P(1) = T(m_observed_P(1));
-        P(2) = T(m_observed_P(2));
+    Eigen::Matrix<T, 2, 1> predicted_p_l;
+    CameraT::spaceToPlane(intrinsic_params_l, q_l, t_l, P, predicted_p_l);
 
-        Eigen::Matrix<T, 2, 1> predicted_p_l;
-        CameraT::spaceToPlane(intrinsic_params_l, q_l, t_l, P, predicted_p_l);
+    Eigen::Quaternion<T> q_r = Eigen::Quaternion<T>(q_l_r) * Eigen::Quaternion<T>(q_l);
 
-        Eigen::Quaternion<T> q_r = Eigen::Quaternion<T>(q_l_r) * Eigen::Quaternion<T>(q_l);
+    Eigen::Matrix<T, 3, 1> t_r;
+    t_r(0) = t_l[0];
+    t_r(1) = t_l[1];
+    t_r(2) = t_l[2];
 
-        Eigen::Matrix<T, 3, 1> t_r;
-        t_r(0) = t_l[0];
-        t_r(1) = t_l[1];
-        t_r(2) = t_l[2];
+    t_r = Eigen::Quaternion<T>(q_l_r) * t_r;
+    t_r(0) += t_l_r[0];
+    t_r(1) += t_l_r[1];
+    t_r(2) += t_l_r[2];
 
-        t_r = Eigen::Quaternion<T>(q_l_r) * t_r;
-        t_r(0) += t_l_r[0];
-        t_r(1) += t_l_r[1];
-        t_r(2) += t_l_r[2];
+    Eigen::Matrix<T, 2, 1> predicted_p_r;
+    CameraT::spaceToPlane(intrinsic_params_r, q_r.coeffs().data(), t_r.data(), P, predicted_p_r);
 
-        Eigen::Matrix<T, 2, 1> predicted_p_r;
-        CameraT::spaceToPlane(intrinsic_params_r, q_r.coeffs().data(), t_r.data(), P, predicted_p_r);
+    residuals[0] = predicted_p_l(0) - T(m_observed_p_l(0));
+    residuals[1] = predicted_p_l(1) - T(m_observed_p_l(1));
+    residuals[2] = predicted_p_r(0) - T(m_observed_p_r(0));
+    residuals[3] = predicted_p_r(1) - T(m_observed_p_r(1));
 
-        residuals[0] = predicted_p_l(0) - T(m_observed_p_l(0));
-        residuals[1] = predicted_p_l(1) - T(m_observed_p_l(1));
-        residuals[2] = predicted_p_r(0) - T(m_observed_p_r(0));
-        residuals[3] = predicted_p_r(1) - T(m_observed_p_r(1));
-
-        return true;
-    }
+    return true;
+  }
 
 private:
-    // observed 3D point
-    Eigen::Vector3d m_observed_P;
+  // observed 3D point
+  Eigen::Vector3d m_observed_P;
 
-    // observed 2D point
-    Eigen::Vector2d m_observed_p_l;
-    Eigen::Vector2d m_observed_p_r;
+  // observed 2D point
+  Eigen::Vector2d m_observed_p_l;
+  Eigen::Vector2d m_observed_p_r;
 };
 
 template <class CameraT>
 class ComprehensionError {
-  public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    ComprehensionError(const Eigen::Vector3d& observed_P, const Eigen::Vector2d& observed_p)
-        : m_observed_P(observed_P),
-          m_observed_p(observed_p),
-          m_sqrtPrecisionMat(Eigen::Matrix2d::Identity()) {
+  ComprehensionError(const Eigen::Vector3d& observed_P, const Eigen::Vector2d& observed_p)
+      : m_observed_P(observed_P),
+        m_observed_p(observed_p),
+        m_sqrtPrecisionMat(Eigen::Matrix2d::Identity()) {}
+
+  template <typename T>
+  bool operator()(const T* const intrinsic_params, const T* const q, const T* const t,
+                  T* residuals) const {
+    {
+      Eigen::Matrix<T, 2, 1> p = m_observed_p.cast<T>();
+
+      Eigen::Matrix<T, 3, 1> predicted_img_P;
+      CameraT::LiftToSphere(intrinsic_params, p, predicted_img_P);
+
+      Eigen::Matrix<T, 2, 1> predicted_p;
+      CameraT::SphereToPlane(intrinsic_params, predicted_img_P, predicted_p);
+
+      Eigen::Matrix<T, 2, 1> e = predicted_p - m_observed_p.cast<T>();
+
+      Eigen::Matrix<T, 2, 1> e_weighted = m_sqrtPrecisionMat.cast<T>() * e;
+
+      residuals[0] = e_weighted(0);
+      residuals[1] = e_weighted(1);
     }
 
-    template <typename T>
-    bool operator()(const T* const intrinsic_params, const T* const q, const T* const t,
-                    T* residuals) const {
-        {
-            Eigen::Matrix<T, 2, 1> p = m_observed_p.cast<T>();
-        
-            Eigen::Matrix<T, 3, 1> predicted_img_P;
-            CameraT::LiftToSphere(intrinsic_params, p, predicted_img_P);
-                
-            Eigen::Matrix<T, 2, 1> predicted_p;
-            CameraT::SphereToPlane(intrinsic_params, predicted_img_P, predicted_p);
+    {
+      Eigen::Matrix<T, 3, 1> P = m_observed_P.cast<T>();
 
-            Eigen::Matrix<T, 2, 1> e = predicted_p - m_observed_p.cast<T>();
+      Eigen::Matrix<T, 2, 1> predicted_p;
+      CameraT::spaceToPlane(intrinsic_params, q, t, P, predicted_p);
 
-            Eigen::Matrix<T, 2, 1> e_weighted = m_sqrtPrecisionMat.cast<T>() * e;
+      Eigen::Matrix<T, 2, 1> e = predicted_p - m_observed_p.cast<T>();
 
-            residuals[0] = e_weighted(0);
-            residuals[1] = e_weighted(1);
-        }
+      Eigen::Matrix<T, 2, 1> e_weighted = m_sqrtPrecisionMat.cast<T>() * e;
 
-        {
-            Eigen::Matrix<T, 3, 1> P = m_observed_P.cast<T>();
-
-            Eigen::Matrix<T, 2, 1> predicted_p;
-            CameraT::spaceToPlane(intrinsic_params, q, t, P, predicted_p);
-
-            Eigen::Matrix<T, 2, 1> e = predicted_p - m_observed_p.cast<T>();
-
-            Eigen::Matrix<T, 2, 1> e_weighted = m_sqrtPrecisionMat.cast<T>() * e;
-
-            residuals[2] = e_weighted(0);
-            residuals[3] = e_weighted(1);
-        }
-
-        return true;
+      residuals[2] = e_weighted(0);
+      residuals[3] = e_weighted(1);
     }
 
-    // private:
-    // camera intrinsics
-    // std::vector<double> m_intrinsic_params;
+    return true;
+  }
 
-    // observed 3D point
-    Eigen::Vector3d m_observed_P;
+  // private:
+  // camera intrinsics
+  // std::vector<double> m_intrinsic_params;
 
-    // observed 2D point
-    Eigen::Vector2d m_observed_p;
+  // observed 3D point
+  Eigen::Vector3d m_observed_P;
 
-    // square root of precision matrix
-    Eigen::Matrix2d m_sqrtPrecisionMat;
+  // observed 2D point
+  Eigen::Vector2d m_observed_p;
+
+  // square root of precision matrix
+  Eigen::Matrix2d m_sqrtPrecisionMat;
 };
 
 boost::shared_ptr<CostFunctionFactory> CostFunctionFactory::m_instance;
 
-CostFunctionFactory::CostFunctionFactory()
-{
+CostFunctionFactory::CostFunctionFactory() {}
 
+boost::shared_ptr<CostFunctionFactory> CostFunctionFactory::instance(void) {
+  if (m_instance.get() == 0) {
+    m_instance.reset(new CostFunctionFactory);
+  }
+
+  return m_instance;
 }
 
-boost::shared_ptr<CostFunctionFactory>
-CostFunctionFactory::instance(void)
-{
-    if (m_instance.get() == 0)
-    {
-        m_instance.reset(new CostFunctionFactory);
-    }
+ceres::CostFunction* CostFunctionFactory::generateCostFunction(const CameraConstPtr& camera,
+                                                               const Eigen::Vector3d& observed_P,
+                                                               const Eigen::Vector2d& observed_p,
+                                                               int flags) const {
+  ceres::CostFunction* costFunction = 0;
 
-    return m_instance;
-}
+  std::vector<double> intrinsic_params;
+  camera->writeParameters(intrinsic_params);
 
-ceres::CostFunction*
-CostFunctionFactory::generateCostFunction(const CameraConstPtr& camera,
-        const Eigen::Vector3d& observed_P,
-        const Eigen::Vector2d& observed_p,
-        int flags) const
-{
-    ceres::CostFunction* costFunction = 0;
-
-    std::vector<double> intrinsic_params;
-    camera->writeParameters(intrinsic_params);
-
-    switch (flags)
-    {
+  switch (flags) {
     case CAMERA_INTRINSICS | CAMERA_POSE:
-        switch (camera->modelType())
-        {
+      switch (camera->modelType()) {
         case Camera::KANNALA_BRANDT:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError1<EquidistantCamera>, 2, 8, 4, 3>(
-                new ReprojectionError1<EquidistantCamera>(observed_P, observed_p));
-            break;
+          costFunction =
+              new ceres::AutoDiffCostFunction<ReprojectionError1<EquidistantCamera>, 2, 8, 4, 3>(
+                  new ReprojectionError1<EquidistantCamera>(observed_P, observed_p));
+          break;
         case Camera::PINHOLE:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError1<PinholeCamera>, 2, 8, 4, 3>(
-                new ReprojectionError1<PinholeCamera>(observed_P, observed_p));
-            break;
+          costFunction =
+              new ceres::AutoDiffCostFunction<ReprojectionError1<PinholeCamera>, 2, 8, 4, 3>(
+                  new ReprojectionError1<PinholeCamera>(observed_P, observed_p));
+          break;
         case Camera::MEI:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError1<CataCamera>, 2, 9, 4, 3>(
-                new ReprojectionError1<CataCamera>(observed_P, observed_p));
-            break;
+          costFunction =
+              new ceres::AutoDiffCostFunction<ReprojectionError1<CataCamera>, 2, 9, 4, 3>(
+                  new ReprojectionError1<CataCamera>(observed_P, observed_p));
+          break;
         case Camera::SCARAMUZZA:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ComprehensionError<OCAMCamera>, 4, SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 3>(
-                new ComprehensionError<OCAMCamera>(observed_P, observed_p));
-                // new ceres::AutoDiffCostFunction<ReprojectionError1<OCAMCamera>, 2, SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 3>(
-                // new ReprojectionError1<OCAMCamera>(observed_P, observed_p));
-            break;
-        }
-        break;
+          costFunction = new ceres::AutoDiffCostFunction<ComprehensionError<OCAMCamera>, 4,
+                                                         SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 3>(
+              new ComprehensionError<OCAMCamera>(observed_P, observed_p));
+          // new ceres::AutoDiffCostFunction<ReprojectionError1<OCAMCamera>, 2,
+          // SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 3>( new ReprojectionError1<OCAMCamera>(observed_P,
+          // observed_p));
+          break;
+      }
+      break;
     case CAMERA_ODOMETRY_TRANSFORM | ODOMETRY_6D_POSE:
-        switch (camera->modelType())
-        {
+      switch (camera->modelType()) {
         case Camera::KANNALA_BRANDT:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError1<EquidistantCamera>, 2, 4, 3, 3, 3>(
-                new ReprojectionError1<EquidistantCamera>(intrinsic_params, observed_P, observed_p));
-            break;
+          costFunction =
+              new ceres::AutoDiffCostFunction<ReprojectionError1<EquidistantCamera>, 2, 4, 3, 3, 3>(
+                  new ReprojectionError1<EquidistantCamera>(intrinsic_params, observed_P,
+                                                            observed_p));
+          break;
         case Camera::PINHOLE:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError1<PinholeCamera>, 2, 4, 3, 3, 3>(
-                new ReprojectionError1<PinholeCamera>(intrinsic_params, observed_P, observed_p));
-            break;
+          costFunction =
+              new ceres::AutoDiffCostFunction<ReprojectionError1<PinholeCamera>, 2, 4, 3, 3, 3>(
+                  new ReprojectionError1<PinholeCamera>(intrinsic_params, observed_P, observed_p));
+          break;
         case Camera::MEI:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError1<CataCamera>, 2, 4, 3, 3, 3>(
-                new ReprojectionError1<CataCamera>(intrinsic_params, observed_P, observed_p));
-            break;
+          costFunction =
+              new ceres::AutoDiffCostFunction<ReprojectionError1<CataCamera>, 2, 4, 3, 3, 3>(
+                  new ReprojectionError1<CataCamera>(intrinsic_params, observed_P, observed_p));
+          break;
         case Camera::SCARAMUZZA:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError1<OCAMCamera>, 2, 4, 3, 3, 3>(
-                new ReprojectionError1<OCAMCamera>(intrinsic_params, observed_P, observed_p));
-            break;
-        }
-        break;
-    }
+          costFunction =
+              new ceres::AutoDiffCostFunction<ReprojectionError1<OCAMCamera>, 2, 4, 3, 3, 3>(
+                  new ReprojectionError1<OCAMCamera>(intrinsic_params, observed_P, observed_p));
+          break;
+      }
+      break;
+  }
 
-    return costFunction;
+  return costFunction;
 }
 
-ceres::CostFunction*
-CostFunctionFactory::generateCostFunction(const CameraConstPtr& camera,
-        const Eigen::Vector3d& observed_P,
-        const Eigen::Vector2d& observed_p,
-        const Eigen::Matrix2d& sqrtPrecisionMat,
-        int flags) const
-{
-    ceres::CostFunction* costFunction = 0;
+ceres::CostFunction* CostFunctionFactory::generateCostFunction(
+    const CameraConstPtr& camera, const Eigen::Vector3d& observed_P,
+    const Eigen::Vector2d& observed_p, const Eigen::Matrix2d& sqrtPrecisionMat, int flags) const {
+  ceres::CostFunction* costFunction = 0;
 
-    std::vector<double> intrinsic_params;
-    camera->writeParameters(intrinsic_params);
+  std::vector<double> intrinsic_params;
+  camera->writeParameters(intrinsic_params);
 
-    switch (flags)
-    {
+  switch (flags) {
     case CAMERA_INTRINSICS | CAMERA_POSE:
-        switch (camera->modelType())
-        {
+      switch (camera->modelType()) {
         case Camera::KANNALA_BRANDT:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError1<EquidistantCamera>, 2, 8, 4, 3>(
-                new ReprojectionError1<EquidistantCamera>(observed_P, observed_p, sqrtPrecisionMat));
-            break;
+          costFunction =
+              new ceres::AutoDiffCostFunction<ReprojectionError1<EquidistantCamera>, 2, 8, 4, 3>(
+                  new ReprojectionError1<EquidistantCamera>(observed_P, observed_p,
+                                                            sqrtPrecisionMat));
+          break;
         case Camera::PINHOLE:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError1<PinholeCamera>, 2, 8, 4, 3>(
-                new ReprojectionError1<PinholeCamera>(observed_P, observed_p, sqrtPrecisionMat));
-            break;
+          costFunction =
+              new ceres::AutoDiffCostFunction<ReprojectionError1<PinholeCamera>, 2, 8, 4, 3>(
+                  new ReprojectionError1<PinholeCamera>(observed_P, observed_p, sqrtPrecisionMat));
+          break;
         case Camera::MEI:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError1<CataCamera>, 2, 9, 4, 3>(
-                new ReprojectionError1<CataCamera>(observed_P, observed_p, sqrtPrecisionMat));
-            break;
+          costFunction =
+              new ceres::AutoDiffCostFunction<ReprojectionError1<CataCamera>, 2, 9, 4, 3>(
+                  new ReprojectionError1<CataCamera>(observed_P, observed_p, sqrtPrecisionMat));
+          break;
         case Camera::SCARAMUZZA:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError1<OCAMCamera>, 2, SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 3>(
-                new ReprojectionError1<OCAMCamera>(observed_P, observed_p, sqrtPrecisionMat));
-            break;
-        }
-        break;
-    }
+          costFunction = new ceres::AutoDiffCostFunction<ReprojectionError1<OCAMCamera>, 2,
+                                                         SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 3>(
+              new ReprojectionError1<OCAMCamera>(observed_P, observed_p, sqrtPrecisionMat));
+          break;
+      }
+      break;
+  }
 
-    return costFunction;
+  return costFunction;
 }
 
-ceres::CostFunction*
-CostFunctionFactory::generateCostFunction(const CameraConstPtr& camera,
-        const Eigen::Vector2d& observed_p,
-        int flags, bool optimize_cam_odo_z) const
-{
-    ceres::CostFunction* costFunction = 0;
+ceres::CostFunction* CostFunctionFactory::generateCostFunction(const CameraConstPtr& camera,
+                                                               const Eigen::Vector2d& observed_p,
+                                                               int flags,
+                                                               bool optimize_cam_odo_z) const {
+  ceres::CostFunction* costFunction = 0;
 
-    std::vector<double> intrinsic_params;
-    camera->writeParameters(intrinsic_params);
+  std::vector<double> intrinsic_params;
+  camera->writeParameters(intrinsic_params);
 
-    switch (flags)
-    {
+  switch (flags) {
     case CAMERA_POSE | POINT_3D:
-        switch (camera->modelType())
-        {
+      switch (camera->modelType()) {
         case Camera::KANNALA_BRANDT:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError2<EquidistantCamera>, 2, 4, 3, 3>(
-                new ReprojectionError2<EquidistantCamera>(intrinsic_params, observed_p));
-            break;
+          costFunction =
+              new ceres::AutoDiffCostFunction<ReprojectionError2<EquidistantCamera>, 2, 4, 3, 3>(
+                  new ReprojectionError2<EquidistantCamera>(intrinsic_params, observed_p));
+          break;
         case Camera::PINHOLE:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError2<PinholeCamera>, 2, 4, 3, 3>(
-                new ReprojectionError2<PinholeCamera>(intrinsic_params, observed_p));
-            break;
+          costFunction =
+              new ceres::AutoDiffCostFunction<ReprojectionError2<PinholeCamera>, 2, 4, 3, 3>(
+                  new ReprojectionError2<PinholeCamera>(intrinsic_params, observed_p));
+          break;
         case Camera::MEI:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError2<CataCamera>, 2, 4, 3, 3>(
-                new ReprojectionError2<CataCamera>(intrinsic_params, observed_p));
-            break;
+          costFunction =
+              new ceres::AutoDiffCostFunction<ReprojectionError2<CataCamera>, 2, 4, 3, 3>(
+                  new ReprojectionError2<CataCamera>(intrinsic_params, observed_p));
+          break;
         case Camera::SCARAMUZZA:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError2<OCAMCamera>, 2, 4, 3, 3>(
-                new ReprojectionError2<OCAMCamera>(intrinsic_params, observed_p));
-            break;
-        }
-        break;
+          costFunction =
+              new ceres::AutoDiffCostFunction<ReprojectionError2<OCAMCamera>, 2, 4, 3, 3>(
+                  new ReprojectionError2<OCAMCamera>(intrinsic_params, observed_p));
+          break;
+      }
+      break;
     case CAMERA_ODOMETRY_TRANSFORM | ODOMETRY_3D_POSE | POINT_3D:
-        switch (camera->modelType())
-        {
+      switch (camera->modelType()) {
         case Camera::KANNALA_BRANDT:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2, 4, 3, 2, 1, 3>(
-                    new ReprojectionError3<EquidistantCamera>(intrinsic_params, observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 2, 2, 1, 3>(
-                    new ReprojectionError3<PinholeCamera>(intrinsic_params, observed_p));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2,
+                                                           4, 3, 2, 1, 3>(
+                new ReprojectionError3<EquidistantCamera>(intrinsic_params, observed_p));
+          } else {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4,
+                                                           2, 2, 1, 3>(
+                new ReprojectionError3<PinholeCamera>(intrinsic_params, observed_p));
+          }
+          break;
         case Camera::PINHOLE:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 3, 2, 1, 3>(
-                    new ReprojectionError3<PinholeCamera>(intrinsic_params, observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 2, 2, 1, 3>(
-                    new ReprojectionError3<PinholeCamera>(intrinsic_params, observed_p));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4,
+                                                           3, 2, 1, 3>(
+                new ReprojectionError3<PinholeCamera>(intrinsic_params, observed_p));
+          } else {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4,
+                                                           2, 2, 1, 3>(
+                new ReprojectionError3<PinholeCamera>(intrinsic_params, observed_p));
+          }
+          break;
         case Camera::MEI:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 3, 2, 1, 3>(
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 3, 2, 1, 3>(
                     new ReprojectionError3<CataCamera>(intrinsic_params, observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 2, 2, 1, 3>(
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 2, 2, 1, 3>(
                     new ReprojectionError3<CataCamera>(intrinsic_params, observed_p));
-            }
-            break;
+          }
+          break;
         case Camera::SCARAMUZZA:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 3, 2, 1, 3>(
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 3, 2, 1, 3>(
                     new ReprojectionError3<OCAMCamera>(intrinsic_params, observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 2, 2, 1, 3>(
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 2, 2, 1, 3>(
                     new ReprojectionError3<OCAMCamera>(intrinsic_params, observed_p));
-            }
-            break;
-        }
-        break;
+          }
+          break;
+      }
+      break;
     case CAMERA_ODOMETRY_TRANSFORM | ODOMETRY_6D_POSE | POINT_3D:
-        switch (camera->modelType())
-        {
+      switch (camera->modelType()) {
         case Camera::KANNALA_BRANDT:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2, 4, 3, 3, 3, 3>(
-                    new ReprojectionError3<EquidistantCamera>(intrinsic_params, observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 2, 3, 3, 3>(
-                    new ReprojectionError3<PinholeCamera>(intrinsic_params, observed_p));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2,
+                                                           4, 3, 3, 3, 3>(
+                new ReprojectionError3<EquidistantCamera>(intrinsic_params, observed_p));
+          } else {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4,
+                                                           2, 3, 3, 3>(
+                new ReprojectionError3<PinholeCamera>(intrinsic_params, observed_p));
+          }
+          break;
         case Camera::PINHOLE:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 3, 3, 3, 3>(
-                    new ReprojectionError3<PinholeCamera>(intrinsic_params, observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 2, 3, 3, 3>(
-                    new ReprojectionError3<PinholeCamera>(intrinsic_params, observed_p));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4,
+                                                           3, 3, 3, 3>(
+                new ReprojectionError3<PinholeCamera>(intrinsic_params, observed_p));
+          } else {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4,
+                                                           2, 3, 3, 3>(
+                new ReprojectionError3<PinholeCamera>(intrinsic_params, observed_p));
+          }
+          break;
         case Camera::MEI:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 3, 3, 3, 3>(
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 3, 3, 3, 3>(
                     new ReprojectionError3<CataCamera>(intrinsic_params, observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 2, 3, 3, 3>(
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 2, 3, 3, 3>(
                     new ReprojectionError3<CataCamera>(intrinsic_params, observed_p));
-            }
-            break;
+          }
+          break;
         case Camera::SCARAMUZZA:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 3, 3, 3, 3>(
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 3, 3, 3, 3>(
                     new ReprojectionError3<OCAMCamera>(intrinsic_params, observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 2, 3, 3, 3>(
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 2, 3, 3, 3>(
                     new ReprojectionError3<OCAMCamera>(intrinsic_params, observed_p));
-            }
-            break;
-        }
-        break;
+          }
+          break;
+      }
+      break;
     case CAMERA_INTRINSICS | CAMERA_ODOMETRY_TRANSFORM | ODOMETRY_3D_POSE | POINT_3D:
-        switch (camera->modelType())
-        {
+      switch (camera->modelType()) {
         case Camera::KANNALA_BRANDT:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2, 8, 4, 3, 2, 1, 3>(
-                    new ReprojectionError3<EquidistantCamera>(observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8, 4, 2, 2, 1, 3>(
-                    new ReprojectionError3<PinholeCamera>(observed_p));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2,
+                                                           8, 4, 3, 2, 1, 3>(
+                new ReprojectionError3<EquidistantCamera>(observed_p));
+          } else {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8,
+                                                           4, 2, 2, 1, 3>(
+                new ReprojectionError3<PinholeCamera>(observed_p));
+          }
+          break;
         case Camera::PINHOLE:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8, 4, 3, 2, 1, 3>(
-                    new ReprojectionError3<PinholeCamera>(observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8, 4, 2, 2, 1, 3>(
-                    new ReprojectionError3<PinholeCamera>(observed_p));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8,
+                                                           4, 3, 2, 1, 3>(
+                new ReprojectionError3<PinholeCamera>(observed_p));
+          } else {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8,
+                                                           4, 2, 2, 1, 3>(
+                new ReprojectionError3<PinholeCamera>(observed_p));
+          }
+          break;
         case Camera::MEI:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 9, 4, 3, 2, 1, 3>(
-                    new ReprojectionError3<CataCamera>(observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 9, 4, 2, 2, 1, 3>(
-                    new ReprojectionError3<CataCamera>(observed_p));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 9, 4, 3, 2, 1,
+                                                3>(new ReprojectionError3<CataCamera>(observed_p));
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 9, 4, 2, 2, 1,
+                                                3>(new ReprojectionError3<CataCamera>(observed_p));
+          }
+          break;
         case Camera::SCARAMUZZA:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 3, 2, 1, 3>(
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2,
+                                                SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 3, 2, 1, 3>(
                     new ReprojectionError3<OCAMCamera>(observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 2, 2, 1, 3>(
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2,
+                                                SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 2, 2, 1, 3>(
                     new ReprojectionError3<OCAMCamera>(observed_p));
-            }
-            break;
-        }
-        break;
+          }
+          break;
+      }
+      break;
     case CAMERA_INTRINSICS | CAMERA_ODOMETRY_TRANSFORM | ODOMETRY_6D_POSE | POINT_3D:
-        switch (camera->modelType())
-        {
+      switch (camera->modelType()) {
         case Camera::KANNALA_BRANDT:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2, 8, 4, 3, 3, 3, 3>(
-                    new ReprojectionError3<EquidistantCamera>(observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8, 4, 2, 3, 3, 3>(
-                    new ReprojectionError3<PinholeCamera>(observed_p));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2,
+                                                           8, 4, 3, 3, 3, 3>(
+                new ReprojectionError3<EquidistantCamera>(observed_p));
+          } else {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8,
+                                                           4, 2, 3, 3, 3>(
+                new ReprojectionError3<PinholeCamera>(observed_p));
+          }
+          break;
         case Camera::PINHOLE:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8, 4, 3, 3, 3, 3>(
-                    new ReprojectionError3<PinholeCamera>(observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8, 4, 2, 3, 3, 3>(
-                    new ReprojectionError3<PinholeCamera>(observed_p));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8,
+                                                           4, 3, 3, 3, 3>(
+                new ReprojectionError3<PinholeCamera>(observed_p));
+          } else {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8,
+                                                           4, 2, 3, 3, 3>(
+                new ReprojectionError3<PinholeCamera>(observed_p));
+          }
+          break;
         case Camera::MEI:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 9, 4, 3, 3, 3, 3>(
-                    new ReprojectionError3<CataCamera>(observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 9, 4, 2, 3, 3, 3>(
-                    new ReprojectionError3<CataCamera>(observed_p));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 9, 4, 3, 3, 3,
+                                                3>(new ReprojectionError3<CataCamera>(observed_p));
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 9, 4, 2, 3, 3,
+                                                3>(new ReprojectionError3<CataCamera>(observed_p));
+          }
+          break;
         case Camera::SCARAMUZZA:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 3, 3, 3, 3>(
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2,
+                                                SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 3, 3, 3, 3>(
                     new ReprojectionError3<OCAMCamera>(observed_p));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 2, 3, 3, 3>(
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2,
+                                                SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 2, 3, 3, 3>(
                     new ReprojectionError3<OCAMCamera>(observed_p));
-            }
-            break;
-        }
-        break;
-    }
+          }
+          break;
+      }
+      break;
+  }
 
-    return costFunction;
+  return costFunction;
 }
 
-ceres::CostFunction*
-CostFunctionFactory::generateCostFunction(const CameraConstPtr& camera,
-        const Eigen::Vector2d& observed_p,
-        const Eigen::Matrix2d& sqrtPrecisionMat,
-        int flags, bool optimize_cam_odo_z) const
-{
-    ceres::CostFunction* costFunction = 0;
+ceres::CostFunction* CostFunctionFactory::generateCostFunction(
+    const CameraConstPtr& camera, const Eigen::Vector2d& observed_p,
+    const Eigen::Matrix2d& sqrtPrecisionMat, int flags, bool optimize_cam_odo_z) const {
+  ceres::CostFunction* costFunction = 0;
 
-    std::vector<double> intrinsic_params;
-    camera->writeParameters(intrinsic_params);
+  std::vector<double> intrinsic_params;
+  camera->writeParameters(intrinsic_params);
 
-    switch (flags)
-    {
+  switch (flags) {
     case CAMERA_ODOMETRY_TRANSFORM | ODOMETRY_6D_POSE | POINT_3D:
-        switch (camera->modelType())
-        {
+      switch (camera->modelType()) {
         case Camera::KANNALA_BRANDT:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2, 4, 3, 3, 3, 3>(
-                    new ReprojectionError3<EquidistantCamera>(intrinsic_params, observed_p, sqrtPrecisionMat));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 2, 3, 3, 3>(
-                    new ReprojectionError3<PinholeCamera>(intrinsic_params, observed_p, sqrtPrecisionMat));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2, 4, 3, 3,
+                                                3, 3>(new ReprojectionError3<EquidistantCamera>(
+                    intrinsic_params, observed_p, sqrtPrecisionMat));
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 2, 3, 3,
+                                                3>(new ReprojectionError3<PinholeCamera>(
+                    intrinsic_params, observed_p, sqrtPrecisionMat));
+          }
+          break;
         case Camera::PINHOLE:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 3, 3, 3, 3>(
-                    new ReprojectionError3<PinholeCamera>(intrinsic_params, observed_p, sqrtPrecisionMat));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 2, 3, 3, 3>(
-                    new ReprojectionError3<PinholeCamera>(intrinsic_params, observed_p, sqrtPrecisionMat));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 3, 3, 3,
+                                                3>(new ReprojectionError3<PinholeCamera>(
+                    intrinsic_params, observed_p, sqrtPrecisionMat));
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 2, 3, 3,
+                                                3>(new ReprojectionError3<PinholeCamera>(
+                    intrinsic_params, observed_p, sqrtPrecisionMat));
+          }
+          break;
         case Camera::MEI:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 3, 3, 3, 3>(
-                    new ReprojectionError3<CataCamera>(intrinsic_params, observed_p, sqrtPrecisionMat));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 2, 3, 3, 3>(
-                    new ReprojectionError3<CataCamera>(intrinsic_params, observed_p, sqrtPrecisionMat));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 3, 3, 3, 3>(
+                    new ReprojectionError3<CataCamera>(intrinsic_params, observed_p,
+                                                       sqrtPrecisionMat));
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 2, 3, 3, 3>(
+                    new ReprojectionError3<CataCamera>(intrinsic_params, observed_p,
+                                                       sqrtPrecisionMat));
+          }
+          break;
         case Camera::SCARAMUZZA:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 3, 3, 3, 3>(
-                    new ReprojectionError3<OCAMCamera>(intrinsic_params, observed_p, sqrtPrecisionMat));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 2, 3, 3, 3>(
-                    new ReprojectionError3<OCAMCamera>(intrinsic_params, observed_p, sqrtPrecisionMat));
-            }
-            break;
-        }
-        break;
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 3, 3, 3, 3>(
+                    new ReprojectionError3<OCAMCamera>(intrinsic_params, observed_p,
+                                                       sqrtPrecisionMat));
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 2, 3, 3, 3>(
+                    new ReprojectionError3<OCAMCamera>(intrinsic_params, observed_p,
+                                                       sqrtPrecisionMat));
+          }
+          break;
+      }
+      break;
     case CAMERA_INTRINSICS | CAMERA_ODOMETRY_TRANSFORM | ODOMETRY_6D_POSE | POINT_3D:
-        switch (camera->modelType())
-        {
+      switch (camera->modelType()) {
         case Camera::KANNALA_BRANDT:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2, 8, 4, 3, 3, 3, 3>(
-                    new ReprojectionError3<EquidistantCamera>(observed_p, sqrtPrecisionMat));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8, 4, 2, 3, 3, 3>(
-                    new ReprojectionError3<PinholeCamera>(observed_p, sqrtPrecisionMat));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2,
+                                                           8, 4, 3, 3, 3, 3>(
+                new ReprojectionError3<EquidistantCamera>(observed_p, sqrtPrecisionMat));
+          } else {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8,
+                                                           4, 2, 3, 3, 3>(
+                new ReprojectionError3<PinholeCamera>(observed_p, sqrtPrecisionMat));
+          }
+          break;
         case Camera::PINHOLE:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8, 4, 3, 3, 3, 3>(
-                    new ReprojectionError3<PinholeCamera>(observed_p, sqrtPrecisionMat));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8, 4, 2, 3, 3, 3>(
-                    new ReprojectionError3<PinholeCamera>(observed_p, sqrtPrecisionMat));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8,
+                                                           4, 3, 3, 3, 3>(
+                new ReprojectionError3<PinholeCamera>(observed_p, sqrtPrecisionMat));
+          } else {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 8,
+                                                           4, 2, 3, 3, 3>(
+                new ReprojectionError3<PinholeCamera>(observed_p, sqrtPrecisionMat));
+          }
+          break;
         case Camera::MEI:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 9, 4, 3, 3, 3, 3>(
-                    new ReprojectionError3<CataCamera>(observed_p, sqrtPrecisionMat));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 9, 4, 2, 3, 3, 3>(
-                    new ReprojectionError3<CataCamera>(observed_p, sqrtPrecisionMat));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 9, 4,
+                                                           3, 3, 3, 3>(
+                new ReprojectionError3<CataCamera>(observed_p, sqrtPrecisionMat));
+          } else {
+            costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 9, 4,
+                                                           2, 3, 3, 3>(
+                new ReprojectionError3<CataCamera>(observed_p, sqrtPrecisionMat));
+          }
+          break;
         case Camera::SCARAMUZZA:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 3, 3, 3, 3>(
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2,
+                                                SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 3, 3, 3, 3>(
                     new ReprojectionError3<OCAMCamera>(observed_p, sqrtPrecisionMat));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 2, 3, 3, 3>(
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2,
+                                                SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 2, 3, 3, 3>(
                     new ReprojectionError3<OCAMCamera>(observed_p, sqrtPrecisionMat));
-            }
-            break;
-        }
-        break;
-    }
+          }
+          break;
+      }
+      break;
+  }
 
-    return costFunction;
+  return costFunction;
 }
 
-ceres::CostFunction*
-CostFunctionFactory::generateCostFunction(const CameraConstPtr& camera,
-        const Eigen::Vector3d& odo_pos,
-        const Eigen::Vector3d& odo_att,
-        const Eigen::Vector2d& observed_p,
-        int flags, bool optimize_cam_odo_z) const
-{
-    ceres::CostFunction* costFunction = 0;
+ceres::CostFunction* CostFunctionFactory::generateCostFunction(
+    const CameraConstPtr& camera, const Eigen::Vector3d& odo_pos, const Eigen::Vector3d& odo_att,
+    const Eigen::Vector2d& observed_p, int flags, bool optimize_cam_odo_z) const {
+  ceres::CostFunction* costFunction = 0;
 
-    std::vector<double> intrinsic_params;
-    camera->writeParameters(intrinsic_params);
+  std::vector<double> intrinsic_params;
+  camera->writeParameters(intrinsic_params);
 
-    switch (flags)
-    {
+  switch (flags) {
     case CAMERA_ODOMETRY_TRANSFORM | POINT_3D:
-        switch (camera->modelType())
-        {
+      switch (camera->modelType()) {
         case Camera::KANNALA_BRANDT:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2, 4, 3, 3>(
-                    new ReprojectionError3<EquidistantCamera>(intrinsic_params, odo_pos, odo_att, observed_p, optimize_cam_odo_z));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2, 4, 2, 3>(
-                    new ReprojectionError3<EquidistantCamera>(intrinsic_params, odo_pos, odo_att, observed_p, optimize_cam_odo_z));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2, 4, 3, 3>(
+                    new ReprojectionError3<EquidistantCamera>(intrinsic_params, odo_pos, odo_att,
+                                                              observed_p, optimize_cam_odo_z));
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2, 4, 2, 3>(
+                    new ReprojectionError3<EquidistantCamera>(intrinsic_params, odo_pos, odo_att,
+                                                              observed_p, optimize_cam_odo_z));
+          }
+          break;
         case Camera::PINHOLE:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 3, 3>(
-                    new ReprojectionError3<PinholeCamera>(intrinsic_params, odo_pos, odo_att, observed_p, optimize_cam_odo_z));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 2, 3>(
-                    new ReprojectionError3<PinholeCamera>(intrinsic_params, odo_pos, odo_att, observed_p, optimize_cam_odo_z));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 3, 3>(
+                    new ReprojectionError3<PinholeCamera>(intrinsic_params, odo_pos, odo_att,
+                                                          observed_p, optimize_cam_odo_z));
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 4, 2, 3>(
+                    new ReprojectionError3<PinholeCamera>(intrinsic_params, odo_pos, odo_att,
+                                                          observed_p, optimize_cam_odo_z));
+          }
+          break;
         case Camera::MEI:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 3, 3>(
-                    new ReprojectionError3<CataCamera>(intrinsic_params, odo_pos, odo_att, observed_p, optimize_cam_odo_z));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 2, 3>(
-                    new ReprojectionError3<CataCamera>(intrinsic_params, odo_pos, odo_att, observed_p, optimize_cam_odo_z));
-            }
-            break;
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 3, 3>(
+                    new ReprojectionError3<CataCamera>(intrinsic_params, odo_pos, odo_att,
+                                                       observed_p, optimize_cam_odo_z));
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 4, 2, 3>(
+                    new ReprojectionError3<CataCamera>(intrinsic_params, odo_pos, odo_att,
+                                                       observed_p, optimize_cam_odo_z));
+          }
+          break;
         case Camera::SCARAMUZZA:
-            if (optimize_cam_odo_z)
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 3, 3>(
-                    new ReprojectionError3<OCAMCamera>(intrinsic_params, odo_pos, odo_att, observed_p, optimize_cam_odo_z));
-            }
-            else
-            {
-                costFunction =
-                    new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 2, 3>(
-                    new ReprojectionError3<OCAMCamera>(intrinsic_params, odo_pos, odo_att, observed_p, optimize_cam_odo_z));
-            }
-            break;
-        }
-        break;
-    }
+          if (optimize_cam_odo_z) {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 3, 3>(
+                    new ReprojectionError3<OCAMCamera>(intrinsic_params, odo_pos, odo_att,
+                                                       observed_p, optimize_cam_odo_z));
+          } else {
+            costFunction =
+                new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 4, 2, 3>(
+                    new ReprojectionError3<OCAMCamera>(intrinsic_params, odo_pos, odo_att,
+                                                       observed_p, optimize_cam_odo_z));
+          }
+          break;
+      }
+      break;
+  }
 
-    return costFunction;
+  return costFunction;
 }
 
-ceres::CostFunction*
-CostFunctionFactory::generateCostFunction(const CameraConstPtr& camera,
-        const Eigen::Quaterniond& cam_odo_q,
-        const Eigen::Vector3d& cam_odo_t,
-        const Eigen::Vector3d& odo_pos,
-        const Eigen::Vector3d& odo_att,
-        const Eigen::Vector2d& observed_p,
-        int flags) const
-{
-    ceres::CostFunction* costFunction = 0;
+ceres::CostFunction* CostFunctionFactory::generateCostFunction(
+    const CameraConstPtr& camera, const Eigen::Quaterniond& cam_odo_q,
+    const Eigen::Vector3d& cam_odo_t, const Eigen::Vector3d& odo_pos,
+    const Eigen::Vector3d& odo_att, const Eigen::Vector2d& observed_p, int flags) const {
+  ceres::CostFunction* costFunction = 0;
 
-    std::vector<double> intrinsic_params;
-    camera->writeParameters(intrinsic_params);
+  std::vector<double> intrinsic_params;
+  camera->writeParameters(intrinsic_params);
 
-    switch (flags)
-    {
+  switch (flags) {
     case POINT_3D:
-        switch (camera->modelType())
-        {
+      switch (camera->modelType()) {
         case Camera::KANNALA_BRANDT:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2, 3>(
-                new ReprojectionError3<EquidistantCamera>(intrinsic_params, cam_odo_q, cam_odo_t, odo_pos, odo_att, observed_p));
-            break;
+          costFunction =
+              new ceres::AutoDiffCostFunction<ReprojectionError3<EquidistantCamera>, 2, 3>(
+                  new ReprojectionError3<EquidistantCamera>(intrinsic_params, cam_odo_q, cam_odo_t,
+                                                            odo_pos, odo_att, observed_p));
+          break;
         case Camera::PINHOLE:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 3>(
-                new ReprojectionError3<PinholeCamera>(intrinsic_params, cam_odo_q, cam_odo_t, odo_pos, odo_att, observed_p));
-            break;
+          costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<PinholeCamera>, 2, 3>(
+              new ReprojectionError3<PinholeCamera>(intrinsic_params, cam_odo_q, cam_odo_t, odo_pos,
+                                                    odo_att, observed_p));
+          break;
         case Camera::MEI:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 3>(
-                new ReprojectionError3<CataCamera>(intrinsic_params, cam_odo_q, cam_odo_t, odo_pos, odo_att, observed_p));
-            break;
+          costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<CataCamera>, 2, 3>(
+              new ReprojectionError3<CataCamera>(intrinsic_params, cam_odo_q, cam_odo_t, odo_pos,
+                                                 odo_att, observed_p));
+          break;
         case Camera::SCARAMUZZA:
-            costFunction =
-                new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 3>(
-                new ReprojectionError3<OCAMCamera>(intrinsic_params, cam_odo_q, cam_odo_t, odo_pos, odo_att, observed_p));
-            break;
-        }
-        break;
-    }
+          costFunction = new ceres::AutoDiffCostFunction<ReprojectionError3<OCAMCamera>, 2, 3>(
+              new ReprojectionError3<OCAMCamera>(intrinsic_params, cam_odo_q, cam_odo_t, odo_pos,
+                                                 odo_att, observed_p));
+          break;
+      }
+      break;
+  }
 
-    return costFunction;
+  return costFunction;
 }
 
-ceres::CostFunction*
-CostFunctionFactory::generateCostFunction(const CameraConstPtr& cameraL,
-        const CameraConstPtr& cameraR,
-        const Eigen::Vector3d& observed_P,
-        const Eigen::Vector2d& observed_p_l,
-        const Eigen::Vector2d& observed_p_r) const
-{
-    ceres::CostFunction* costFunction = 0;
+ceres::CostFunction* CostFunctionFactory::generateCostFunction(
+    const CameraConstPtr& cameraL, const CameraConstPtr& cameraR, const Eigen::Vector3d& observed_P,
+    const Eigen::Vector2d& observed_p_l, const Eigen::Vector2d& observed_p_r) const {
+  ceres::CostFunction* costFunction = 0;
 
-    if (cameraL->modelType() != cameraR->modelType())
-    {
-        return costFunction;
-    }
+  if (cameraL->modelType() != cameraR->modelType()) {
+    return costFunction;
+  }
 
-    switch (cameraL->modelType())
-    {
+  switch (cameraL->modelType()) {
     case Camera::KANNALA_BRANDT:
-        costFunction =
-            new ceres::AutoDiffCostFunction<StereoReprojectionError<EquidistantCamera>, 4, 8, 8, 4, 3, 4, 3>(
-            new StereoReprojectionError<EquidistantCamera>(observed_P, observed_p_l, observed_p_r));
-        break;
+      costFunction = new ceres::AutoDiffCostFunction<StereoReprojectionError<EquidistantCamera>, 4,
+                                                     8, 8, 4, 3, 4, 3>(
+          new StereoReprojectionError<EquidistantCamera>(observed_P, observed_p_l, observed_p_r));
+      break;
     case Camera::PINHOLE:
-        costFunction =
-            new ceres::AutoDiffCostFunction<StereoReprojectionError<PinholeCamera>, 4, 8, 8, 4, 3, 4, 3>(
-            new StereoReprojectionError<PinholeCamera>(observed_P, observed_p_l, observed_p_r));
-        break;
+      costFunction = new ceres::AutoDiffCostFunction<StereoReprojectionError<PinholeCamera>, 4, 8,
+                                                     8, 4, 3, 4, 3>(
+          new StereoReprojectionError<PinholeCamera>(observed_P, observed_p_l, observed_p_r));
+      break;
     case Camera::MEI:
-        costFunction =
-            new ceres::AutoDiffCostFunction<StereoReprojectionError<CataCamera>, 4, 9, 9, 4, 3, 4, 3>(
-            new StereoReprojectionError<CataCamera>(observed_P, observed_p_l, observed_p_r));
-        break;
+      costFunction =
+          new ceres::AutoDiffCostFunction<StereoReprojectionError<CataCamera>, 4, 9, 9, 4, 3, 4, 3>(
+              new StereoReprojectionError<CataCamera>(observed_P, observed_p_l, observed_p_r));
+      break;
     case Camera::SCARAMUZZA:
-        costFunction =
-            new ceres::AutoDiffCostFunction<StereoReprojectionError<OCAMCamera>, 4, SCARAMUZZA_CAMERA_NUM_PARAMS, SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 3, 4, 3>(
-            new StereoReprojectionError<OCAMCamera>(observed_P, observed_p_l, observed_p_r));
-        break;
-    }
+      costFunction = new ceres::AutoDiffCostFunction<StereoReprojectionError<OCAMCamera>, 4,
+                                                     SCARAMUZZA_CAMERA_NUM_PARAMS,
+                                                     SCARAMUZZA_CAMERA_NUM_PARAMS, 4, 3, 4, 3>(
+          new StereoReprojectionError<OCAMCamera>(observed_P, observed_p_l, observed_p_r));
+      break;
+  }
 
-    return costFunction;
+  return costFunction;
 }
 
-}
-
+}  // namespace camodocal

--- a/src/frontend/camodocal/camera_models/EquidistantCamera.cc
+++ b/src/frontend/camodocal/camera_models/EquidistantCamera.cc
@@ -11,399 +11,272 @@
 
 #include "frontend/camodocal/gpl/gpl.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
 EquidistantCamera::Parameters::Parameters()
- : Camera::Parameters(KANNALA_BRANDT)
- , m_k2(0.0)
- , m_k3(0.0)
- , m_k4(0.0)
- , m_k5(0.0)
- , m_mu(0.0)
- , m_mv(0.0)
- , m_u0(0.0)
- , m_v0(0.0)
-{
+    : Camera::Parameters(KANNALA_BRANDT),
+      m_k2(0.0),
+      m_k3(0.0),
+      m_k4(0.0),
+      m_k5(0.0),
+      m_mu(0.0),
+      m_mv(0.0),
+      m_u0(0.0),
+      m_v0(0.0) {}
 
-}
-
-EquidistantCamera::Parameters::Parameters(const std::string& cameraName,
-                                          int w, int h,
-                                          double k2, double k3, double k4, double k5,
-                                          double mu, double mv,
+EquidistantCamera::Parameters::Parameters(const std::string& cameraName, int w, int h, double k2,
+                                          double k3, double k4, double k5, double mu, double mv,
                                           double u0, double v0)
- : Camera::Parameters(KANNALA_BRANDT, cameraName, w, h)
- , m_k2(k2)
- , m_k3(k3)
- , m_k4(k4)
- , m_k5(k5)
- , m_mu(mu)
- , m_mv(mv)
- , m_u0(u0)
- , m_v0(v0)
-{
+    : Camera::Parameters(KANNALA_BRANDT, cameraName, w, h),
+      m_k2(k2),
+      m_k3(k3),
+      m_k4(k4),
+      m_k5(k5),
+      m_mu(mu),
+      m_mv(mv),
+      m_u0(u0),
+      m_v0(v0) {}
 
-}
+double& EquidistantCamera::Parameters::k2(void) { return m_k2; }
 
-double&
-EquidistantCamera::Parameters::k2(void)
-{
-    return m_k2;
-}
+double& EquidistantCamera::Parameters::k3(void) { return m_k3; }
 
-double&
-EquidistantCamera::Parameters::k3(void)
-{
-    return m_k3;
-}
+double& EquidistantCamera::Parameters::k4(void) { return m_k4; }
 
-double&
-EquidistantCamera::Parameters::k4(void)
-{
-    return m_k4;
-}
+double& EquidistantCamera::Parameters::k5(void) { return m_k5; }
 
-double&
-EquidistantCamera::Parameters::k5(void)
-{
-    return m_k5;
-}
+double& EquidistantCamera::Parameters::mu(void) { return m_mu; }
 
-double&
-EquidistantCamera::Parameters::mu(void)
-{
-    return m_mu;
-}
+double& EquidistantCamera::Parameters::mv(void) { return m_mv; }
 
-double&
-EquidistantCamera::Parameters::mv(void)
-{
-    return m_mv;
-}
+double& EquidistantCamera::Parameters::u0(void) { return m_u0; }
 
-double&
-EquidistantCamera::Parameters::u0(void)
-{
-    return m_u0;
-}
+double& EquidistantCamera::Parameters::v0(void) { return m_v0; }
 
-double&
-EquidistantCamera::Parameters::v0(void)
-{
-    return m_v0;
-}
+double EquidistantCamera::Parameters::k2(void) const { return m_k2; }
 
-double
-EquidistantCamera::Parameters::k2(void) const
-{
-    return m_k2;
-}
+double EquidistantCamera::Parameters::k3(void) const { return m_k3; }
 
-double
-EquidistantCamera::Parameters::k3(void) const
-{
-    return m_k3;
-}
+double EquidistantCamera::Parameters::k4(void) const { return m_k4; }
 
-double
-EquidistantCamera::Parameters::k4(void) const
-{
-    return m_k4;
-}
+double EquidistantCamera::Parameters::k5(void) const { return m_k5; }
 
-double
-EquidistantCamera::Parameters::k5(void) const
-{
-    return m_k5;
-}
+double EquidistantCamera::Parameters::mu(void) const { return m_mu; }
 
-double
-EquidistantCamera::Parameters::mu(void) const
-{
-    return m_mu;
-}
+double EquidistantCamera::Parameters::mv(void) const { return m_mv; }
 
-double
-EquidistantCamera::Parameters::mv(void) const
-{
-    return m_mv;
-}
+double EquidistantCamera::Parameters::u0(void) const { return m_u0; }
 
-double
-EquidistantCamera::Parameters::u0(void) const
-{
-    return m_u0;
-}
+double EquidistantCamera::Parameters::v0(void) const { return m_v0; }
 
-double
-EquidistantCamera::Parameters::v0(void) const
-{
-    return m_v0;
-}
+bool EquidistantCamera::Parameters::readFromYamlFile(const std::string& filename) {
+  cv::FileStorage fs(filename, cv::FileStorage::READ);
 
-bool
-EquidistantCamera::Parameters::readFromYamlFile(const std::string& filename)
-{
-    cv::FileStorage fs(filename, cv::FileStorage::READ);
+  if (!fs.isOpened()) {
+    return false;
+  }
 
-    if (!fs.isOpened())
-    {
-        return false;
+  if (!fs["model_type"].isNone()) {
+    std::string sModelType;
+    fs["model_type"] >> sModelType;
+
+    if (sModelType.compare("KANNALA_BRANDT") != 0) {
+      return false;
     }
+  }
 
-    if (!fs["model_type"].isNone())
-    {
-        std::string sModelType;
-        fs["model_type"] >> sModelType;
+  m_modelType = KANNALA_BRANDT;
+  fs["camera_name"] >> m_cameraName;
+  m_imageWidth = static_cast<int>(fs["image_width"]);
+  m_imageHeight = static_cast<int>(fs["image_height"]);
 
-        if (sModelType.compare("KANNALA_BRANDT") != 0)
-        {
-            return false;
-        }
-    }
+  cv::FileNode n = fs["projection_parameters"];
+  m_k2 = static_cast<double>(n["k2"]);
+  m_k3 = static_cast<double>(n["k3"]);
+  m_k4 = static_cast<double>(n["k4"]);
+  m_k5 = static_cast<double>(n["k5"]);
+  m_mu = static_cast<double>(n["mu"]);
+  m_mv = static_cast<double>(n["mv"]);
+  m_u0 = static_cast<double>(n["u0"]);
+  m_v0 = static_cast<double>(n["v0"]);
 
-    m_modelType = KANNALA_BRANDT;
-    fs["camera_name"] >> m_cameraName;
-    m_imageWidth = static_cast<int>(fs["image_width"]);
-    m_imageHeight = static_cast<int>(fs["image_height"]);
-
-    cv::FileNode n = fs["projection_parameters"];
-    m_k2 = static_cast<double>(n["k2"]);
-    m_k3 = static_cast<double>(n["k3"]);
-    m_k4 = static_cast<double>(n["k4"]);
-    m_k5 = static_cast<double>(n["k5"]);
-    m_mu = static_cast<double>(n["mu"]);
-    m_mv = static_cast<double>(n["mv"]);
-    m_u0 = static_cast<double>(n["u0"]);
-    m_v0 = static_cast<double>(n["v0"]);
-
-    return true;
+  return true;
 }
 
-void
-EquidistantCamera::Parameters::writeToYamlFile(const std::string& filename) const
-{
-    cv::FileStorage fs(filename, cv::FileStorage::WRITE);
+void EquidistantCamera::Parameters::writeToYamlFile(const std::string& filename) const {
+  cv::FileStorage fs(filename, cv::FileStorage::WRITE);
 
-    fs << "model_type" << "KANNALA_BRANDT";
-    fs << "camera_name" << m_cameraName;
-    fs << "image_width" << m_imageWidth;
-    fs << "image_height" << m_imageHeight;
+  fs << "model_type" << "KANNALA_BRANDT";
+  fs << "camera_name" << m_cameraName;
+  fs << "image_width" << m_imageWidth;
+  fs << "image_height" << m_imageHeight;
 
-    // projection: k2, k3, k4, k5, mu, mv, u0, v0
-    fs << "projection_parameters";
-    fs << "{" << "k2" << m_k2
-              << "k3" << m_k3
-              << "k4" << m_k4
-              << "k5" << m_k5
-              << "mu" << m_mu
-              << "mv" << m_mv
-              << "u0" << m_u0
-              << "v0" << m_v0 << "}";
+  // projection: k2, k3, k4, k5, mu, mv, u0, v0
+  fs << "projection_parameters";
+  fs << "{" << "k2" << m_k2 << "k3" << m_k3 << "k4" << m_k4 << "k5" << m_k5 << "mu" << m_mu << "mv"
+     << m_mv << "u0" << m_u0 << "v0" << m_v0 << "}";
 
-    fs.release();
+  fs.release();
 }
 
-EquidistantCamera::Parameters&
-EquidistantCamera::Parameters::operator=(const EquidistantCamera::Parameters& other)
-{
-    if (this != &other)
-    {
-        m_modelType = other.m_modelType;
-        m_cameraName = other.m_cameraName;
-        m_imageWidth = other.m_imageWidth;
-        m_imageHeight = other.m_imageHeight;
-        m_k2 = other.m_k2;
-        m_k3 = other.m_k3;
-        m_k4 = other.m_k4;
-        m_k5 = other.m_k5;
-        m_mu = other.m_mu;
-        m_mv = other.m_mv;
-        m_u0 = other.m_u0;
-        m_v0 = other.m_v0;
-    }
+EquidistantCamera::Parameters& EquidistantCamera::Parameters::operator=(
+    const EquidistantCamera::Parameters& other) {
+  if (this != &other) {
+    m_modelType = other.m_modelType;
+    m_cameraName = other.m_cameraName;
+    m_imageWidth = other.m_imageWidth;
+    m_imageHeight = other.m_imageHeight;
+    m_k2 = other.m_k2;
+    m_k3 = other.m_k3;
+    m_k4 = other.m_k4;
+    m_k5 = other.m_k5;
+    m_mu = other.m_mu;
+    m_mv = other.m_mv;
+    m_u0 = other.m_u0;
+    m_v0 = other.m_v0;
+  }
 
-    return *this;
+  return *this;
 }
 
-std::ostream&
-operator<< (std::ostream& out, const EquidistantCamera::Parameters& params)
-{
-    out << "Camera Parameters:" << std::endl;
-    out << "    model_type " << "KANNALA_BRANDT" << std::endl;
-    out << "   camera_name " << params.m_cameraName << std::endl;
-    out << "   image_width " << params.m_imageWidth << std::endl;
-    out << "  image_height " << params.m_imageHeight << std::endl;
+std::ostream& operator<<(std::ostream& out, const EquidistantCamera::Parameters& params) {
+  out << "Camera Parameters:" << std::endl;
+  out << "    model_type " << "KANNALA_BRANDT" << std::endl;
+  out << "   camera_name " << params.m_cameraName << std::endl;
+  out << "   image_width " << params.m_imageWidth << std::endl;
+  out << "  image_height " << params.m_imageHeight << std::endl;
 
-    // projection: k2, k3, k4, k5, mu, mv, u0, v0
-    out << "Projection Parameters" << std::endl;
-    out << "            k2 " << params.m_k2 << std::endl
-        << "            k3 " << params.m_k3 << std::endl
-        << "            k4 " << params.m_k4 << std::endl
-        << "            k5 " << params.m_k5 << std::endl
-        << "            mu " << params.m_mu << std::endl
-        << "            mv " << params.m_mv << std::endl
-        << "            u0 " << params.m_u0 << std::endl
-        << "            v0 " << params.m_v0 << std::endl;
+  // projection: k2, k3, k4, k5, mu, mv, u0, v0
+  out << "Projection Parameters" << std::endl;
+  out << "            k2 " << params.m_k2 << std::endl
+      << "            k3 " << params.m_k3 << std::endl
+      << "            k4 " << params.m_k4 << std::endl
+      << "            k5 " << params.m_k5 << std::endl
+      << "            mu " << params.m_mu << std::endl
+      << "            mv " << params.m_mv << std::endl
+      << "            u0 " << params.m_u0 << std::endl
+      << "            v0 " << params.m_v0 << std::endl;
 
-    return out;
+  return out;
 }
 
 EquidistantCamera::EquidistantCamera()
- : m_inv_K11(1.0)
- , m_inv_K13(0.0)
- , m_inv_K22(1.0)
- , m_inv_K23(0.0)
-{
+    : m_inv_K11(1.0), m_inv_K13(0.0), m_inv_K22(1.0), m_inv_K23(0.0) {}
 
-}
-
-EquidistantCamera::EquidistantCamera(const std::string& cameraName,
-                                     int imageWidth, int imageHeight,
-                                     double k2, double k3, double k4, double k5,
-                                     double mu, double mv,
-                                     double u0, double v0)
- : mParameters(cameraName, imageWidth, imageHeight,
-               k2, k3, k4, k5, mu, mv, u0, v0)
-{
-    // Inverse camera projection matrix parameters
-    m_inv_K11 = 1.0 / mParameters.mu();
-    m_inv_K13 = -mParameters.u0() / mParameters.mu();
-    m_inv_K22 = 1.0 / mParameters.mv();
-    m_inv_K23 = -mParameters.v0() / mParameters.mv();
+EquidistantCamera::EquidistantCamera(const std::string& cameraName, int imageWidth, int imageHeight,
+                                     double k2, double k3, double k4, double k5, double mu,
+                                     double mv, double u0, double v0)
+    : mParameters(cameraName, imageWidth, imageHeight, k2, k3, k4, k5, mu, mv, u0, v0) {
+  // Inverse camera projection matrix parameters
+  m_inv_K11 = 1.0 / mParameters.mu();
+  m_inv_K13 = -mParameters.u0() / mParameters.mu();
+  m_inv_K22 = 1.0 / mParameters.mv();
+  m_inv_K23 = -mParameters.v0() / mParameters.mv();
 }
 
 EquidistantCamera::EquidistantCamera(const EquidistantCamera::Parameters& params)
- : mParameters(params)
-{
-    // Inverse camera projection matrix parameters
-    m_inv_K11 = 1.0 / mParameters.mu();
-    m_inv_K13 = -mParameters.u0() / mParameters.mu();
-    m_inv_K22 = 1.0 / mParameters.mv();
-    m_inv_K23 = -mParameters.v0() / mParameters.mv();
+    : mParameters(params) {
+  // Inverse camera projection matrix parameters
+  m_inv_K11 = 1.0 / mParameters.mu();
+  m_inv_K13 = -mParameters.u0() / mParameters.mu();
+  m_inv_K22 = 1.0 / mParameters.mv();
+  m_inv_K23 = -mParameters.v0() / mParameters.mv();
 }
 
-Camera::ModelType
-EquidistantCamera::modelType(void) const
-{
-    return mParameters.modelType();
-}
+Camera::ModelType EquidistantCamera::modelType(void) const { return mParameters.modelType(); }
 
-const std::string&
-EquidistantCamera::cameraName(void) const
-{
-    return mParameters.cameraName();
-}
+const std::string& EquidistantCamera::cameraName(void) const { return mParameters.cameraName(); }
 
-int
-EquidistantCamera::imageWidth(void) const
-{
-    return mParameters.imageWidth();
-}
+int EquidistantCamera::imageWidth(void) const { return mParameters.imageWidth(); }
 
-int
-EquidistantCamera::imageHeight(void) const
-{
-    return mParameters.imageHeight();
-}
+int EquidistantCamera::imageHeight(void) const { return mParameters.imageHeight(); }
 
-void
-EquidistantCamera::estimateIntrinsics(const cv::Size& boardSize,
-                                      const std::vector< std::vector<cv::Point3f> >& objectPoints,
-                                      const std::vector< std::vector<cv::Point2f> >& imagePoints)
-{
-    Parameters params = getParameters();
+void EquidistantCamera::estimateIntrinsics(
+    const cv::Size& boardSize, const std::vector<std::vector<cv::Point3f> >& objectPoints,
+    const std::vector<std::vector<cv::Point2f> >& imagePoints) {
+  Parameters params = getParameters();
 
-    double u0 = params.imageWidth() / 2.0;
-    double v0 = params.imageHeight() / 2.0;
+  double u0 = params.imageWidth() / 2.0;
+  double v0 = params.imageHeight() / 2.0;
 
-    double minReprojErr = std::numeric_limits<double>::max();
+  double minReprojErr = std::numeric_limits<double>::max();
 
-    std::vector<cv::Mat> rvecs, tvecs;
-    rvecs.assign(objectPoints.size(), cv::Mat());
-    tvecs.assign(objectPoints.size(), cv::Mat());
+  std::vector<cv::Mat> rvecs, tvecs;
+  rvecs.assign(objectPoints.size(), cv::Mat());
+  tvecs.assign(objectPoints.size(), cv::Mat());
 
-    params.k2() = 0.0;
-    params.k3() = 0.0;
-    params.k4() = 0.0;
-    params.k5() = 0.0;
-    params.u0() = u0;
-    params.v0() = v0;
+  params.k2() = 0.0;
+  params.k3() = 0.0;
+  params.k4() = 0.0;
+  params.k5() = 0.0;
+  params.u0() = u0;
+  params.v0() = v0;
 
-    // Initialize focal length
-    // C. Hughes, P. Denny, M. Glavin, and E. Jones,
-    // Equidistant Fish-Eye Calibration and Rectification by Vanishing Point
-    // Extraction, PAMI 2010
-    // Find circles from rows of chessboard corners, and for each pair
-    // of circles, find vanishing points: v1 and v2.
-    // f = ||v1 - v2|| / PI;
-    double f0 = 0.0;
-    for (size_t i = 0; i < imagePoints.size(); ++i)
-    {
-        std::vector<Eigen::Vector2d> center(boardSize.height);
-        double radius[boardSize.height];
-        for (int r = 0; r < boardSize.height; ++r)
-        {
-            std::vector<cv::Point2d> circle;
-            for (int c = 0; c < boardSize.width; ++c)
-            {
-                circle.push_back(imagePoints.at(i).at(r * boardSize.width + c));
-            }
+  // Initialize focal length
+  // C. Hughes, P. Denny, M. Glavin, and E. Jones,
+  // Equidistant Fish-Eye Calibration and Rectification by Vanishing Point
+  // Extraction, PAMI 2010
+  // Find circles from rows of chessboard corners, and for each pair
+  // of circles, find vanishing points: v1 and v2.
+  // f = ||v1 - v2|| / PI;
+  double f0 = 0.0;
+  for (size_t i = 0; i < imagePoints.size(); ++i) {
+    std::vector<Eigen::Vector2d> center(boardSize.height);
+    double radius[boardSize.height];
+    for (int r = 0; r < boardSize.height; ++r) {
+      std::vector<cv::Point2d> circle;
+      for (int c = 0; c < boardSize.width; ++c) {
+        circle.push_back(imagePoints.at(i).at(r * boardSize.width + c));
+      }
 
-            fitCircle(circle, center[r](0), center[r](1), radius[r]);
-        }
-
-        for (int j = 0; j < boardSize.height; ++j)
-        {
-            for (int k = j + 1; k < boardSize.height; ++k)
-            {
-                // find distance between pair of vanishing points which
-                // correspond to intersection points of 2 circles
-                std::vector<cv::Point2d> ipts;
-                ipts = intersectCircles(center[j](0), center[j](1), radius[j],
-                                        center[k](0), center[k](1), radius[k]);
-
-                if (ipts.size() < 2)
-                {
-                    continue;
-                }
-
-                double f = cv::norm(ipts.at(0) - ipts.at(1)) / M_PI;
-
-                params.mu() = f;
-                params.mv() = f;
-
-                setParameters(params);
-
-                for (size_t l = 0; l < objectPoints.size(); ++l)
-                {
-                    estimateExtrinsics(objectPoints.at(l), imagePoints.at(l), rvecs.at(l), tvecs.at(l));
-                }
-
-                double reprojErr = reprojectionError(objectPoints, imagePoints, rvecs, tvecs, cv::noArray());
-
-                if (reprojErr < minReprojErr)
-                {
-                    minReprojErr = reprojErr;
-                    f0 = f;
-                }
-            }
-        }
+      fitCircle(circle, center[r](0), center[r](1), radius[r]);
     }
 
-    if (f0 <= 0.0 && minReprojErr >= std::numeric_limits<double>::max())
-    {
-        std::cout << "[" << params.cameraName() << "] "
-                  << "# INFO: kannala-Brandt model fails with given data. " << std::endl;
+    for (int j = 0; j < boardSize.height; ++j) {
+      for (int k = j + 1; k < boardSize.height; ++k) {
+        // find distance between pair of vanishing points which
+        // correspond to intersection points of 2 circles
+        std::vector<cv::Point2d> ipts;
+        ipts = intersectCircles(center[j](0), center[j](1), radius[j], center[k](0), center[k](1),
+                                radius[k]);
 
-        return;
+        if (ipts.size() < 2) {
+          continue;
+        }
+
+        double f = cv::norm(ipts.at(0) - ipts.at(1)) / M_PI;
+
+        params.mu() = f;
+        params.mv() = f;
+
+        setParameters(params);
+
+        for (size_t l = 0; l < objectPoints.size(); ++l) {
+          estimateExtrinsics(objectPoints.at(l), imagePoints.at(l), rvecs.at(l), tvecs.at(l));
+        }
+
+        double reprojErr =
+            reprojectionError(objectPoints, imagePoints, rvecs, tvecs, cv::noArray());
+
+        if (reprojErr < minReprojErr) {
+          minReprojErr = reprojErr;
+          f0 = f;
+        }
+      }
     }
+  }
 
-    params.mu() = f0;
-    params.mv() = f0;
+  if (f0 <= 0.0 && minReprojErr >= std::numeric_limits<double>::max()) {
+    std::cout << "[" << params.cameraName() << "] "
+              << "# INFO: kannala-Brandt model fails with given data. " << std::endl;
 
-    setParameters(params);
+    return;
+  }
+
+  params.mu() = f0;
+  params.mv() = f0;
+
+  setParameters(params);
 }
 
 /**
@@ -412,409 +285,333 @@ EquidistantCamera::estimateIntrinsics(const cv::Size& boardSize,
  * \param p image coordinates
  * \param P coordinates of the point on the sphere
  */
-void
-EquidistantCamera::liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const
-{
-    liftProjective(p, P);
+void EquidistantCamera::liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const {
+  liftProjective(p, P);
 }
 
-/** 
+/**
  * \brief Lifts a point from the image plane to its projective ray
  *
  * \param p image coordinates
  * \param P coordinates of the projective ray
  */
-void
-EquidistantCamera::liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const
-{
-    // Lift points to normalised plane
-    Eigen::Vector2d p_u;
-    p_u << m_inv_K11 * p(0) + m_inv_K13,
-           m_inv_K22 * p(1) + m_inv_K23;
+void EquidistantCamera::liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const {
+  // Lift points to normalised plane
+  Eigen::Vector2d p_u;
+  p_u << m_inv_K11 * p(0) + m_inv_K13, m_inv_K22 * p(1) + m_inv_K23;
 
-    // Obtain a projective ray
-    double theta, phi;
-    backprojectSymmetric(p_u, theta, phi);
+  // Obtain a projective ray
+  double theta, phi;
+  backprojectSymmetric(p_u, theta, phi);
 
-    P(0) = sin(theta) * cos(phi);
-    P(1) = sin(theta) * sin(phi);
-    P(2) = cos(theta);
+  P(0) = sin(theta) * cos(phi);
+  P(1) = sin(theta) * sin(phi);
+  P(2) = cos(theta);
 }
 
-/** 
+/**
  * \brief Project a 3D point (\a x,\a y,\a z) to the image plane in (\a u,\a v)
  *
  * \param P 3D point coordinates
  * \param p return value, contains the image point coordinates
  */
-void
-EquidistantCamera::spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const
-{
-    double theta = acos(P(2) / P.norm());
-    double phi = atan2(P(1), P(0));
+void EquidistantCamera::spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const {
+  double theta = acos(P(2) / P.norm());
+  double phi = atan2(P(1), P(0));
 
-    Eigen::Vector2d p_u = r(mParameters.k2(), mParameters.k3(), mParameters.k4(), mParameters.k5(), theta) * Eigen::Vector2d(cos(phi), sin(phi));
+  Eigen::Vector2d p_u =
+      r(mParameters.k2(), mParameters.k3(), mParameters.k4(), mParameters.k5(), theta) *
+      Eigen::Vector2d(cos(phi), sin(phi));
 
-    // Apply generalised projection matrix
-    p << mParameters.mu() * p_u(0) + mParameters.u0(),
-         mParameters.mv() * p_u(1) + mParameters.v0();
+  // Apply generalised projection matrix
+  p << mParameters.mu() * p_u(0) + mParameters.u0(), mParameters.mv() * p_u(1) + mParameters.v0();
 }
 
-
-/** 
+/**
  * \brief Project a 3D point to the image plane and calculate Jacobian
  *
  * \param P 3D point coordinates
  * \param p return value, contains the image point coordinates
  */
-void
-EquidistantCamera::spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p,
-                                Eigen::Matrix<double,2,3>& J) const
-{
-    double theta = acos(P(2) / P.norm());
-    double phi = atan2(P(1), P(0));
+void EquidistantCamera::spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p,
+                                     Eigen::Matrix<double, 2, 3>& J) const {
+  double theta = acos(P(2) / P.norm());
+  double phi = atan2(P(1), P(0));
 
-    Eigen::Vector2d p_u = r(mParameters.k2(), mParameters.k3(), mParameters.k4(), mParameters.k5(), theta) * Eigen::Vector2d(cos(phi), sin(phi));
+  Eigen::Vector2d p_u =
+      r(mParameters.k2(), mParameters.k3(), mParameters.k4(), mParameters.k5(), theta) *
+      Eigen::Vector2d(cos(phi), sin(phi));
 
-    // Apply generalised projection matrix
-    p << mParameters.mu() * p_u(0) + mParameters.u0(),
-         mParameters.mv() * p_u(1) + mParameters.v0();
+  // Apply generalised projection matrix
+  p << mParameters.mu() * p_u(0) + mParameters.u0(), mParameters.mv() * p_u(1) + mParameters.v0();
 }
 
-/** 
+/**
  * \brief Projects an undistorted 2D point p_u to the image plane
  *
  * \param p_u 2D point coordinates
  * \return image point coordinates
  */
-void
-EquidistantCamera::undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const
-{
-//    Eigen::Vector2d p_d;
-//
-//    if (m_noDistortion)
-//    {
-//        p_d = p_u;
-//    }
-//    else
-//    {
-//        // Apply distortion
-//        Eigen::Vector2d d_u;
-//        distortion(p_u, d_u);
-//        p_d = p_u + d_u;
-//    }
-//
-//    // Apply generalised projection matrix
-//    p << mParameters.gamma1() * p_d(0) + mParameters.u0(),
-//         mParameters.gamma2() * p_d(1) + mParameters.v0();
+void EquidistantCamera::undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const {
+  //    Eigen::Vector2d p_d;
+  //
+  //    if (m_noDistortion)
+  //    {
+  //        p_d = p_u;
+  //    }
+  //    else
+  //    {
+  //        // Apply distortion
+  //        Eigen::Vector2d d_u;
+  //        distortion(p_u, d_u);
+  //        p_d = p_u + d_u;
+  //    }
+  //
+  //    // Apply generalised projection matrix
+  //    p << mParameters.gamma1() * p_d(0) + mParameters.u0(),
+  //         mParameters.gamma2() * p_d(1) + mParameters.v0();
 }
 
-void
-EquidistantCamera::initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale) const
-{
-    cv::Size imageSize(mParameters.imageWidth(), mParameters.imageHeight());
+void EquidistantCamera::initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale) const {
+  cv::Size imageSize(mParameters.imageWidth(), mParameters.imageHeight());
 
-    cv::Mat mapX = cv::Mat::zeros(imageSize, CV_32F);
-    cv::Mat mapY = cv::Mat::zeros(imageSize, CV_32F);
+  cv::Mat mapX = cv::Mat::zeros(imageSize, CV_32F);
+  cv::Mat mapY = cv::Mat::zeros(imageSize, CV_32F);
 
-    for (int v = 0; v < imageSize.height; ++v)
-    {
-        for (int u = 0; u < imageSize.width; ++u)
-        {
-            double mx_u = m_inv_K11 / fScale * u + m_inv_K13 / fScale;
-            double my_u = m_inv_K22 / fScale * v + m_inv_K23 / fScale;
+  for (int v = 0; v < imageSize.height; ++v) {
+    for (int u = 0; u < imageSize.width; ++u) {
+      double mx_u = m_inv_K11 / fScale * u + m_inv_K13 / fScale;
+      double my_u = m_inv_K22 / fScale * v + m_inv_K23 / fScale;
 
-            double theta, phi;
-            backprojectSymmetric(Eigen::Vector2d(mx_u, my_u), theta, phi);
+      double theta, phi;
+      backprojectSymmetric(Eigen::Vector2d(mx_u, my_u), theta, phi);
 
-            Eigen::Vector3d P;
-            P << sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta);
+      Eigen::Vector3d P;
+      P << sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta);
 
-            Eigen::Vector2d p;
-            spaceToPlane(P, p);
+      Eigen::Vector2d p;
+      spaceToPlane(P, p);
 
-            mapX.at<float>(v,u) = p(0);
-            mapY.at<float>(v,u) = p(1);
-        }
+      mapX.at<float>(v, u) = p(0);
+      mapY.at<float>(v, u) = p(1);
     }
+  }
 
-    cv::convertMaps(mapX, mapY, map1, map2, CV_32FC1, false);
+  cv::convertMaps(mapX, mapY, map1, map2, CV_32FC1, false);
 }
 
-cv::Mat
-EquidistantCamera::initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2,
-                                           float fx, float fy,
-                                           cv::Size imageSize,
-                                           float cx, float cy,
-                                           cv::Mat rmat) const
-{
-    if (imageSize == cv::Size(0, 0))
-    {
-        imageSize = cv::Size(mParameters.imageWidth(), mParameters.imageHeight());
+cv::Mat EquidistantCamera::initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2, float fx, float fy,
+                                                   cv::Size imageSize, float cx, float cy,
+                                                   cv::Mat rmat) const {
+  if (imageSize == cv::Size(0, 0)) {
+    imageSize = cv::Size(mParameters.imageWidth(), mParameters.imageHeight());
+  }
+
+  cv::Mat mapX = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
+  cv::Mat mapY = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
+
+  Eigen::Matrix3f K_rect;
+
+  if (cx == -1.0f && cy == -1.0f) {
+    K_rect << fx, 0, imageSize.width / 2, 0, fy, imageSize.height / 2, 0, 0, 1;
+  } else {
+    K_rect << fx, 0, cx, 0, fy, cy, 0, 0, 1;
+  }
+
+  if (fx == -1.0f || fy == -1.0f) {
+    K_rect(0, 0) = mParameters.mu();
+    K_rect(1, 1) = mParameters.mv();
+  }
+
+  Eigen::Matrix3f K_rect_inv = K_rect.inverse();
+
+  Eigen::Matrix3f R, R_inv;
+  cv::cv2eigen(rmat, R);
+  R_inv = R.inverse();
+
+  for (int v = 0; v < imageSize.height; ++v) {
+    for (int u = 0; u < imageSize.width; ++u) {
+      Eigen::Vector3f xo;
+      xo << u, v, 1;
+
+      Eigen::Vector3f uo = R_inv * K_rect_inv * xo;
+
+      Eigen::Vector2d p;
+      spaceToPlane(uo.cast<double>(), p);
+
+      mapX.at<float>(v, u) = p(0);
+      mapY.at<float>(v, u) = p(1);
     }
+  }
 
-    cv::Mat mapX = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
-    cv::Mat mapY = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
+  cv::convertMaps(mapX, mapY, map1, map2, CV_32FC1, false);
 
-    Eigen::Matrix3f K_rect;
-
-    if (cx == -1.0f && cy == -1.0f)
-    {
-        K_rect << fx, 0, imageSize.width / 2,
-                  0, fy, imageSize.height / 2,
-                  0, 0, 1;
-    }
-    else
-    {
-        K_rect << fx, 0, cx,
-                  0, fy, cy,
-                  0, 0, 1;
-    }
-
-    if (fx == -1.0f || fy == -1.0f)
-    {
-        K_rect(0,0) = mParameters.mu();
-        K_rect(1,1) = mParameters.mv();
-    }
-
-    Eigen::Matrix3f K_rect_inv = K_rect.inverse();
-
-    Eigen::Matrix3f R, R_inv;
-    cv::cv2eigen(rmat, R);
-    R_inv = R.inverse();
-
-    for (int v = 0; v < imageSize.height; ++v)
-    {
-        for (int u = 0; u < imageSize.width; ++u)
-        {
-            Eigen::Vector3f xo;
-            xo << u, v, 1;
-
-            Eigen::Vector3f uo = R_inv * K_rect_inv * xo;
-
-            Eigen::Vector2d p;
-            spaceToPlane(uo.cast<double>(), p);
-
-            mapX.at<float>(v,u) = p(0);
-            mapY.at<float>(v,u) = p(1);
-        }
-    }
-
-    cv::convertMaps(mapX, mapY, map1, map2, CV_32FC1, false);
-
-    cv::Mat K_rect_cv;
-    cv::eigen2cv(K_rect, K_rect_cv);
-    return K_rect_cv;
+  cv::Mat K_rect_cv;
+  cv::eigen2cv(K_rect, K_rect_cv);
+  return K_rect_cv;
 }
 
-int
-EquidistantCamera::parameterCount(void) const
-{
-    return 8;
+int EquidistantCamera::parameterCount(void) const { return 8; }
+
+const EquidistantCamera::Parameters& EquidistantCamera::getParameters(void) const {
+  return mParameters;
 }
 
-const EquidistantCamera::Parameters&
-EquidistantCamera::getParameters(void) const
-{
-    return mParameters;
+void EquidistantCamera::setParameters(const EquidistantCamera::Parameters& parameters) {
+  mParameters = parameters;
+
+  // Inverse camera projection matrix parameters
+  m_inv_K11 = 1.0 / mParameters.mu();
+  m_inv_K13 = -mParameters.u0() / mParameters.mu();
+  m_inv_K22 = 1.0 / mParameters.mv();
+  m_inv_K23 = -mParameters.v0() / mParameters.mv();
 }
 
-void
-EquidistantCamera::setParameters(const EquidistantCamera::Parameters& parameters)
-{
-    mParameters = parameters;
+void EquidistantCamera::readParameters(const std::vector<double>& parameterVec) {
+  if (parameterVec.size() != parameterCount()) {
+    return;
+  }
 
-    // Inverse camera projection matrix parameters
-    m_inv_K11 = 1.0 / mParameters.mu();
-    m_inv_K13 = -mParameters.u0() / mParameters.mu();
-    m_inv_K22 = 1.0 / mParameters.mv();
-    m_inv_K23 = -mParameters.v0() / mParameters.mv();
+  Parameters params = getParameters();
+
+  params.k2() = parameterVec.at(0);
+  params.k3() = parameterVec.at(1);
+  params.k4() = parameterVec.at(2);
+  params.k5() = parameterVec.at(3);
+  params.mu() = parameterVec.at(4);
+  params.mv() = parameterVec.at(5);
+  params.u0() = parameterVec.at(6);
+  params.v0() = parameterVec.at(7);
+
+  setParameters(params);
 }
 
-void
-EquidistantCamera::readParameters(const std::vector<double>& parameterVec)
-{
-    if (parameterVec.size() != parameterCount())
-    {
-        return;
-    }
-
-    Parameters params = getParameters();
-
-    params.k2() = parameterVec.at(0);
-    params.k3() = parameterVec.at(1);
-    params.k4() = parameterVec.at(2);
-    params.k5() = parameterVec.at(3);
-    params.mu() = parameterVec.at(4);
-    params.mv() = parameterVec.at(5);
-    params.u0() = parameterVec.at(6);
-    params.v0() = parameterVec.at(7);
-
-    setParameters(params);
+void EquidistantCamera::writeParameters(std::vector<double>& parameterVec) const {
+  parameterVec.resize(parameterCount());
+  parameterVec.at(0) = mParameters.k2();
+  parameterVec.at(1) = mParameters.k3();
+  parameterVec.at(2) = mParameters.k4();
+  parameterVec.at(3) = mParameters.k5();
+  parameterVec.at(4) = mParameters.mu();
+  parameterVec.at(5) = mParameters.mv();
+  parameterVec.at(6) = mParameters.u0();
+  parameterVec.at(7) = mParameters.v0();
 }
 
-void
-EquidistantCamera::writeParameters(std::vector<double>& parameterVec) const
-{
-    parameterVec.resize(parameterCount());
-    parameterVec.at(0) = mParameters.k2();
-    parameterVec.at(1) = mParameters.k3();
-    parameterVec.at(2) = mParameters.k4();
-    parameterVec.at(3) = mParameters.k5();
-    parameterVec.at(4) = mParameters.mu();
-    parameterVec.at(5) = mParameters.mv();
-    parameterVec.at(6) = mParameters.u0();
-    parameterVec.at(7) = mParameters.v0();
+void EquidistantCamera::writeParametersToYamlFile(const std::string& filename) const {
+  mParameters.writeToYamlFile(filename);
 }
 
-void
-EquidistantCamera::writeParametersToYamlFile(const std::string& filename) const
-{
-    mParameters.writeToYamlFile(filename);
+std::string EquidistantCamera::parametersToString(void) const {
+  std::ostringstream oss;
+  oss << mParameters;
+
+  return oss.str();
 }
 
-std::string
-EquidistantCamera::parametersToString(void) const
-{
-    std::ostringstream oss;
-    oss << mParameters;
+void EquidistantCamera::fitOddPoly(const std::vector<double>& x, const std::vector<double>& y,
+                                   int n, std::vector<double>& coeffs) const {
+  std::vector<int> pows;
+  for (int i = 1; i <= n; i += 2) {
+    pows.push_back(i);
+  }
 
-    return oss.str();
+  Eigen::MatrixXd X(x.size(), pows.size());
+  Eigen::MatrixXd Y(y.size(), 1);
+  for (size_t i = 0; i < x.size(); ++i) {
+    for (size_t j = 0; j < pows.size(); ++j) {
+      X(i, j) = pow(x.at(i), pows.at(j));
+    }
+    Y(i, 0) = y.at(i);
+  }
+
+  Eigen::MatrixXd A = (X.transpose() * X).inverse() * X.transpose() * Y;
+
+  coeffs.resize(A.rows());
+  for (int i = 0; i < A.rows(); ++i) {
+    coeffs.at(i) = A(i, 0);
+  }
 }
 
-void
-EquidistantCamera::fitOddPoly(const std::vector<double>& x, const std::vector<double>& y,
-                              int n, std::vector<double>& coeffs) const
-{
-    std::vector<int> pows;
-    for (int i = 1; i <= n; i += 2)
-    {
-        pows.push_back(i);
+void EquidistantCamera::backprojectSymmetric(const Eigen::Vector2d& p_u, double& theta,
+                                             double& phi) const {
+  double tol = 1e-10;
+  double p_u_norm = p_u.norm();
+
+  if (p_u_norm < 1e-10) {
+    phi = 0.0;
+  } else {
+    phi = atan2(p_u(1), p_u(0));
+  }
+
+  int npow = 9;
+  if (mParameters.k5() == 0.0) {
+    npow -= 2;
+  }
+  if (mParameters.k4() == 0.0) {
+    npow -= 2;
+  }
+  if (mParameters.k3() == 0.0) {
+    npow -= 2;
+  }
+  if (mParameters.k2() == 0.0) {
+    npow -= 2;
+  }
+
+  Eigen::MatrixXd coeffs(npow + 1, 1);
+  coeffs.setZero();
+  coeffs(0) = -p_u_norm;
+  coeffs(1) = 1.0;
+
+  if (npow >= 3) {
+    coeffs(3) = mParameters.k2();
+  }
+  if (npow >= 5) {
+    coeffs(5) = mParameters.k3();
+  }
+  if (npow >= 7) {
+    coeffs(7) = mParameters.k4();
+  }
+  if (npow >= 9) {
+    coeffs(9) = mParameters.k5();
+  }
+
+  if (npow == 1) {
+    theta = p_u_norm;
+  } else {
+    // Get eigenvalues of companion matrix corresponding to polynomial.
+    // Eigenvalues correspond to roots of polynomial.
+    Eigen::MatrixXd A(npow, npow);
+    A.setZero();
+    A.block(1, 0, npow - 1, npow - 1).setIdentity();
+    A.col(npow - 1) = -coeffs.block(0, 0, npow, 1) / coeffs(npow);
+
+    Eigen::EigenSolver<Eigen::MatrixXd> es(A);
+    Eigen::MatrixXcd eigval = es.eigenvalues();
+
+    std::vector<double> thetas;
+    for (int i = 0; i < eigval.rows(); ++i) {
+      if (fabs(eigval(i).imag()) > tol) {
+        continue;
+      }
+
+      double t = eigval(i).real();
+
+      if (t < -tol) {
+        continue;
+      } else if (t < 0.0) {
+        t = 0.0;
+      }
+
+      thetas.push_back(t);
     }
 
-    Eigen::MatrixXd X(x.size(), pows.size());
-    Eigen::MatrixXd Y(y.size(), 1);
-    for (size_t i = 0; i < x.size(); ++i)
-    {
-        for (size_t j = 0; j < pows.size(); ++j)
-        {
-            X(i,j) = pow(x.at(i), pows.at(j));
-        }
-        Y(i,0) = y.at(i);
+    if (thetas.empty()) {
+      theta = p_u_norm;
+    } else {
+      theta = *std::min_element(thetas.begin(), thetas.end());
     }
-
-    Eigen::MatrixXd A = (X.transpose() * X).inverse() * X.transpose() * Y;
-
-    coeffs.resize(A.rows());
-    for (int i = 0; i < A.rows(); ++i)
-    {
-        coeffs.at(i) = A(i,0);
-    }
+  }
 }
 
-void
-EquidistantCamera::backprojectSymmetric(const Eigen::Vector2d& p_u,
-                                        double& theta, double& phi) const
-{
-    double tol = 1e-10;
-    double p_u_norm = p_u.norm();
-
-    if (p_u_norm < 1e-10)
-    {
-        phi = 0.0;
-    }
-    else
-    {
-        phi = atan2(p_u(1), p_u(0));
-    }
-
-    int npow = 9;
-    if (mParameters.k5() == 0.0)
-    {
-        npow -= 2;
-    }
-    if (mParameters.k4() == 0.0)
-    {
-        npow -= 2;
-    }
-    if (mParameters.k3() == 0.0)
-    {
-        npow -= 2;
-    }
-    if (mParameters.k2() == 0.0)
-    {
-        npow -= 2;
-    }
-
-    Eigen::MatrixXd coeffs(npow + 1, 1);
-    coeffs.setZero();
-    coeffs(0) = -p_u_norm;
-    coeffs(1) = 1.0;
-
-    if (npow >= 3)
-    {
-        coeffs(3) = mParameters.k2();
-    }
-    if (npow >= 5)
-    {
-        coeffs(5) = mParameters.k3();
-    }
-    if (npow >= 7)
-    {
-        coeffs(7) = mParameters.k4();
-    }
-    if (npow >= 9)
-    {
-        coeffs(9) = mParameters.k5();
-    }
-
-    if (npow == 1)
-    {
-        theta = p_u_norm;
-    }
-    else
-    {
-        // Get eigenvalues of companion matrix corresponding to polynomial.
-        // Eigenvalues correspond to roots of polynomial.
-        Eigen::MatrixXd A(npow, npow);
-        A.setZero();
-        A.block(1, 0, npow - 1, npow - 1).setIdentity();
-        A.col(npow - 1) = - coeffs.block(0, 0, npow, 1) / coeffs(npow);
-
-        Eigen::EigenSolver<Eigen::MatrixXd> es(A);
-        Eigen::MatrixXcd eigval = es.eigenvalues();
-
-        std::vector<double> thetas;
-        for (int i = 0; i < eigval.rows(); ++i)
-        {
-            if (fabs(eigval(i).imag()) > tol)
-            {
-                continue;
-            }
-
-            double t = eigval(i).real();
-
-            if (t < -tol)
-            {
-                continue;
-            }
-            else if (t < 0.0)
-            {
-                t = 0.0;
-            }
-
-            thetas.push_back(t);
-        }
-
-        if (thetas.empty())
-        {
-            theta = p_u_norm;
-        }
-        else
-        {
-            theta = *std::min_element(thetas.begin(), thetas.end());
-        }
-    }
-}
-
-}
+}  // namespace camodocal

--- a/src/frontend/camodocal/camera_models/PinholeCamera.cc
+++ b/src/frontend/camodocal/camera_models/PinholeCamera.cc
@@ -10,420 +10,290 @@
 
 #include "frontend/camodocal/gpl/gpl.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
 PinholeCamera::Parameters::Parameters()
- : Camera::Parameters(PINHOLE)
- , m_k1(0.0)
- , m_k2(0.0)
- , m_p1(0.0)
- , m_p2(0.0)
- , m_fx(0.0)
- , m_fy(0.0)
- , m_cx(0.0)
- , m_cy(0.0)
-{
+    : Camera::Parameters(PINHOLE),
+      m_k1(0.0),
+      m_k2(0.0),
+      m_p1(0.0),
+      m_p2(0.0),
+      m_fx(0.0),
+      m_fy(0.0),
+      m_cx(0.0),
+      m_cy(0.0) {}
 
-}
-
-PinholeCamera::Parameters::Parameters(const std::string& cameraName,
-                                      int w, int h,
-                                      double k1, double k2,
-                                      double p1, double p2,
-                                      double fx, double fy,
+PinholeCamera::Parameters::Parameters(const std::string& cameraName, int w, int h, double k1,
+                                      double k2, double p1, double p2, double fx, double fy,
                                       double cx, double cy)
- : Camera::Parameters(PINHOLE, cameraName, w, h)
- , m_k1(k1)
- , m_k2(k2)
- , m_p1(p1)
- , m_p2(p2)
- , m_fx(fx)
- , m_fy(fy)
- , m_cx(cx)
- , m_cy(cy)
-{
-}
+    : Camera::Parameters(PINHOLE, cameraName, w, h),
+      m_k1(k1),
+      m_k2(k2),
+      m_p1(p1),
+      m_p2(p2),
+      m_fx(fx),
+      m_fy(fy),
+      m_cx(cx),
+      m_cy(cy) {}
 
-double&
-PinholeCamera::Parameters::k1(void)
-{
-    return m_k1;
-}
+double& PinholeCamera::Parameters::k1(void) { return m_k1; }
 
-double&
-PinholeCamera::Parameters::k2(void)
-{
-    return m_k2;
-}
+double& PinholeCamera::Parameters::k2(void) { return m_k2; }
 
-double&
-PinholeCamera::Parameters::p1(void)
-{
-    return m_p1;
-}
+double& PinholeCamera::Parameters::p1(void) { return m_p1; }
 
-double&
-PinholeCamera::Parameters::p2(void)
-{
-    return m_p2;
-}
+double& PinholeCamera::Parameters::p2(void) { return m_p2; }
 
-double&
-PinholeCamera::Parameters::fx(void)
-{
-    return m_fx;
-}
+double& PinholeCamera::Parameters::fx(void) { return m_fx; }
 
-double&
-PinholeCamera::Parameters::fy(void)
-{
-    return m_fy;
-}
+double& PinholeCamera::Parameters::fy(void) { return m_fy; }
 
-double&
-PinholeCamera::Parameters::cx(void)
-{
-    return m_cx;
-}
+double& PinholeCamera::Parameters::cx(void) { return m_cx; }
 
-double&
-PinholeCamera::Parameters::cy(void)
-{
-    return m_cy;
-}
+double& PinholeCamera::Parameters::cy(void) { return m_cy; }
 
-double
-PinholeCamera::Parameters::k1(void) const
-{
-    return m_k1;
-}
+double PinholeCamera::Parameters::k1(void) const { return m_k1; }
 
-double
-PinholeCamera::Parameters::k2(void) const
-{
-    return m_k2;
-}
+double PinholeCamera::Parameters::k2(void) const { return m_k2; }
 
-double
-PinholeCamera::Parameters::p1(void) const
-{
-    return m_p1;
-}
+double PinholeCamera::Parameters::p1(void) const { return m_p1; }
 
-double
-PinholeCamera::Parameters::p2(void) const
-{
-    return m_p2;
-}
+double PinholeCamera::Parameters::p2(void) const { return m_p2; }
 
-double
-PinholeCamera::Parameters::fx(void) const
-{
-    return m_fx;
-}
+double PinholeCamera::Parameters::fx(void) const { return m_fx; }
 
-double
-PinholeCamera::Parameters::fy(void) const
-{
-    return m_fy;
-}
+double PinholeCamera::Parameters::fy(void) const { return m_fy; }
 
-double
-PinholeCamera::Parameters::cx(void) const
-{
-    return m_cx;
-}
+double PinholeCamera::Parameters::cx(void) const { return m_cx; }
 
-double
-PinholeCamera::Parameters::cy(void) const
-{
-    return m_cy;
-}
+double PinholeCamera::Parameters::cy(void) const { return m_cy; }
 
-bool
-PinholeCamera::Parameters::readFromYamlFile(const std::string& filename)
-{
-    cv::FileStorage fs(filename, cv::FileStorage::READ);
+bool PinholeCamera::Parameters::readFromYamlFile(const std::string& filename) {
+  cv::FileStorage fs(filename, cv::FileStorage::READ);
 
-    if (!fs.isOpened())
-    {
-        return false;
+  if (!fs.isOpened()) {
+    return false;
+  }
+
+  if (!fs["model_type"].isNone()) {
+    std::string sModelType;
+    fs["model_type"] >> sModelType;
+
+    if (sModelType.compare("PINHOLE") != 0) {
+      return false;
     }
+  }
 
-    if (!fs["model_type"].isNone())
-    {
-        std::string sModelType;
-        fs["model_type"] >> sModelType;
+  m_modelType = PINHOLE;
+  fs["camera_name"] >> m_cameraName;
+  m_imageWidth = static_cast<int>(fs["image_width"]);
+  m_imageHeight = static_cast<int>(fs["image_height"]);
 
-        if (sModelType.compare("PINHOLE") != 0)
-        {
-            return false;
-        }
-    }
+  cv::FileNode n = fs["distortion_parameters"];
+  m_k1 = static_cast<double>(n["k1"]);
+  m_k2 = static_cast<double>(n["k2"]);
+  m_p1 = static_cast<double>(n["p1"]);
+  m_p2 = static_cast<double>(n["p2"]);
 
-    m_modelType = PINHOLE;
-    fs["camera_name"] >> m_cameraName;
-    m_imageWidth = static_cast<int>(fs["image_width"]);
-    m_imageHeight = static_cast<int>(fs["image_height"]);
+  n = fs["projection_parameters"];
+  m_fx = static_cast<double>(n["fx"]);
+  m_fy = static_cast<double>(n["fy"]);
+  m_cx = static_cast<double>(n["cx"]);
+  m_cy = static_cast<double>(n["cy"]);
 
-    cv::FileNode n = fs["distortion_parameters"];
-    m_k1 = static_cast<double>(n["k1"]);
-    m_k2 = static_cast<double>(n["k2"]);
-    m_p1 = static_cast<double>(n["p1"]);
-    m_p2 = static_cast<double>(n["p2"]);
-
-    n = fs["projection_parameters"];
-    m_fx = static_cast<double>(n["fx"]);
-    m_fy = static_cast<double>(n["fy"]);
-    m_cx = static_cast<double>(n["cx"]);
-    m_cy = static_cast<double>(n["cy"]);
-
-    return true;
+  return true;
 }
 
-void
-PinholeCamera::Parameters::writeToYamlFile(const std::string& filename) const
-{
-    cv::FileStorage fs(filename, cv::FileStorage::WRITE);
+void PinholeCamera::Parameters::writeToYamlFile(const std::string& filename) const {
+  cv::FileStorage fs(filename, cv::FileStorage::WRITE);
 
-    fs << "model_type" << "PINHOLE";
-    fs << "camera_name" << m_cameraName;
-    fs << "image_width" << m_imageWidth;
-    fs << "image_height" << m_imageHeight;
+  fs << "model_type" << "PINHOLE";
+  fs << "camera_name" << m_cameraName;
+  fs << "image_width" << m_imageWidth;
+  fs << "image_height" << m_imageHeight;
 
-    // radial distortion: k1, k2
-    // tangential distortion: p1, p2
-    fs << "distortion_parameters";
-    fs << "{" << "k1" << m_k1
-              << "k2" << m_k2
-              << "p1" << m_p1
-              << "p2" << m_p2 << "}";
+  // radial distortion: k1, k2
+  // tangential distortion: p1, p2
+  fs << "distortion_parameters";
+  fs << "{" << "k1" << m_k1 << "k2" << m_k2 << "p1" << m_p1 << "p2" << m_p2 << "}";
 
-    // projection: fx, fy, cx, cy
-    fs << "projection_parameters";
-    fs << "{" << "fx" << m_fx
-              << "fy" << m_fy
-              << "cx" << m_cx
-              << "cy" << m_cy << "}";
+  // projection: fx, fy, cx, cy
+  fs << "projection_parameters";
+  fs << "{" << "fx" << m_fx << "fy" << m_fy << "cx" << m_cx << "cy" << m_cy << "}";
 
-    fs.release();
+  fs.release();
 }
 
-PinholeCamera::Parameters&
-PinholeCamera::Parameters::operator=(const PinholeCamera::Parameters& other)
-{
-    if (this != &other)
-    {
-        m_modelType = other.m_modelType;
-        m_cameraName = other.m_cameraName;
-        m_imageWidth = other.m_imageWidth;
-        m_imageHeight = other.m_imageHeight;
-        m_k1 = other.m_k1;
-        m_k2 = other.m_k2;
-        m_p1 = other.m_p1;
-        m_p2 = other.m_p2;
-        m_fx = other.m_fx;
-        m_fy = other.m_fy;
-        m_cx = other.m_cx;
-        m_cy = other.m_cy;
-    }
+PinholeCamera::Parameters& PinholeCamera::Parameters::operator=(
+    const PinholeCamera::Parameters& other) {
+  if (this != &other) {
+    m_modelType = other.m_modelType;
+    m_cameraName = other.m_cameraName;
+    m_imageWidth = other.m_imageWidth;
+    m_imageHeight = other.m_imageHeight;
+    m_k1 = other.m_k1;
+    m_k2 = other.m_k2;
+    m_p1 = other.m_p1;
+    m_p2 = other.m_p2;
+    m_fx = other.m_fx;
+    m_fy = other.m_fy;
+    m_cx = other.m_cx;
+    m_cy = other.m_cy;
+  }
 
-    return *this;
+  return *this;
 }
 
-std::ostream&
-operator<< (std::ostream& out, const PinholeCamera::Parameters& params)
-{
-    out << "Camera Parameters:" << std::endl;
-    out << "    model_type " << "PINHOLE" << std::endl;
-    out << "   camera_name " << params.m_cameraName << std::endl;
-    out << "   image_width " << params.m_imageWidth << std::endl;
-    out << "  image_height " << params.m_imageHeight << std::endl;
+std::ostream& operator<<(std::ostream& out, const PinholeCamera::Parameters& params) {
+  out << "Camera Parameters:" << std::endl;
+  out << "    model_type " << "PINHOLE" << std::endl;
+  out << "   camera_name " << params.m_cameraName << std::endl;
+  out << "   image_width " << params.m_imageWidth << std::endl;
+  out << "  image_height " << params.m_imageHeight << std::endl;
 
-    // radial distortion: k1, k2
-    // tangential distortion: p1, p2
-    out << "Distortion Parameters" << std::endl;
-    out << "            k1 " << params.m_k1 << std::endl
-        << "            k2 " << params.m_k2 << std::endl
-        << "            p1 " << params.m_p1 << std::endl
-        << "            p2 " << params.m_p2 << std::endl;
+  // radial distortion: k1, k2
+  // tangential distortion: p1, p2
+  out << "Distortion Parameters" << std::endl;
+  out << "            k1 " << params.m_k1 << std::endl
+      << "            k2 " << params.m_k2 << std::endl
+      << "            p1 " << params.m_p1 << std::endl
+      << "            p2 " << params.m_p2 << std::endl;
 
-    // projection: fx, fy, cx, cy
-    out << "Projection Parameters" << std::endl;
-    out << "            fx " << params.m_fx << std::endl
-        << "            fy " << params.m_fy << std::endl
-        << "            cx " << params.m_cx << std::endl
-        << "            cy " << params.m_cy << std::endl;
+  // projection: fx, fy, cx, cy
+  out << "Projection Parameters" << std::endl;
+  out << "            fx " << params.m_fx << std::endl
+      << "            fy " << params.m_fy << std::endl
+      << "            cx " << params.m_cx << std::endl
+      << "            cy " << params.m_cy << std::endl;
 
-    return out;
+  return out;
 }
 
 PinholeCamera::PinholeCamera()
- : m_inv_K11(1.0)
- , m_inv_K13(0.0)
- , m_inv_K22(1.0)
- , m_inv_K23(0.0)
- , m_noDistortion(true)
-{
+    : m_inv_K11(1.0), m_inv_K13(0.0), m_inv_K22(1.0), m_inv_K23(0.0), m_noDistortion(true) {}
 
+PinholeCamera::PinholeCamera(const std::string& cameraName, int imageWidth, int imageHeight,
+                             double k1, double k2, double p1, double p2, double fx, double fy,
+                             double cx, double cy)
+    : mParameters(cameraName, imageWidth, imageHeight, k1, k2, p1, p2, fx, fy, cx, cy) {
+  if ((mParameters.k1() == 0.0) && (mParameters.k2() == 0.0) && (mParameters.p1() == 0.0) &&
+      (mParameters.p2() == 0.0)) {
+    m_noDistortion = true;
+  } else {
+    m_noDistortion = false;
+  }
+
+  // Inverse camera projection matrix parameters
+  m_inv_K11 = 1.0 / mParameters.fx();
+  m_inv_K13 = -mParameters.cx() / mParameters.fx();
+  m_inv_K22 = 1.0 / mParameters.fy();
+  m_inv_K23 = -mParameters.cy() / mParameters.fy();
 }
 
-PinholeCamera::PinholeCamera(const std::string& cameraName,
-                             int imageWidth, int imageHeight,
-                             double k1, double k2, double p1, double p2,
-                             double fx, double fy, double cx, double cy)
- : mParameters(cameraName, imageWidth, imageHeight,
-               k1, k2, p1, p2, fx, fy, cx, cy)
-{
-    if ((mParameters.k1() == 0.0) &&
-        (mParameters.k2() == 0.0) &&
-        (mParameters.p1() == 0.0) &&
-        (mParameters.p2() == 0.0))
-    {
-        m_noDistortion = true;
-    }
-    else
-    {
-        m_noDistortion = false;
-    }
+PinholeCamera::PinholeCamera(const PinholeCamera::Parameters& params) : mParameters(params) {
+  if ((mParameters.k1() == 0.0) && (mParameters.k2() == 0.0) && (mParameters.p1() == 0.0) &&
+      (mParameters.p2() == 0.0)) {
+    m_noDistortion = true;
+  } else {
+    m_noDistortion = false;
+  }
 
-    // Inverse camera projection matrix parameters
-    m_inv_K11 = 1.0 / mParameters.fx();
-    m_inv_K13 = -mParameters.cx() / mParameters.fx();
-    m_inv_K22 = 1.0 / mParameters.fy();
-    m_inv_K23 = -mParameters.cy() / mParameters.fy();
+  // Inverse camera projection matrix parameters
+  m_inv_K11 = 1.0 / mParameters.fx();
+  m_inv_K13 = -mParameters.cx() / mParameters.fx();
+  m_inv_K22 = 1.0 / mParameters.fy();
+  m_inv_K23 = -mParameters.cy() / mParameters.fy();
 }
 
-PinholeCamera::PinholeCamera(const PinholeCamera::Parameters& params)
- : mParameters(params)
-{
-    if ((mParameters.k1() == 0.0) &&
-        (mParameters.k2() == 0.0) &&
-        (mParameters.p1() == 0.0) &&
-        (mParameters.p2() == 0.0))
-    {
-        m_noDistortion = true;
-    }
-    else
-    {
-        m_noDistortion = false;
-    }
+Camera::ModelType PinholeCamera::modelType(void) const { return mParameters.modelType(); }
 
-    // Inverse camera projection matrix parameters
-    m_inv_K11 = 1.0 / mParameters.fx();
-    m_inv_K13 = -mParameters.cx() / mParameters.fx();
-    m_inv_K22 = 1.0 / mParameters.fy();
-    m_inv_K23 = -mParameters.cy() / mParameters.fy();
-}
+const std::string& PinholeCamera::cameraName(void) const { return mParameters.cameraName(); }
 
-Camera::ModelType
-PinholeCamera::modelType(void) const
-{
-    return mParameters.modelType();
-}
+int PinholeCamera::imageWidth(void) const { return mParameters.imageWidth(); }
 
-const std::string&
-PinholeCamera::cameraName(void) const
-{
-    return mParameters.cameraName();
-}
+int PinholeCamera::imageHeight(void) const { return mParameters.imageHeight(); }
 
-int
-PinholeCamera::imageWidth(void) const
-{
-    return mParameters.imageWidth();
-}
+void PinholeCamera::estimateIntrinsics(const cv::Size& boardSize,
+                                       const std::vector<std::vector<cv::Point3f> >& objectPoints,
+                                       const std::vector<std::vector<cv::Point2f> >& imagePoints) {
+  // Z. Zhang, A Flexible New Technique for Camera Calibration, PAMI 2000
 
-int
-PinholeCamera::imageHeight(void) const
-{
-    return mParameters.imageHeight();
-}
+  Parameters params = getParameters();
 
-void
-PinholeCamera::estimateIntrinsics(const cv::Size& boardSize,
-                                  const std::vector< std::vector<cv::Point3f> >& objectPoints,
-                                  const std::vector< std::vector<cv::Point2f> >& imagePoints)
-{
-    // Z. Zhang, A Flexible New Technique for Camera Calibration, PAMI 2000
+  params.k1() = 0.0;
+  params.k2() = 0.0;
+  params.p1() = 0.0;
+  params.p2() = 0.0;
 
-    Parameters params = getParameters();
+  double cx = params.imageWidth() / 2.0;
+  double cy = params.imageHeight() / 2.0;
+  params.cx() = cx;
+  params.cy() = cy;
 
-    params.k1() = 0.0;
-    params.k2() = 0.0;
-    params.p1() = 0.0;
-    params.p2() = 0.0;
+  size_t nImages = imagePoints.size();
 
-    double cx = params.imageWidth() / 2.0;
-    double cy = params.imageHeight() / 2.0;
-    params.cx() = cx;
-    params.cy() = cy;
+  cv::Mat A(nImages * 2, 2, CV_64F);
+  cv::Mat b(nImages * 2, 1, CV_64F);
 
-    size_t nImages = imagePoints.size();
+  for (size_t i = 0; i < nImages; ++i) {
+    const std::vector<cv::Point3f>& oPoints = objectPoints.at(i);
 
-    cv::Mat A(nImages * 2, 2, CV_64F);
-    cv::Mat b(nImages * 2, 1, CV_64F);
-
-    for (size_t i = 0; i < nImages; ++i)
-    {
-        const std::vector<cv::Point3f>& oPoints = objectPoints.at(i);
-
-        std::vector<cv::Point2f> M(oPoints.size());
-        for (size_t j = 0; j < M.size(); ++j)
-        {
-            M.at(j) = cv::Point2f(oPoints.at(j).x, oPoints.at(j).y);
-        }
-
-        cv::Mat H = cv::findHomography(M, imagePoints.at(i));
-
-        H.at<double>(0,0) -= H.at<double>(2,0) * cx;
-        H.at<double>(0,1) -= H.at<double>(2,1) * cx;
-        H.at<double>(0,2) -= H.at<double>(2,2) * cx;
-        H.at<double>(1,0) -= H.at<double>(2,0) * cy;
-        H.at<double>(1,1) -= H.at<double>(2,1) * cy;
-        H.at<double>(1,2) -= H.at<double>(2,2) * cy;
-
-        double h[3], v[3], d1[3], d2[3];
-        double n[4] = {0,0,0,0};
-
-        for (int j = 0; j < 3; ++j)
-        {
-            double t0 = H.at<double>(j,0);
-            double t1 = H.at<double>(j,1);
-            h[j] = t0; v[j] = t1;
-            d1[j] = (t0 + t1) * 0.5;
-            d2[j] = (t0 - t1) * 0.5;
-            n[0] += t0 * t0; n[1] += t1 * t1;
-            n[2] += d1[j] * d1[j]; n[3] += d2[j] * d2[j];
-        }
-
-        for (int j = 0; j < 4; ++j)
-        {
-            n[j] = 1.0 / sqrt(n[j]);
-        }
-
-        for (int j = 0; j < 3; ++j)
-        {
-            h[j] *= n[0]; v[j] *= n[1];
-            d1[j] *= n[2]; d2[j] *= n[3];
-        }
-
-        A.at<double>(i * 2, 0) = h[0] * v[0];
-        A.at<double>(i * 2, 1) = h[1] * v[1];
-        A.at<double>(i * 2 + 1, 0) = d1[0] * d2[0];
-        A.at<double>(i * 2 + 1, 1) = d1[1] * d2[1];
-        b.at<double>(i * 2, 0) = -h[2] * v[2];
-        b.at<double>(i * 2 + 1, 0) = -d1[2] * d2[2];
+    std::vector<cv::Point2f> M(oPoints.size());
+    for (size_t j = 0; j < M.size(); ++j) {
+      M.at(j) = cv::Point2f(oPoints.at(j).x, oPoints.at(j).y);
     }
 
-    cv::Mat f(2, 1, CV_64F);
-    cv::solve(A, b, f, cv::DECOMP_NORMAL | cv::DECOMP_LU);
+    cv::Mat H = cv::findHomography(M, imagePoints.at(i));
 
-    params.fx() = sqrt(fabs(1.0 / f.at<double>(0)));
-    params.fy() = sqrt(fabs(1.0 / f.at<double>(1)));
+    H.at<double>(0, 0) -= H.at<double>(2, 0) * cx;
+    H.at<double>(0, 1) -= H.at<double>(2, 1) * cx;
+    H.at<double>(0, 2) -= H.at<double>(2, 2) * cx;
+    H.at<double>(1, 0) -= H.at<double>(2, 0) * cy;
+    H.at<double>(1, 1) -= H.at<double>(2, 1) * cy;
+    H.at<double>(1, 2) -= H.at<double>(2, 2) * cy;
 
-    setParameters(params);
+    double h[3], v[3], d1[3], d2[3];
+    double n[4] = {0, 0, 0, 0};
+
+    for (int j = 0; j < 3; ++j) {
+      double t0 = H.at<double>(j, 0);
+      double t1 = H.at<double>(j, 1);
+      h[j] = t0;
+      v[j] = t1;
+      d1[j] = (t0 + t1) * 0.5;
+      d2[j] = (t0 - t1) * 0.5;
+      n[0] += t0 * t0;
+      n[1] += t1 * t1;
+      n[2] += d1[j] * d1[j];
+      n[3] += d2[j] * d2[j];
+    }
+
+    for (int j = 0; j < 4; ++j) {
+      n[j] = 1.0 / sqrt(n[j]);
+    }
+
+    for (int j = 0; j < 3; ++j) {
+      h[j] *= n[0];
+      v[j] *= n[1];
+      d1[j] *= n[2];
+      d2[j] *= n[3];
+    }
+
+    A.at<double>(i * 2, 0) = h[0] * v[0];
+    A.at<double>(i * 2, 1) = h[1] * v[1];
+    A.at<double>(i * 2 + 1, 0) = d1[0] * d2[0];
+    A.at<double>(i * 2 + 1, 1) = d1[1] * d2[1];
+    b.at<double>(i * 2, 0) = -h[2] * v[2];
+    b.at<double>(i * 2 + 1, 0) = -d1[2] * d2[2];
+  }
+
+  cv::Mat f(2, 1, CV_64F);
+  cv::solve(A, b, f, cv::DECOMP_NORMAL | cv::DECOMP_LU);
+
+  params.fx() = sqrt(fabs(1.0 / f.at<double>(0)));
+  params.fy() = sqrt(fabs(1.0 / f.at<double>(1)));
+
+  setParameters(params);
 }
 
 /**
@@ -432,12 +302,10 @@ PinholeCamera::estimateIntrinsics(const cv::Size& boardSize,
  * \param p image coordinates
  * \param P coordinates of the point on the sphere
  */
-void
-PinholeCamera::liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const
-{
-    liftProjective(p, P);
+void PinholeCamera::liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const {
+  liftProjective(p, P);
 
-    P.normalize();
+  P.normalize();
 }
 
 /**
@@ -446,69 +314,59 @@ PinholeCamera::liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const
  * \param p image coordinates
  * \param P coordinates of the projective ray
  */
-void
-PinholeCamera::liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const
-{
-    double mx_d, my_d,mx2_d, mxy_d, my2_d, mx_u, my_u;
-    double rho2_d, rho4_d, radDist_d, Dx_d, Dy_d, inv_denom_d;
-    //double lambda;
+void PinholeCamera::liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const {
+  double mx_d, my_d, mx2_d, mxy_d, my2_d, mx_u, my_u;
+  double rho2_d, rho4_d, radDist_d, Dx_d, Dy_d, inv_denom_d;
+  // double lambda;
 
-    // Lift points to normalised plane
-    mx_d = m_inv_K11 * p(0) + m_inv_K13;
-    my_d = m_inv_K22 * p(1) + m_inv_K23;
+  // Lift points to normalised plane
+  mx_d = m_inv_K11 * p(0) + m_inv_K13;
+  my_d = m_inv_K22 * p(1) + m_inv_K23;
 
-    if (m_noDistortion)
-    {
-        mx_u = mx_d;
-        my_u = my_d;
+  if (m_noDistortion) {
+    mx_u = mx_d;
+    my_u = my_d;
+  } else {
+    if (0) {
+      double k1 = mParameters.k1();
+      double k2 = mParameters.k2();
+      double p1 = mParameters.p1();
+      double p2 = mParameters.p2();
+
+      // Apply inverse distortion model
+      // proposed by Heikkila
+      mx2_d = mx_d * mx_d;
+      my2_d = my_d * my_d;
+      mxy_d = mx_d * my_d;
+      rho2_d = mx2_d + my2_d;
+      rho4_d = rho2_d * rho2_d;
+      radDist_d = k1 * rho2_d + k2 * rho4_d;
+      Dx_d = mx_d * radDist_d + p2 * (rho2_d + 2 * mx2_d) + 2 * p1 * mxy_d;
+      Dy_d = my_d * radDist_d + p1 * (rho2_d + 2 * my2_d) + 2 * p2 * mxy_d;
+      inv_denom_d = 1 / (1 + 4 * k1 * rho2_d + 6 * k2 * rho4_d + 8 * p1 * my_d + 8 * p2 * mx_d);
+
+      mx_u = mx_d - inv_denom_d * Dx_d;
+      my_u = my_d - inv_denom_d * Dy_d;
+    } else {
+      // Recursive distortion model
+      int n = 8;
+      Eigen::Vector2d d_u;
+      distortion(Eigen::Vector2d(mx_d, my_d), d_u);
+      // Approximate value
+      mx_u = mx_d - d_u(0);
+      my_u = my_d - d_u(1);
+
+      for (int i = 1; i < n; ++i) {
+        distortion(Eigen::Vector2d(mx_u, my_u), d_u);
+        mx_u = mx_d - d_u(0);
+        my_u = my_d - d_u(1);
+      }
     }
-    else
-    {
-        if (0)
-        {
-            double k1 = mParameters.k1();
-            double k2 = mParameters.k2();
-            double p1 = mParameters.p1();
-            double p2 = mParameters.p2();
+  }
 
-            // Apply inverse distortion model
-            // proposed by Heikkila
-            mx2_d = mx_d*mx_d;
-            my2_d = my_d*my_d;
-            mxy_d = mx_d*my_d;
-            rho2_d = mx2_d+my2_d;
-            rho4_d = rho2_d*rho2_d;
-            radDist_d = k1*rho2_d+k2*rho4_d;
-            Dx_d = mx_d*radDist_d + p2*(rho2_d+2*mx2_d) + 2*p1*mxy_d;
-            Dy_d = my_d*radDist_d + p1*(rho2_d+2*my2_d) + 2*p2*mxy_d;
-            inv_denom_d = 1/(1+4*k1*rho2_d+6*k2*rho4_d+8*p1*my_d+8*p2*mx_d);
-
-            mx_u = mx_d - inv_denom_d*Dx_d;
-            my_u = my_d - inv_denom_d*Dy_d;
-        }
-        else
-        {
-            // Recursive distortion model
-            int n = 8;
-            Eigen::Vector2d d_u;
-            distortion(Eigen::Vector2d(mx_d, my_d), d_u);
-            // Approximate value
-            mx_u = mx_d - d_u(0);
-            my_u = my_d - d_u(1);
-
-            for (int i = 1; i < n; ++i)
-            {
-                distortion(Eigen::Vector2d(mx_u, my_u), d_u);
-                mx_u = mx_d - d_u(0);
-                my_u = my_d - d_u(1);
-            }
-        }
-    }
-
-    // Obtain a projective ray
-    P << mx_u, my_u, 1.0;
+  // Obtain a projective ray
+  P << mx_u, my_u, 1.0;
 }
-
 
 /**
  * \brief Project a 3D point (\a x,\a y,\a z) to the image plane in (\a u,\a v)
@@ -516,29 +374,23 @@ PinholeCamera::liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) cons
  * \param P 3D point coordinates
  * \param p return value, contains the image point coordinates
  */
-void
-PinholeCamera::spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const
-{
-    Eigen::Vector2d p_u, p_d;
+void PinholeCamera::spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const {
+  Eigen::Vector2d p_u, p_d;
 
-    // Project points to the normalised plane
-    p_u << P(0) / P(2), P(1) / P(2);
+  // Project points to the normalised plane
+  p_u << P(0) / P(2), P(1) / P(2);
 
-    if (m_noDistortion)
-    {
-        p_d = p_u;
-    }
-    else
-    {
-        // Apply distortion
-        Eigen::Vector2d d_u;
-        distortion(p_u, d_u);
-        p_d = p_u + d_u;
-    }
+  if (m_noDistortion) {
+    p_d = p_u;
+  } else {
+    // Apply distortion
+    Eigen::Vector2d d_u;
+    distortion(p_u, d_u);
+    p_d = p_u + d_u;
+  }
 
-    // Apply generalised projection matrix
-    p << mParameters.fx() * p_d(0) + mParameters.cx(),
-         mParameters.fy() * p_d(1) + mParameters.cy();
+  // Apply generalised projection matrix
+  p << mParameters.fx() * p_d(0) + mParameters.cx(), mParameters.fy() * p_d(1) + mParameters.cy();
 }
 
 #if 0
@@ -614,26 +466,20 @@ PinholeCamera::spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p,
  * \param p_u 2D point coordinates
  * \return image point coordinates
  */
-void
-PinholeCamera::undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const
-{
-    Eigen::Vector2d p_d;
+void PinholeCamera::undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const {
+  Eigen::Vector2d p_d;
 
-    if (m_noDistortion)
-    {
-        p_d = p_u;
-    }
-    else
-    {
-        // Apply distortion
-        Eigen::Vector2d d_u;
-        distortion(p_u, d_u);
-        p_d = p_u + d_u;
-    }
+  if (m_noDistortion) {
+    p_d = p_u;
+  } else {
+    // Apply distortion
+    Eigen::Vector2d d_u;
+    distortion(p_u, d_u);
+    p_d = p_u + d_u;
+  }
 
-    // Apply generalised projection matrix
-    p << mParameters.fx() * p_d(0) + mParameters.cx(),
-         mParameters.fy() * p_d(1) + mParameters.cy();
+  // Apply generalised projection matrix
+  p << mParameters.fx() * p_d(0) + mParameters.cx(), mParameters.fy() * p_d(1) + mParameters.cy();
 }
 
 /**
@@ -642,23 +488,21 @@ PinholeCamera::undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) con
  * \param p_u undistorted coordinates of point on the normalised plane
  * \return to obtain the distorted point: p_d = p_u + d_u
  */
-void
-PinholeCamera::distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u) const
-{
-    double k1 = mParameters.k1();
-    double k2 = mParameters.k2();
-    double p1 = mParameters.p1();
-    double p2 = mParameters.p2();
+void PinholeCamera::distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u) const {
+  double k1 = mParameters.k1();
+  double k2 = mParameters.k2();
+  double p1 = mParameters.p1();
+  double p2 = mParameters.p2();
 
-    double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
+  double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
 
-    mx2_u = p_u(0) * p_u(0);
-    my2_u = p_u(1) * p_u(1);
-    mxy_u = p_u(0) * p_u(1);
-    rho2_u = mx2_u + my2_u;
-    rad_dist_u = k1 * rho2_u + k2 * rho2_u * rho2_u;
-    d_u << p_u(0) * rad_dist_u + 2.0 * p1 * mxy_u + p2 * (rho2_u + 2.0 * mx2_u),
-           p_u(1) * rad_dist_u + 2.0 * p2 * mxy_u + p1 * (rho2_u + 2.0 * my2_u);
+  mx2_u = p_u(0) * p_u(0);
+  my2_u = p_u(1) * p_u(1);
+  mxy_u = p_u(0) * p_u(1);
+  rho2_u = mx2_u + my2_u;
+  rad_dist_u = k1 * rho2_u + k2 * rho2_u * rho2_u;
+  d_u << p_u(0) * rad_dist_u + 2.0 * p1 * mxy_u + p2 * (rho2_u + 2.0 * mx2_u),
+      p_u(1) * rad_dist_u + 2.0 * p2 * mxy_u + p1 * (rho2_u + 2.0 * my2_u);
 }
 
 /**
@@ -668,214 +512,171 @@ PinholeCamera::distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u) cons
  * \param p_u undistorted coordinates of point on the normalised plane
  * \return to obtain the distorted point: p_d = p_u + d_u
  */
-void
-PinholeCamera::distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u,
-                          Eigen::Matrix2d& J) const
-{
-    double k1 = mParameters.k1();
-    double k2 = mParameters.k2();
-    double p1 = mParameters.p1();
-    double p2 = mParameters.p2();
+void PinholeCamera::distortion(const Eigen::Vector2d& p_u, Eigen::Vector2d& d_u,
+                               Eigen::Matrix2d& J) const {
+  double k1 = mParameters.k1();
+  double k2 = mParameters.k2();
+  double p1 = mParameters.p1();
+  double p2 = mParameters.p2();
 
-    double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
+  double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
 
-    mx2_u = p_u(0) * p_u(0);
-    my2_u = p_u(1) * p_u(1);
-    mxy_u = p_u(0) * p_u(1);
-    rho2_u = mx2_u + my2_u;
-    rad_dist_u = k1 * rho2_u + k2 * rho2_u * rho2_u;
-    d_u << p_u(0) * rad_dist_u + 2.0 * p1 * mxy_u + p2 * (rho2_u + 2.0 * mx2_u),
-           p_u(1) * rad_dist_u + 2.0 * p2 * mxy_u + p1 * (rho2_u + 2.0 * my2_u);
+  mx2_u = p_u(0) * p_u(0);
+  my2_u = p_u(1) * p_u(1);
+  mxy_u = p_u(0) * p_u(1);
+  rho2_u = mx2_u + my2_u;
+  rad_dist_u = k1 * rho2_u + k2 * rho2_u * rho2_u;
+  d_u << p_u(0) * rad_dist_u + 2.0 * p1 * mxy_u + p2 * (rho2_u + 2.0 * mx2_u),
+      p_u(1) * rad_dist_u + 2.0 * p2 * mxy_u + p1 * (rho2_u + 2.0 * my2_u);
 
-    double dxdmx = 1.0 + rad_dist_u + k1 * 2.0 * mx2_u + k2 * rho2_u * 4.0 * mx2_u + 2.0 * p1 * p_u(1) + 6.0 * p2 * p_u(0);
-    double dydmx = k1 * 2.0 * p_u(0) * p_u(1) + k2 * 4.0 * rho2_u * p_u(0) * p_u(1) + p1 * 2.0 * p_u(0) + 2.0 * p2 * p_u(1);
-    double dxdmy = dydmx;
-    double dydmy = 1.0 + rad_dist_u + k1 * 2.0 * my2_u + k2 * rho2_u * 4.0 * my2_u + 6.0 * p1 * p_u(1) + 2.0 * p2 * p_u(0);
+  double dxdmx = 1.0 + rad_dist_u + k1 * 2.0 * mx2_u + k2 * rho2_u * 4.0 * mx2_u +
+                 2.0 * p1 * p_u(1) + 6.0 * p2 * p_u(0);
+  double dydmx = k1 * 2.0 * p_u(0) * p_u(1) + k2 * 4.0 * rho2_u * p_u(0) * p_u(1) +
+                 p1 * 2.0 * p_u(0) + 2.0 * p2 * p_u(1);
+  double dxdmy = dydmx;
+  double dydmy = 1.0 + rad_dist_u + k1 * 2.0 * my2_u + k2 * rho2_u * 4.0 * my2_u +
+                 6.0 * p1 * p_u(1) + 2.0 * p2 * p_u(0);
 
-    J << dxdmx, dxdmy,
-         dydmx, dydmy;
+  J << dxdmx, dxdmy, dydmx, dydmy;
 }
 
-void
-PinholeCamera::initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale) const
-{
-    cv::Size imageSize(mParameters.imageWidth(), mParameters.imageHeight());
+void PinholeCamera::initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale) const {
+  cv::Size imageSize(mParameters.imageWidth(), mParameters.imageHeight());
 
-    cv::Mat mapX = cv::Mat::zeros(imageSize, CV_32F);
-    cv::Mat mapY = cv::Mat::zeros(imageSize, CV_32F);
+  cv::Mat mapX = cv::Mat::zeros(imageSize, CV_32F);
+  cv::Mat mapY = cv::Mat::zeros(imageSize, CV_32F);
 
-    for (int v = 0; v < imageSize.height; ++v)
-    {
-        for (int u = 0; u < imageSize.width; ++u)
-        {
-            double mx_u = m_inv_K11 / fScale * u + m_inv_K13 / fScale;
-            double my_u = m_inv_K22 / fScale * v + m_inv_K23 / fScale;
+  for (int v = 0; v < imageSize.height; ++v) {
+    for (int u = 0; u < imageSize.width; ++u) {
+      double mx_u = m_inv_K11 / fScale * u + m_inv_K13 / fScale;
+      double my_u = m_inv_K22 / fScale * v + m_inv_K23 / fScale;
 
-            Eigen::Vector3d P;
-            P << mx_u, my_u, 1.0;
+      Eigen::Vector3d P;
+      P << mx_u, my_u, 1.0;
 
-            Eigen::Vector2d p;
-            spaceToPlane(P, p);
+      Eigen::Vector2d p;
+      spaceToPlane(P, p);
 
-            mapX.at<float>(v,u) = p(0);
-            mapY.at<float>(v,u) = p(1);
-        }
+      mapX.at<float>(v, u) = p(0);
+      mapY.at<float>(v, u) = p(1);
     }
+  }
 
-    cv::convertMaps(mapX, mapY, map1, map2, CV_32FC1, false);
+  cv::convertMaps(mapX, mapY, map1, map2, CV_32FC1, false);
 }
 
-cv::Mat
-PinholeCamera::initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2,
-                                       float fx, float fy,
-                                       cv::Size imageSize,
-                                       float cx, float cy,
-                                       cv::Mat rmat) const
-{
-    if (imageSize == cv::Size(0, 0))
-    {
-        imageSize = cv::Size(mParameters.imageWidth(), mParameters.imageHeight());
+cv::Mat PinholeCamera::initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2, float fx, float fy,
+                                               cv::Size imageSize, float cx, float cy,
+                                               cv::Mat rmat) const {
+  if (imageSize == cv::Size(0, 0)) {
+    imageSize = cv::Size(mParameters.imageWidth(), mParameters.imageHeight());
+  }
+
+  cv::Mat mapX = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
+  cv::Mat mapY = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
+
+  Eigen::Matrix3f R, R_inv;
+  cv::cv2eigen(rmat, R);
+  R_inv = R.inverse();
+
+  // assume no skew
+  Eigen::Matrix3f K_rect;
+
+  if (cx == -1.0f || cy == -1.0f) {
+    K_rect << fx, 0, imageSize.width / 2, 0, fy, imageSize.height / 2, 0, 0, 1;
+  } else {
+    K_rect << fx, 0, cx, 0, fy, cy, 0, 0, 1;
+  }
+
+  if (fx == -1.0f || fy == -1.0f) {
+    K_rect(0, 0) = mParameters.fx();
+    K_rect(1, 1) = mParameters.fy();
+  }
+
+  Eigen::Matrix3f K_rect_inv = K_rect.inverse();
+
+  for (int v = 0; v < imageSize.height; ++v) {
+    for (int u = 0; u < imageSize.width; ++u) {
+      Eigen::Vector3f xo;
+      xo << u, v, 1;
+
+      Eigen::Vector3f uo = R_inv * K_rect_inv * xo;
+
+      Eigen::Vector2d p;
+      spaceToPlane(uo.cast<double>(), p);
+
+      mapX.at<float>(v, u) = p(0);
+      mapY.at<float>(v, u) = p(1);
     }
+  }
 
-    cv::Mat mapX = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
-    cv::Mat mapY = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
+  cv::convertMaps(mapX, mapY, map1, map2, CV_32FC1, false);
 
-    Eigen::Matrix3f R, R_inv;
-    cv::cv2eigen(rmat, R);
-    R_inv = R.inverse();
-
-    // assume no skew
-    Eigen::Matrix3f K_rect;
-
-    if (cx == -1.0f || cy == -1.0f)
-    {
-        K_rect << fx, 0, imageSize.width / 2,
-                  0, fy, imageSize.height / 2,
-                  0, 0, 1;
-    }
-    else
-    {
-        K_rect << fx, 0, cx,
-                  0, fy, cy,
-                  0, 0, 1;
-    }
-
-    if (fx == -1.0f || fy == -1.0f)
-    {
-        K_rect(0,0) = mParameters.fx();
-        K_rect(1,1) = mParameters.fy();
-    }
-
-    Eigen::Matrix3f K_rect_inv = K_rect.inverse();
-
-    for (int v = 0; v < imageSize.height; ++v)
-    {
-        for (int u = 0; u < imageSize.width; ++u)
-        {
-            Eigen::Vector3f xo;
-            xo << u, v, 1;
-
-            Eigen::Vector3f uo = R_inv * K_rect_inv * xo;
-
-            Eigen::Vector2d p;
-            spaceToPlane(uo.cast<double>(), p);
-
-            mapX.at<float>(v,u) = p(0);
-            mapY.at<float>(v,u) = p(1);
-        }
-    }
-
-    cv::convertMaps(mapX, mapY, map1, map2, CV_32FC1, false);
-
-    cv::Mat K_rect_cv;
-    cv::eigen2cv(K_rect, K_rect_cv);
-    return K_rect_cv;
+  cv::Mat K_rect_cv;
+  cv::eigen2cv(K_rect, K_rect_cv);
+  return K_rect_cv;
 }
 
-int
-PinholeCamera::parameterCount(void) const
-{
-    return 8;
+int PinholeCamera::parameterCount(void) const { return 8; }
+
+const PinholeCamera::Parameters& PinholeCamera::getParameters(void) const { return mParameters; }
+
+void PinholeCamera::setParameters(const PinholeCamera::Parameters& parameters) {
+  mParameters = parameters;
+
+  if ((mParameters.k1() == 0.0) && (mParameters.k2() == 0.0) && (mParameters.p1() == 0.0) &&
+      (mParameters.p2() == 0.0)) {
+    m_noDistortion = true;
+  } else {
+    m_noDistortion = false;
+  }
+
+  m_inv_K11 = 1.0 / mParameters.fx();
+  m_inv_K13 = -mParameters.cx() / mParameters.fx();
+  m_inv_K22 = 1.0 / mParameters.fy();
+  m_inv_K23 = -mParameters.cy() / mParameters.fy();
 }
 
-const PinholeCamera::Parameters&
-PinholeCamera::getParameters(void) const
-{
-    return mParameters;
+void PinholeCamera::readParameters(const std::vector<double>& parameterVec) {
+  if ((int)parameterVec.size() != parameterCount()) {
+    return;
+  }
+
+  Parameters params = getParameters();
+
+  params.k1() = parameterVec.at(0);
+  params.k2() = parameterVec.at(1);
+  params.p1() = parameterVec.at(2);
+  params.p2() = parameterVec.at(3);
+  params.fx() = parameterVec.at(4);
+  params.fy() = parameterVec.at(5);
+  params.cx() = parameterVec.at(6);
+  params.cy() = parameterVec.at(7);
+
+  setParameters(params);
 }
 
-void
-PinholeCamera::setParameters(const PinholeCamera::Parameters& parameters)
-{
-    mParameters = parameters;
-
-    if ((mParameters.k1() == 0.0) &&
-        (mParameters.k2() == 0.0) &&
-        (mParameters.p1() == 0.0) &&
-        (mParameters.p2() == 0.0))
-    {
-        m_noDistortion = true;
-    }
-    else
-    {
-        m_noDistortion = false;
-    }
-
-    m_inv_K11 = 1.0 / mParameters.fx();
-    m_inv_K13 = -mParameters.cx() / mParameters.fx();
-    m_inv_K22 = 1.0 / mParameters.fy();
-    m_inv_K23 = -mParameters.cy() / mParameters.fy();
+void PinholeCamera::writeParameters(std::vector<double>& parameterVec) const {
+  parameterVec.resize(parameterCount());
+  parameterVec.at(0) = mParameters.k1();
+  parameterVec.at(1) = mParameters.k2();
+  parameterVec.at(2) = mParameters.p1();
+  parameterVec.at(3) = mParameters.p2();
+  parameterVec.at(4) = mParameters.fx();
+  parameterVec.at(5) = mParameters.fy();
+  parameterVec.at(6) = mParameters.cx();
+  parameterVec.at(7) = mParameters.cy();
 }
 
-void
-PinholeCamera::readParameters(const std::vector<double>& parameterVec)
-{
-    if ((int)parameterVec.size() != parameterCount())
-    {
-        return;
-    }
-
-    Parameters params = getParameters();
-
-    params.k1() = parameterVec.at(0);
-    params.k2() = parameterVec.at(1);
-    params.p1() = parameterVec.at(2);
-    params.p2() = parameterVec.at(3);
-    params.fx() = parameterVec.at(4);
-    params.fy() = parameterVec.at(5);
-    params.cx() = parameterVec.at(6);
-    params.cy() = parameterVec.at(7);
-
-    setParameters(params);
+void PinholeCamera::writeParametersToYamlFile(const std::string& filename) const {
+  mParameters.writeToYamlFile(filename);
 }
 
-void
-PinholeCamera::writeParameters(std::vector<double>& parameterVec) const
-{
-    parameterVec.resize(parameterCount());
-    parameterVec.at(0) = mParameters.k1();
-    parameterVec.at(1) = mParameters.k2();
-    parameterVec.at(2) = mParameters.p1();
-    parameterVec.at(3) = mParameters.p2();
-    parameterVec.at(4) = mParameters.fx();
-    parameterVec.at(5) = mParameters.fy();
-    parameterVec.at(6) = mParameters.cx();
-    parameterVec.at(7) = mParameters.cy();
+std::string PinholeCamera::parametersToString(void) const {
+  std::ostringstream oss;
+  oss << mParameters;
+
+  return oss.str();
 }
 
-void
-PinholeCamera::writeParametersToYamlFile(const std::string& filename) const
-{
-    mParameters.writeToYamlFile(filename);
-}
-
-std::string
-PinholeCamera::parametersToString(void) const
-{
-    std::ostringstream oss;
-    oss << mParameters;
-
-    return oss.str();
-}
-
-}
+}  // namespace camodocal

--- a/src/frontend/camodocal/camera_models/ScaramuzzaCamera.cc
+++ b/src/frontend/camodocal/camera_models/ScaramuzzaCamera.cc
@@ -1,5 +1,7 @@
 #include "frontend/camodocal/camera_models/ScaramuzzaCamera.h"
 
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
 #include <cmath>
 #include <cstdio>
 #include <eigen3/Eigen/Dense>
@@ -9,663 +11,603 @@
 #include <opencv2/calib3d/calib3d.hpp>
 #include <opencv2/core/eigen.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/algorithm/string.hpp>
 
 #include "frontend/camodocal/gpl/gpl.h"
 
-
 Eigen::VectorXd polyfit(Eigen::VectorXd& xVec, Eigen::VectorXd& yVec, int poly_order) {
-    assert(poly_order > 0);
-    assert(xVec.size() > poly_order);
-    assert(xVec.size() == yVec.size());
+  assert(poly_order > 0);
+  assert(xVec.size() > poly_order);
+  assert(xVec.size() == yVec.size());
 
-    Eigen::MatrixXd A(xVec.size(), poly_order+1);
-    Eigen::VectorXd B(xVec.size());
+  Eigen::MatrixXd A(xVec.size(), poly_order + 1);
+  Eigen::VectorXd B(xVec.size());
 
-    for(int i = 0; i < xVec.size(); ++i) {
-        const double x = xVec(i);
-        const double y = yVec(i);
+  for (int i = 0; i < xVec.size(); ++i) {
+    const double x = xVec(i);
+    const double y = yVec(i);
 
-        double x_pow_k = 1.0;
+    double x_pow_k = 1.0;
 
-        for(int k=0; k<=poly_order; ++k) {
-            A(i,k) = x_pow_k;
-            x_pow_k *= x;
-        }
-
-        B(i) = y;
+    for (int k = 0; k <= poly_order; ++k) {
+      A(i, k) = x_pow_k;
+      x_pow_k *= x;
     }
 
-    Eigen::JacobiSVD<Eigen::MatrixXd> svd(A, Eigen::ComputeThinU | Eigen::ComputeThinV);
-    Eigen::VectorXd x = svd.solve(B);
+    B(i) = y;
+  }
 
-    return x;
+  Eigen::JacobiSVD<Eigen::MatrixXd> svd(A, Eigen::ComputeThinU | Eigen::ComputeThinV);
+  Eigen::VectorXd x = svd.solve(B);
+
+  return x;
 }
 
-namespace camodocal
-{
+namespace camodocal {
 
 OCAMCamera::Parameters::Parameters()
- : Camera::Parameters(SCARAMUZZA)
- , m_C(0.0)
- , m_D(0.0)
- , m_E(0.0)
- , m_center_x(0.0)
- , m_center_y(0.0)
-{
-    memset(m_poly, 0, sizeof(double) * SCARAMUZZA_POLY_SIZE);
-    memset(m_inv_poly, 0, sizeof(double) * SCARAMUZZA_INV_POLY_SIZE);
+    : Camera::Parameters(SCARAMUZZA),
+      m_C(0.0),
+      m_D(0.0),
+      m_E(0.0),
+      m_center_x(0.0),
+      m_center_y(0.0) {
+  memset(m_poly, 0, sizeof(double) * SCARAMUZZA_POLY_SIZE);
+  memset(m_inv_poly, 0, sizeof(double) * SCARAMUZZA_INV_POLY_SIZE);
 }
 
+bool OCAMCamera::Parameters::readFromYamlFile(const std::string& filename) {
+  cv::FileStorage fs(filename, cv::FileStorage::READ);
 
+  if (!fs.isOpened()) {
+    return false;
+  }
 
-bool
-OCAMCamera::Parameters::readFromYamlFile(const std::string& filename)
-{
-    cv::FileStorage fs(filename, cv::FileStorage::READ);
+  if (!fs["model_type"].isNone()) {
+    std::string sModelType;
+    fs["model_type"] >> sModelType;
 
-    if (!fs.isOpened())
-    {
-        return false;
+    if (!boost::iequals(sModelType, "scaramuzza")) {
+      return false;
+    }
+  }
+
+  m_modelType = SCARAMUZZA;
+  fs["camera_name"] >> m_cameraName;
+  m_imageWidth = static_cast<int>(fs["image_width"]);
+  m_imageHeight = static_cast<int>(fs["image_height"]);
+
+  cv::FileNode n = fs["poly_parameters"];
+  for (int i = 0; i < SCARAMUZZA_POLY_SIZE; i++)
+    m_poly[i] = static_cast<double>(n[std::string("p") + boost::lexical_cast<std::string>(i)]);
+
+  n = fs["inv_poly_parameters"];
+  for (int i = 0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
+    m_inv_poly[i] = static_cast<double>(n[std::string("p") + boost::lexical_cast<std::string>(i)]);
+
+  n = fs["affine_parameters"];
+  m_C = static_cast<double>(n["ac"]);
+  m_D = static_cast<double>(n["ad"]);
+  m_E = static_cast<double>(n["ae"]);
+
+  m_center_x = static_cast<double>(n["cx"]);
+  m_center_y = static_cast<double>(n["cy"]);
+
+  return true;
+}
+
+void OCAMCamera::Parameters::writeToYamlFile(const std::string& filename) const {
+  cv::FileStorage fs(filename, cv::FileStorage::WRITE);
+
+  fs << "model_type" << "scaramuzza";
+  fs << "camera_name" << m_cameraName;
+  fs << "image_width" << m_imageWidth;
+  fs << "image_height" << m_imageHeight;
+
+  fs << "poly_parameters";
+  fs << "{";
+  for (int i = 0; i < SCARAMUZZA_POLY_SIZE; i++)
+    fs << std::string("p") + boost::lexical_cast<std::string>(i) << m_poly[i];
+  fs << "}";
+
+  fs << "inv_poly_parameters";
+  fs << "{";
+  for (int i = 0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
+    fs << std::string("p") + boost::lexical_cast<std::string>(i) << m_inv_poly[i];
+  fs << "}";
+
+  fs << "affine_parameters";
+  fs << "{" << "ac" << m_C << "ad" << m_D << "ae" << m_E << "cx" << m_center_x << "cy" << m_center_y
+     << "}";
+
+  fs.release();
+}
+
+OCAMCamera::Parameters& OCAMCamera::Parameters::operator=(const OCAMCamera::Parameters& other) {
+  if (this != &other) {
+    m_modelType = other.m_modelType;
+    m_cameraName = other.m_cameraName;
+    m_imageWidth = other.m_imageWidth;
+    m_imageHeight = other.m_imageHeight;
+    m_C = other.m_C;
+    m_D = other.m_D;
+    m_E = other.m_E;
+    m_center_x = other.m_center_x;
+    m_center_y = other.m_center_y;
+
+    memcpy(m_poly, other.m_poly, sizeof(double) * SCARAMUZZA_POLY_SIZE);
+    memcpy(m_inv_poly, other.m_inv_poly, sizeof(double) * SCARAMUZZA_INV_POLY_SIZE);
+  }
+
+  return *this;
+}
+
+std::ostream& operator<<(std::ostream& out, const OCAMCamera::Parameters& params) {
+  out << "Camera Parameters:" << std::endl;
+  out << "    model_type " << "scaramuzza" << std::endl;
+  out << "   camera_name " << params.m_cameraName << std::endl;
+  out << "   image_width " << params.m_imageWidth << std::endl;
+  out << "  image_height " << params.m_imageHeight << std::endl;
+
+  out << std::fixed << std::setprecision(10);
+
+  out << "Poly Parameters" << std::endl;
+  for (int i = 0; i < SCARAMUZZA_POLY_SIZE; i++)
+    out << std::string("p") + boost::lexical_cast<std::string>(i) << ": " << params.m_poly[i]
+        << std::endl;
+
+  out << "Inverse Poly Parameters" << std::endl;
+  for (int i = 0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
+    out << std::string("p") + boost::lexical_cast<std::string>(i) << ": " << params.m_inv_poly[i]
+        << std::endl;
+
+  out << "Affine Parameters" << std::endl;
+  out << "            ac " << params.m_C << std::endl
+      << "            ad " << params.m_D << std::endl
+      << "            ae " << params.m_E << std::endl;
+  out << "            cx " << params.m_center_x << std::endl
+      << "            cy " << params.m_center_y << std::endl;
+
+  return out;
+}
+
+OCAMCamera::OCAMCamera() : m_inv_scale(0.0) {}
+
+OCAMCamera::OCAMCamera(const OCAMCamera::Parameters& params) : mParameters(params) {
+  m_inv_scale = 1.0 / (params.C() - params.D() * params.E());
+}
+
+Camera::ModelType OCAMCamera::modelType(void) const { return mParameters.modelType(); }
+
+const std::string& OCAMCamera::cameraName(void) const { return mParameters.cameraName(); }
+
+int OCAMCamera::imageWidth(void) const { return mParameters.imageWidth(); }
+
+int OCAMCamera::imageHeight(void) const { return mParameters.imageHeight(); }
+
+void OCAMCamera::estimateIntrinsics(const cv::Size& boardSize,
+                                    const std::vector<std::vector<cv::Point3f> >& objectPoints,
+                                    const std::vector<std::vector<cv::Point2f> >& imagePoints) {
+  // std::cout << "OCAMCamera::estimateIntrinsics - NOT IMPLEMENTED" << std::endl;
+  // throw std::string("OCAMCamera::estimateIntrinsics - NOT IMPLEMENTED");
+
+  // Reference: Page 30 of
+  // " Scaramuzza, D. Omnidirectional Vision: from Calibration to Robot Motion Estimation, ETH
+  // Zurich. Thesis no. 17635." http://e-collection.library.ethz.ch/eserv/eth:30301/eth-30301-02.pdf
+  // Matlab code: calibrate.m
+
+  // First, estimate every image's extrinsics parameters
+  std::vector<Eigen::Matrix3d> RList;
+  std::vector<Eigen::Vector3d> TList;
+
+  RList.reserve(imagePoints.size());
+  TList.reserve(imagePoints.size());
+
+  // i-th image
+  for (size_t image_index = 0; image_index < imagePoints.size(); ++image_index) {
+    const std::vector<cv::Point3f>& objPts = objectPoints.at(image_index);
+    const std::vector<cv::Point2f>& imgPts = imagePoints.at(image_index);
+
+    assert(objPts.size() == imgPts.size());
+    assert(objPts.size() == static_cast<unsigned int>(boardSize.width * boardSize.height));
+
+    Eigen::MatrixXd M(objPts.size(), 6);
+
+    for (size_t corner_index = 0; corner_index < objPts.size(); ++corner_index) {
+      double X = objPts.at(corner_index).x;
+      double Y = objPts.at(corner_index).y;
+      assert(objPts.at(corner_index).z == 0.0);
+
+      double u = imgPts.at(corner_index).x;
+      double v = imgPts.at(corner_index).y;
+
+      M(corner_index, 0) = -v * X;
+      M(corner_index, 1) = -v * Y;
+      M(corner_index, 2) = u * X;
+      M(corner_index, 3) = u * Y;
+      M(corner_index, 4) = -v;
+      M(corner_index, 5) = u;
     }
 
-    if (!fs["model_type"].isNone())
-    {
-        std::string sModelType;
-        fs["model_type"] >> sModelType;
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd(M, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    assert(svd.matrixV().cols() == 6);
+    Eigen::VectorXd h = -svd.matrixV().col(5);
 
-        if (!boost::iequals(sModelType, "scaramuzza"))
-        {
-            return false;
+    // scaled version of R and T
+    const double sr11 = h(0);
+    const double sr12 = h(1);
+    const double sr21 = h(2);
+    const double sr22 = h(3);
+    const double st1 = h(4);
+    const double st2 = h(5);
+
+    const double AA = square(sr11 * sr12 + sr21 * sr22);
+    const double BB = square(sr11) + square(sr21);
+    const double CC = square(sr12) + square(sr22);
+
+    const double sr32_squared_1 = (-(CC - BB) + sqrt(square(CC - BB) + 4.0 * AA)) / 2.0;
+    const double sr32_squared_2 = (-(CC - BB) - sqrt(square(CC - BB) + 4.0 * AA)) / 2.0;
+
+    // printf("rst = %.12f\n", sr32_squared_1*sr32_squared_1 + (CC-BB)*sr32_squared_1 - AA);
+
+    std::vector<double> sr32_squared_values;
+    if (sr32_squared_1 > 0) sr32_squared_values.push_back(sr32_squared_1);
+    if (sr32_squared_2 > 0) sr32_squared_values.push_back(sr32_squared_2);
+    assert(!sr32_squared_values.empty());
+
+    std::vector<double> sr32_values;
+    std::vector<double> sr31_values;
+    for (auto sr32_squared : sr32_squared_values) {
+      for (int sign = -1; sign <= 1; sign += 2) {
+        const double sr32 = static_cast<double>(sign) * std::sqrt(sr32_squared);
+        sr32_values.push_back(sr32);
+        if (sr32_squared == 0.0) {
+          // sr31 can be calculated through norm equality,
+          // but it has positive and negative posibilities
+          // positive one
+          sr31_values.push_back(std::sqrt(CC - BB));
+          // negative one
+          sr32_values.push_back(sr32);
+          sr31_values.push_back(-std::sqrt(CC - BB));
+
+          break;  // skip the same situation
+        } else {
+          // sr31 can be calculated throught dot product == 0
+          sr31_values.push_back(-(sr11 * sr12 + sr21 * sr22) / sr32);
         }
+      }
     }
 
-    m_modelType = SCARAMUZZA;
-    fs["camera_name"] >> m_cameraName;
-    m_imageWidth = static_cast<int>(fs["image_width"]);
-    m_imageHeight = static_cast<int>(fs["image_height"]);
+    // std::cout << "h= " << std::setprecision(12) << h.transpose() << std::endl;
+    // std::cout << "length: " << sr32_values.size() << " & " << sr31_values.size() << std::endl;
 
-    cv::FileNode n = fs["poly_parameters"];
-    for(int i=0; i < SCARAMUZZA_POLY_SIZE; i++)
-        m_poly[i] = static_cast<double>(n[std::string("p") + boost::lexical_cast<std::string>(i)]);
+    assert(!sr31_values.empty());
+    assert(sr31_values.size() == sr32_values.size());
 
-    n = fs["inv_poly_parameters"];
-    for(int i=0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
-        m_inv_poly[i] = static_cast<double>(n[std::string("p") + boost::lexical_cast<std::string>(i)]);
+    std::vector<Eigen::Matrix3d> H_values;
+    for (size_t i = 0; i < sr31_values.size(); ++i) {
+      const double sr31 = sr31_values.at(i);
+      const double sr32 = sr32_values.at(i);
+      const double lambda = 1.0 / sqrt(sr11 * sr11 + sr21 * sr21 + sr31 * sr31);
+      Eigen::Matrix3d H;
+      H.setZero();
+      H(0, 0) = sr11;
+      H(0, 1) = sr12;
+      H(0, 2) = st1;
+      H(1, 0) = sr21;
+      H(1, 1) = sr22;
+      H(1, 2) = st2;
+      H(2, 0) = sr31;
+      H(2, 1) = sr32;
+      H(2, 2) = 0;
 
-    n = fs["affine_parameters"];
-    m_C = static_cast<double>(n["ac"]);
-    m_D = static_cast<double>(n["ad"]);
-    m_E = static_cast<double>(n["ae"]);
-
-    m_center_x = static_cast<double>(n["cx"]);
-    m_center_y = static_cast<double>(n["cy"]);
-
-    return true;
-}
-
-void
-OCAMCamera::Parameters::writeToYamlFile(const std::string& filename) const
-{
-    cv::FileStorage fs(filename, cv::FileStorage::WRITE);
-
-    fs << "model_type" << "scaramuzza";
-    fs << "camera_name" << m_cameraName;
-    fs << "image_width" << m_imageWidth;
-    fs << "image_height" << m_imageHeight;
-
-    fs << "poly_parameters";
-    fs << "{";
-    for(int i=0; i < SCARAMUZZA_POLY_SIZE; i++)
-        fs << std::string("p") + boost::lexical_cast<std::string>(i) << m_poly[i];
-    fs << "}";
-
-    fs << "inv_poly_parameters";
-    fs << "{";
-    for(int i=0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
-        fs << std::string("p") + boost::lexical_cast<std::string>(i) << m_inv_poly[i];
-    fs << "}";
-
-    fs << "affine_parameters";
-    fs << "{" << "ac" << m_C
-              << "ad" << m_D
-              << "ae" << m_E
-              << "cx" << m_center_x
-              << "cy" << m_center_y << "}";
-
-    fs.release();
-}
-
-OCAMCamera::Parameters&
-OCAMCamera::Parameters::operator=(const OCAMCamera::Parameters& other)
-{
-    if (this != &other)
-    {
-        m_modelType = other.m_modelType;
-        m_cameraName = other.m_cameraName;
-        m_imageWidth = other.m_imageWidth;
-        m_imageHeight = other.m_imageHeight;
-        m_C = other.m_C;
-        m_D = other.m_D;
-        m_E = other.m_E;
-        m_center_x = other.m_center_x;
-        m_center_y = other.m_center_y;
-
-        memcpy(m_poly, other.m_poly, sizeof(double) * SCARAMUZZA_POLY_SIZE);
-        memcpy(m_inv_poly, other.m_inv_poly, sizeof(double) * SCARAMUZZA_INV_POLY_SIZE);
+      H_values.push_back(lambda * H);
+      H_values.push_back(-lambda * H);
     }
 
-    return *this;
-}
-
-std::ostream&
-operator<< (std::ostream& out, const OCAMCamera::Parameters& params)
-{
-    out << "Camera Parameters:" << std::endl;
-    out << "    model_type " << "scaramuzza" << std::endl;
-    out << "   camera_name " << params.m_cameraName << std::endl;
-    out << "   image_width " << params.m_imageWidth << std::endl;
-    out << "  image_height " << params.m_imageHeight << std::endl;
-
-    out << std::fixed << std::setprecision(10);
-
-    out << "Poly Parameters" << std::endl;
-    for(int i=0; i < SCARAMUZZA_POLY_SIZE; i++)
-        out << std::string("p") + boost::lexical_cast<std::string>(i) << ": " << params.m_poly[i] << std::endl;
-
-    out << "Inverse Poly Parameters" << std::endl;
-    for(int i=0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
-        out << std::string("p") + boost::lexical_cast<std::string>(i) << ": " << params.m_inv_poly[i] << std::endl;
-
-    out << "Affine Parameters" << std::endl;
-    out << "            ac " << params.m_C << std::endl
-        << "            ad " << params.m_D << std::endl
-        << "            ae " << params.m_E << std::endl;
-    out << "            cx " << params.m_center_x << std::endl
-        << "            cy " << params.m_center_y << std::endl;
-
-    return out;
-}
-
-OCAMCamera::OCAMCamera()
- : m_inv_scale(0.0)
-{
-
-}
-
-OCAMCamera::OCAMCamera(const OCAMCamera::Parameters& params)
- : mParameters(params)
-{
-    m_inv_scale = 1.0 / (params.C() - params.D() * params.E());
-}
-
-Camera::ModelType
-OCAMCamera::modelType(void) const
-{
-    return mParameters.modelType();
-}
-
-const std::string&
-OCAMCamera::cameraName(void) const
-{
-    return mParameters.cameraName();
-}
-
-int
-OCAMCamera::imageWidth(void) const
-{
-    return mParameters.imageWidth();
-}
-
-int
-OCAMCamera::imageHeight(void) const
-{
-    return mParameters.imageHeight();
-}
-
-void
-OCAMCamera::estimateIntrinsics(const cv::Size& boardSize,
-                               const std::vector< std::vector<cv::Point3f> >& objectPoints,
-                               const std::vector< std::vector<cv::Point2f> >& imagePoints)
-{
-    // std::cout << "OCAMCamera::estimateIntrinsics - NOT IMPLEMENTED" << std::endl;
-    // throw std::string("OCAMCamera::estimateIntrinsics - NOT IMPLEMENTED");
-
-    // Reference: Page 30 of
-    // " Scaramuzza, D. Omnidirectional Vision: from Calibration to Robot Motion Estimation, ETH Zurich. Thesis no. 17635."
-    // http://e-collection.library.ethz.ch/eserv/eth:30301/eth-30301-02.pdf
-    // Matlab code: calibrate.m
-
-    // First, estimate every image's extrinsics parameters
-    std::vector< Eigen::Matrix3d > RList;
-    std::vector< Eigen::Vector3d > TList;
-
-    RList.reserve(imagePoints.size());
-    TList.reserve(imagePoints.size());
-
-    // i-th image
-    for (size_t image_index = 0; image_index < imagePoints.size(); ++image_index)
-    {
-        const std::vector<cv::Point3f>& objPts = objectPoints.at(image_index);
-        const std::vector<cv::Point2f>& imgPts = imagePoints.at(image_index);
-
-        assert(objPts.size() == imgPts.size());
-        assert(objPts.size() == static_cast<unsigned int>(boardSize.width * boardSize.height));
-
-        Eigen::MatrixXd M(objPts.size(), 6);
-
-        for(size_t corner_index = 0; corner_index < objPts.size(); ++corner_index) {
-            double X = objPts.at(corner_index).x;
-            double Y = objPts.at(corner_index).y;
-            assert(objPts.at(corner_index).z==0.0);
-            
-            double u = imgPts.at(corner_index).x;
-            double v = imgPts.at(corner_index).y;
-
-            M(corner_index, 0) = -v * X;
-            M(corner_index, 1) = -v * Y;
-            M(corner_index, 2) =  u * X;
-            M(corner_index, 3) =  u * Y;
-            M(corner_index, 4) = -v;
-            M(corner_index, 5) =  u;
-        }
-
-        Eigen::JacobiSVD<Eigen::MatrixXd> svd(M, Eigen::ComputeFullU | Eigen::ComputeFullV);
-        assert(svd.matrixV().cols() == 6);
-        Eigen::VectorXd h = -svd.matrixV().col(5);
-
-        // scaled version of R and T
-        const double sr11 = h(0);
-        const double sr12 = h(1);
-        const double sr21 = h(2);
-        const double sr22 = h(3);
-        const double st1  = h(4);
-        const double st2  = h(5);
-
-        const double AA = square(sr11*sr12 + sr21*sr22);
-        const double BB = square(sr11) + square(sr21);
-        const double CC = square(sr12) + square(sr22);
-
-        const double sr32_squared_1 = (- (CC-BB) + sqrt(square(CC-BB) + 4.0 * AA)) / 2.0;
-        const double sr32_squared_2 = (- (CC-BB) - sqrt(square(CC-BB) + 4.0 * AA)) / 2.0;
-
-// printf("rst = %.12f\n", sr32_squared_1*sr32_squared_1 + (CC-BB)*sr32_squared_1 - AA);
-
-        std::vector<double> sr32_squared_values;
-        if (sr32_squared_1 > 0) sr32_squared_values.push_back(sr32_squared_1);
-        if (sr32_squared_2 > 0) sr32_squared_values.push_back(sr32_squared_2);
-        assert(!sr32_squared_values.empty());
-
-        std::vector<double> sr32_values;
-        std::vector<double> sr31_values;
-        for (auto sr32_squared : sr32_squared_values) {
-            for(int sign = -1; sign <= 1; sign += 2) {
-                const double sr32 = static_cast<double>(sign) * std::sqrt(sr32_squared);
-                sr32_values.push_back( sr32 );
-                if (sr32_squared == 0.0) {
-                    // sr31 can be calculated through norm equality, 
-                    // but it has positive and negative posibilities
-                    // positive one
-                    sr31_values.push_back(std::sqrt(CC-BB));
-                    // negative one
-                    sr32_values.push_back( sr32 );
-                    sr31_values.push_back(-std::sqrt(CC-BB));
-                    
-                    break; // skip the same situation
-                } else {
-                    // sr31 can be calculated throught dot product == 0
-                    sr31_values.push_back(- (sr11*sr12 + sr21*sr22) / sr32);
-                }
-            }
-        }
-
-        // std::cout << "h= " << std::setprecision(12) << h.transpose() << std::endl;
-        // std::cout << "length: " << sr32_values.size() << " & " << sr31_values.size() << std::endl;
-
-        assert(!sr31_values.empty());
-        assert(sr31_values.size() == sr32_values.size());
-        
-        std::vector<Eigen::Matrix3d> H_values;
-        for(size_t i=0;i<sr31_values.size(); ++i) {
-            const double sr31 = sr31_values.at(i);
-            const double sr32 = sr32_values.at(i);
-            const double lambda = 1.0 / sqrt(sr11*sr11 + sr21*sr21 + sr31*sr31);
-            Eigen::Matrix3d H;
-            H.setZero();
-            H(0,0) = sr11; H(0,1) = sr12; H(0,2) = st1;
-            H(1,0) = sr21; H(1,1) = sr22; H(1,2) = st2;
-            H(2,0) = sr31; H(2,1) = sr32; H(2,2) = 0;
-
-            H_values.push_back( lambda * H);
-            H_values.push_back(-lambda * H);
-        }
-
-        for(auto& H : H_values) {
-            // std::cout << "H=\n" << H << std::endl;
-            Eigen::Matrix3d R;
-            R.col(0) = H.col(0);
-            R.col(1) = H.col(1);
-            R.col(2) = H.col(0).cross(H.col(1));
-            // std::cout << "R33 = " << R(2,2) << std::endl;
-        }
-        
-        std::vector<Eigen::Matrix3d> H_candidates;
-
-        for (auto& H : H_values)
-        {
-            Eigen::MatrixXd A_mat(2 * imagePoints.at(image_index).size(), 4);
-            Eigen::VectorXd B_vec(2 * imagePoints.at(image_index).size());
-            A_mat.setZero();
-            B_vec.setZero();
-
-            size_t line_index = 0;
-
-            // iterate images
-            const double& r11 = H(0,0);
-            const double& r12 = H(0,1);
-            // const double& r13 = H(0,2);
-            const double& r21 = H(1,0);
-            const double& r22 = H(1,1);
-            // const double& r23 = H(1,2);
-            const double& r31 = H(2,0);
-            const double& r32 = H(2,1);
-            // const double& r33 = H(2,2);
-            const double& t1  = H(0);
-            const double& t2  = H(1);
-                
-            // iterate chessboard corners in the image
-            for(size_t j=0; j<imagePoints.at(image_index).size(); ++j) {
-                assert(line_index == 2 * j);
-
-                const double& X = objectPoints.at(image_index).at(j).x;
-                const double& Y = objectPoints.at(image_index).at(j).y;
-                const double& u = imagePoints.at(image_index).at(j).x;
-                const double& v = imagePoints.at(image_index).at(j).y;
-
-                double A = r21 * X + r22 * Y + t2;
-                double B = v * (r31 * X + r32 * Y);
-                double C = r11 * X + r12 * Y + t1;
-                double D = u * (r31 * X + r32 * Y);
-                double rou = std::sqrt(u*u + v*v);
-
-                
-                A_mat(line_index+0, 0) = A;
-                A_mat(line_index+1, 0) = C;
-                A_mat(line_index+0, 1) = A * rou;
-                A_mat(line_index+1, 1) = C * rou;
-                A_mat(line_index+0, 2) = A * rou * rou;
-                A_mat(line_index+1, 2) = C * rou * rou;
-                
-                A_mat(line_index+0, 3) = -v;
-                A_mat(line_index+1, 3) = -u;
-                B_vec(line_index+0) = B;
-                B_vec(line_index+1) = D;
-
-                line_index += 2;
-            }
-
-            assert(line_index == static_cast<unsigned int>(A_mat.rows()));
-
-            // pseudo-inverse for polynomial parameters and all t3s
-            {
-                Eigen::JacobiSVD<Eigen::MatrixXd> svd(A_mat, Eigen::ComputeThinU | Eigen::ComputeThinV);
-
-                Eigen::VectorXd x = svd.solve(B_vec);
-
-                // std::cout << "x(poly and t3) = " << x << std::endl;
-
-                if (x(2) > 0 && x(3) > 0) {
-                    H_candidates.push_back(H);
-                }
-            }
-        }
-
-        // printf("H_candidates.size()=%zu\n", H_candidates.size());
-        assert(H_candidates.size()==1);
-
-        Eigen::Matrix3d& H = H_candidates.front();
-
-        Eigen::Matrix3d R; 
-        R.col(0) = H.col(0); 
-        R.col(1) = H.col(1); 
-        R.col(2) = H.col(0).cross(H.col(1)); 
-
-        Eigen::Vector3d T = H.col(2);
-        RList.push_back(R);
-        TList.push_back(T);
-
-        // std::cout << "#" << image_index << " frame" << " R =" << R << " \nT = " << T.transpose() << std::endl;
+    for (auto& H : H_values) {
+      // std::cout << "H=\n" << H << std::endl;
+      Eigen::Matrix3d R;
+      R.col(0) = H.col(0);
+      R.col(1) = H.col(1);
+      R.col(2) = H.col(0).cross(H.col(1));
+      // std::cout << "R33 = " << R(2,2) << std::endl;
     }
 
-    // Second, estimate camera intrinsic parameters and all t3
-    Eigen::MatrixXd A_mat(2 * imagePoints.size() * imagePoints.at(0).size(), SCARAMUZZA_POLY_SIZE-1 + imagePoints.size());
-    Eigen::VectorXd B_vec(2 * imagePoints.size() * imagePoints.at(0).size());
-    A_mat.setZero();
-    B_vec.setZero();
+    std::vector<Eigen::Matrix3d> H_candidates;
 
-    size_t line_index = 0;
+    for (auto& H : H_values) {
+      Eigen::MatrixXd A_mat(2 * imagePoints.at(image_index).size(), 4);
+      Eigen::VectorXd B_vec(2 * imagePoints.at(image_index).size());
+      A_mat.setZero();
+      B_vec.setZero();
 
-    // iterate images
-    for(size_t i = 0; i < imagePoints.size(); ++i) {
-        const double& r11 = RList.at(i)(0,0);
-        const double& r12 = RList.at(i)(0,1);
-        // const double& r13 = RList.at(i)(0,2);
-        const double& r21 = RList.at(i)(1,0);
-        const double& r22 = RList.at(i)(1,1);
-        // const double& r23 = RList.at(i)(1,2);
-        const double& r31 = RList.at(i)(2,0);
-        const double& r32 = RList.at(i)(2,1);
-        // const double& r33 = RList.at(i)(2,2);
-        const double& t1  = TList.at(i)(0);
-        const double& t2  = TList.at(i)(1);
-        
-        // iterate chessboard corners in the image
-        for(size_t j=0; j<imagePoints.at(i).size(); ++j) {
-            assert(line_index == 2 * (i * imagePoints.at(0).size() + j));
+      size_t line_index = 0;
 
-            const double& X = objectPoints.at(i).at(j).x;
-            const double& Y = objectPoints.at(i).at(j).y;
-            const double& u = imagePoints.at(i).at(j).x;
-            const double& v = imagePoints.at(i).at(j).y;
+      // iterate images
+      const double& r11 = H(0, 0);
+      const double& r12 = H(0, 1);
+      // const double& r13 = H(0,2);
+      const double& r21 = H(1, 0);
+      const double& r22 = H(1, 1);
+      // const double& r23 = H(1,2);
+      const double& r31 = H(2, 0);
+      const double& r32 = H(2, 1);
+      // const double& r33 = H(2,2);
+      const double& t1 = H(0);
+      const double& t2 = H(1);
 
-            double A = r21 * X + r22 * Y + t2;
-            double B = v * (r31 * X + r32 * Y);
-            double C = r11 * X + r12 * Y + t1;
-            double D = u * (r31 * X + r32 * Y);
-            double rou = std::sqrt(u*u + v*v);
+      // iterate chessboard corners in the image
+      for (size_t j = 0; j < imagePoints.at(image_index).size(); ++j) {
+        assert(line_index == 2 * j);
 
-            for(int k=1;k<=SCARAMUZZA_POLY_SIZE-1;++k) {
-                double pow_rou = 0.0;
-                if (k == 1) {
-                    pow_rou = 1.0;
-                }
-                else {
-                    pow_rou = std::pow(rou, k);
-                }
+        const double& X = objectPoints.at(image_index).at(j).x;
+        const double& Y = objectPoints.at(image_index).at(j).y;
+        const double& u = imagePoints.at(image_index).at(j).x;
+        const double& v = imagePoints.at(image_index).at(j).y;
 
-                A_mat(line_index+0, k-1) = A * pow_rou;
-                A_mat(line_index+1, k-1) = C * pow_rou;
-            }
-            
-            A_mat(line_index+0, SCARAMUZZA_POLY_SIZE-1+i) = -v;
-            A_mat(line_index+1, SCARAMUZZA_POLY_SIZE-1+i) = -u;
-            B_vec(line_index+0) = B;
-            B_vec(line_index+1) = D;
+        double A = r21 * X + r22 * Y + t2;
+        double B = v * (r31 * X + r32 * Y);
+        double C = r11 * X + r12 * Y + t1;
+        double D = u * (r31 * X + r32 * Y);
+        double rou = std::sqrt(u * u + v * v);
 
-            line_index += 2;
-        }
-    }
+        A_mat(line_index + 0, 0) = A;
+        A_mat(line_index + 1, 0) = C;
+        A_mat(line_index + 0, 1) = A * rou;
+        A_mat(line_index + 1, 1) = C * rou;
+        A_mat(line_index + 0, 2) = A * rou * rou;
+        A_mat(line_index + 1, 2) = C * rou * rou;
 
-    assert(line_index == static_cast<unsigned int>(A_mat.rows()));
+        A_mat(line_index + 0, 3) = -v;
+        A_mat(line_index + 1, 3) = -u;
+        B_vec(line_index + 0) = B;
+        B_vec(line_index + 1) = D;
 
-    Eigen::Matrix<double, SCARAMUZZA_POLY_SIZE, 1> poly_coeff;
-    // pseudo-inverse for polynomial parameters and all t3s
-    {
+        line_index += 2;
+      }
+
+      assert(line_index == static_cast<unsigned int>(A_mat.rows()));
+
+      // pseudo-inverse for polynomial parameters and all t3s
+      {
         Eigen::JacobiSVD<Eigen::MatrixXd> svd(A_mat, Eigen::ComputeThinU | Eigen::ComputeThinV);
 
         Eigen::VectorXd x = svd.solve(B_vec);
 
-        poly_coeff[0] = x(0);
-        poly_coeff[1] = 0.0;
-        for(int i=1;i<poly_coeff.size()-1;++i) {
-            poly_coeff[i+1] = x(i);
+        // std::cout << "x(poly and t3) = " << x << std::endl;
+
+        if (x(2) > 0 && x(3) > 0) {
+          H_candidates.push_back(H);
         }
-        assert(x.size() == static_cast<unsigned int>(SCARAMUZZA_POLY_SIZE-1+TList.size()));
+      }
     }
 
-    Parameters params = getParameters();
+    // printf("H_candidates.size()=%zu\n", H_candidates.size());
+    assert(H_candidates.size() == 1);
 
-    // Affine matrix A is constructed as [C D; E 1]
-    params.C() = 1.0;
-    params.D() = 0.0;
-    params.E() = 0.0;
+    Eigen::Matrix3d& H = H_candidates.front();
 
-    params.center_x() = params.imageWidth() / 2.0;
-    params.center_y() = params.imageHeight() / 2.0;
-    
-    for(size_t i=0; i<SCARAMUZZA_POLY_SIZE; ++i) {
-        params.poly(i) = poly_coeff[i];
+    Eigen::Matrix3d R;
+    R.col(0) = H.col(0);
+    R.col(1) = H.col(1);
+    R.col(2) = H.col(0).cross(H.col(1));
+
+    Eigen::Vector3d T = H.col(2);
+    RList.push_back(R);
+    TList.push_back(T);
+
+    // std::cout << "#" << image_index << " frame" << " R =" << R << " \nT = " << T.transpose() <<
+    // std::endl;
+  }
+
+  // Second, estimate camera intrinsic parameters and all t3
+  Eigen::MatrixXd A_mat(2 * imagePoints.size() * imagePoints.at(0).size(),
+                        SCARAMUZZA_POLY_SIZE - 1 + imagePoints.size());
+  Eigen::VectorXd B_vec(2 * imagePoints.size() * imagePoints.at(0).size());
+  A_mat.setZero();
+  B_vec.setZero();
+
+  size_t line_index = 0;
+
+  // iterate images
+  for (size_t i = 0; i < imagePoints.size(); ++i) {
+    const double& r11 = RList.at(i)(0, 0);
+    const double& r12 = RList.at(i)(0, 1);
+    // const double& r13 = RList.at(i)(0,2);
+    const double& r21 = RList.at(i)(1, 0);
+    const double& r22 = RList.at(i)(1, 1);
+    // const double& r23 = RList.at(i)(1,2);
+    const double& r31 = RList.at(i)(2, 0);
+    const double& r32 = RList.at(i)(2, 1);
+    // const double& r33 = RList.at(i)(2,2);
+    const double& t1 = TList.at(i)(0);
+    const double& t2 = TList.at(i)(1);
+
+    // iterate chessboard corners in the image
+    for (size_t j = 0; j < imagePoints.at(i).size(); ++j) {
+      assert(line_index == 2 * (i * imagePoints.at(0).size() + j));
+
+      const double& X = objectPoints.at(i).at(j).x;
+      const double& Y = objectPoints.at(i).at(j).y;
+      const double& u = imagePoints.at(i).at(j).x;
+      const double& v = imagePoints.at(i).at(j).y;
+
+      double A = r21 * X + r22 * Y + t2;
+      double B = v * (r31 * X + r32 * Y);
+      double C = r11 * X + r12 * Y + t1;
+      double D = u * (r31 * X + r32 * Y);
+      double rou = std::sqrt(u * u + v * v);
+
+      for (int k = 1; k <= SCARAMUZZA_POLY_SIZE - 1; ++k) {
+        double pow_rou = 0.0;
+        if (k == 1) {
+          pow_rou = 1.0;
+        } else {
+          pow_rou = std::pow(rou, k);
+        }
+
+        A_mat(line_index + 0, k - 1) = A * pow_rou;
+        A_mat(line_index + 1, k - 1) = C * pow_rou;
+      }
+
+      A_mat(line_index + 0, SCARAMUZZA_POLY_SIZE - 1 + i) = -v;
+      A_mat(line_index + 1, SCARAMUZZA_POLY_SIZE - 1 + i) = -u;
+      B_vec(line_index + 0) = B;
+      B_vec(line_index + 1) = D;
+
+      line_index += 2;
+    }
+  }
+
+  assert(line_index == static_cast<unsigned int>(A_mat.rows()));
+
+  Eigen::Matrix<double, SCARAMUZZA_POLY_SIZE, 1> poly_coeff;
+  // pseudo-inverse for polynomial parameters and all t3s
+  {
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd(A_mat, Eigen::ComputeThinU | Eigen::ComputeThinV);
+
+    Eigen::VectorXd x = svd.solve(B_vec);
+
+    poly_coeff[0] = x(0);
+    poly_coeff[1] = 0.0;
+    for (int i = 1; i < poly_coeff.size() - 1; ++i) {
+      poly_coeff[i + 1] = x(i);
+    }
+    assert(x.size() == static_cast<unsigned int>(SCARAMUZZA_POLY_SIZE - 1 + TList.size()));
+  }
+
+  Parameters params = getParameters();
+
+  // Affine matrix A is constructed as [C D; E 1]
+  params.C() = 1.0;
+  params.D() = 0.0;
+  params.E() = 0.0;
+
+  params.center_x() = params.imageWidth() / 2.0;
+  params.center_y() = params.imageHeight() / 2.0;
+
+  for (size_t i = 0; i < SCARAMUZZA_POLY_SIZE; ++i) {
+    params.poly(i) = poly_coeff[i];
+  }
+
+  // params.poly(0) = -216.9657476318;
+  // params.poly(1) = 0.0;
+  // params.poly(2) = 0.0017866911;
+  // params.poly(3) = -0.0000019866;
+  // params.poly(4) =  0.0000000077;
+
+  // inv_poly
+  {
+    std::vector<double> rou_vec;
+    std::vector<double> z_vec;
+    for (double rou = 0.0; rou <= (params.imageWidth() + params.imageHeight()) / 2; rou += 0.1) {
+      double rou_pow_k = 1.0;
+      double z = 0.0;
+
+      for (int k = 0; k < SCARAMUZZA_POLY_SIZE; k++) {
+        z += rou_pow_k * params.poly(k);
+        rou_pow_k *= rou;
+      }
+
+      rou_vec.push_back(rou);
+      z_vec.push_back(z);
     }
 
-    // params.poly(0) = -216.9657476318;
-    // params.poly(1) = 0.0;
-    // params.poly(2) = 0.0017866911;
-    // params.poly(3) = -0.0000019866;
-    // params.poly(4) =  0.0000000077;
+    assert(rou_vec.size() == z_vec.size());
+    Eigen::VectorXd xVec(rou_vec.size());
+    Eigen::VectorXd yVec(rou_vec.size());
 
-    
-    // inv_poly
-    {
-        std::vector<double> rou_vec;
-        std::vector<double> z_vec;
-        for(double rou = 0.0; rou <= (params.imageWidth() + params.imageHeight())/2; rou += 0.1) {
-            double rou_pow_k = 1.0;
-            double z = 0.0;
-
-            for (int k = 0; k < SCARAMUZZA_POLY_SIZE; k++)
-            {
-                z += rou_pow_k * params.poly(k);
-                rou_pow_k *= rou;
-            }
-
-            rou_vec.push_back(rou);
-            z_vec.push_back(z);
-        }
-
-        assert(rou_vec.size() == z_vec.size());
-        Eigen::VectorXd xVec(rou_vec.size());
-        Eigen::VectorXd yVec(rou_vec.size());
-
-        for(size_t i=0; i<rou_vec.size(); ++i) {
-            xVec(i) = std::atan2(-z_vec.at(i), rou_vec.at(i));
-            yVec(i) = rou_vec.at(i);
-        }
-
-        // use lower order poly to eliminate over-fitting cause by noisy/inaccurate data
-        const int poly_fit_order = 4;
-        Eigen::VectorXd inv_poly_coeff = polyfit(xVec, yVec, poly_fit_order);
-        
-        for(int i=0; i<=poly_fit_order; ++i) {
-            params.inv_poly(i) = inv_poly_coeff(i);
-        }
+    for (size_t i = 0; i < rou_vec.size(); ++i) {
+      xVec(i) = std::atan2(-z_vec.at(i), rou_vec.at(i));
+      yVec(i) = rou_vec.at(i);
     }
 
-    setParameters(params);
+    // use lower order poly to eliminate over-fitting cause by noisy/inaccurate data
+    const int poly_fit_order = 4;
+    Eigen::VectorXd inv_poly_coeff = polyfit(xVec, yVec, poly_fit_order);
 
-    std::cout << "initial params:\n" << params << std::endl; 
+    for (int i = 0; i <= poly_fit_order; ++i) {
+      params.inv_poly(i) = inv_poly_coeff(i);
+    }
+  }
+
+  setParameters(params);
+
+  std::cout << "initial params:\n" << params << std::endl;
 }
 
-/** 
+/**
  * \brief Lifts a point from the image plane to the unit sphere
  *
  * \param p image coordinates
  * \param P coordinates of the point on the sphere
  */
-void
-OCAMCamera::liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const
-{
-    liftProjective(p, P);
-    P.normalize();
+void OCAMCamera::liftSphere(const Eigen::Vector2d& p, Eigen::Vector3d& P) const {
+  liftProjective(p, P);
+  P.normalize();
 }
 
-/** 
+/**
  * \brief Lifts a point from the image plane to its projective ray
  *
  * \param p image coordinates
  * \param P coordinates of the projective ray
  */
-void
-OCAMCamera::liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const
-{
-    // Relative to Center
-    Eigen::Vector2d xc(p[0] - mParameters.center_x(), p[1] - mParameters.center_y());
+void OCAMCamera::liftProjective(const Eigen::Vector2d& p, Eigen::Vector3d& P) const {
+  // Relative to Center
+  Eigen::Vector2d xc(p[0] - mParameters.center_x(), p[1] - mParameters.center_y());
 
-    // Affine Transformation
-    // xc_a = inv(A) * xc;
-    Eigen::Vector2d xc_a(
-        m_inv_scale * (xc[0] - mParameters.D() * xc[1]),
-        m_inv_scale * (-mParameters.E() * xc[0] + mParameters.C() * xc[1])
-    );
+  // Affine Transformation
+  // xc_a = inv(A) * xc;
+  Eigen::Vector2d xc_a(m_inv_scale * (xc[0] - mParameters.D() * xc[1]),
+                       m_inv_scale * (-mParameters.E() * xc[0] + mParameters.C() * xc[1]));
 
-    double phi = std::sqrt(xc_a[0] * xc_a[0] + xc_a[1] * xc_a[1]);
-    double phi_i = 1.0;
-    double z = 0.0;
+  double phi = std::sqrt(xc_a[0] * xc_a[0] + xc_a[1] * xc_a[1]);
+  double phi_i = 1.0;
+  double z = 0.0;
 
-    for (int i = 0; i < SCARAMUZZA_POLY_SIZE; i++)
-    {
-        z += phi_i * mParameters.poly(i);
-        phi_i *= phi;
-    }
+  for (int i = 0; i < SCARAMUZZA_POLY_SIZE; i++) {
+    z += phi_i * mParameters.poly(i);
+    phi_i *= phi;
+  }
 
-    P << xc[0], xc[1], -z;
+  P << xc[0], xc[1], -z;
 }
 
-
-/** 
+/**
  * \brief Project a 3D point (\a x,\a y,\a z) to the image plane in (\a u,\a v)
  *
  * \param P 3D point coordinates
  * \param p return value, contains the image point coordinates
  */
-void
-OCAMCamera::spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const
-{
-    double norm = std::sqrt(P[0] * P[0] + P[1] * P[1]);
-    double theta = std::atan2(-P[2], norm);
-    double rho = 0.0;
-    double theta_i = 1.0;
+void OCAMCamera::spaceToPlane(const Eigen::Vector3d& P, Eigen::Vector2d& p) const {
+  double norm = std::sqrt(P[0] * P[0] + P[1] * P[1]);
+  double theta = std::atan2(-P[2], norm);
+  double rho = 0.0;
+  double theta_i = 1.0;
 
-    for (int i = 0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
-    {
-        rho += theta_i * mParameters.inv_poly(i);
-        theta_i *= theta;
-    }
+  for (int i = 0; i < SCARAMUZZA_INV_POLY_SIZE; i++) {
+    rho += theta_i * mParameters.inv_poly(i);
+    theta_i *= theta;
+  }
 
-    double invNorm = 1.0 / norm;
-    Eigen::Vector2d xn(
-        P[0] * invNorm * rho,
-        P[1] * invNorm * rho
-    );
+  double invNorm = 1.0 / norm;
+  Eigen::Vector2d xn(P[0] * invNorm * rho, P[1] * invNorm * rho);
 
-    p << xn[0] * mParameters.C() + xn[1] * mParameters.D() + mParameters.center_x(),
-         xn[0] * mParameters.E() + xn[1]                   + mParameters.center_y();
+  p << xn[0] * mParameters.C() + xn[1] * mParameters.D() + mParameters.center_x(),
+      xn[0] * mParameters.E() + xn[1] + mParameters.center_y();
 }
 
-
-/** 
+/**
  * \brief Projects an undistorted 2D point p_u to the image plane
  *
  * \param p_u 2D point coordinates
  * \return image point coordinates
  */
-void
-OCAMCamera::undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const
-{
-    Eigen::Vector3d P(p_u[0], p_u[1], 1.0);
-    spaceToPlane(P, p);
+void OCAMCamera::undistToPlane(const Eigen::Vector2d& p_u, Eigen::Vector2d& p) const {
+  Eigen::Vector3d P(p_u[0], p_u[1], 1.0);
+  spaceToPlane(P, p);
 }
-
 
 #if 0
 void
@@ -701,133 +643,103 @@ OCAMCamera::initUndistortMap(cv::Mat& map1, cv::Mat& map2, double fScale) const
 }
 #endif
 
-cv::Mat
-OCAMCamera::initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2,
-                                    float fx, float fy,
-                                    cv::Size imageSize,
-                                    float cx, float cy,
-                                    cv::Mat rmat) const
-{
-    if (imageSize == cv::Size(0, 0))
-    {
-        imageSize = cv::Size(mParameters.imageWidth(), mParameters.imageHeight());
+cv::Mat OCAMCamera::initUndistortRectifyMap(cv::Mat& map1, cv::Mat& map2, float fx, float fy,
+                                            cv::Size imageSize, float cx, float cy,
+                                            cv::Mat rmat) const {
+  if (imageSize == cv::Size(0, 0)) {
+    imageSize = cv::Size(mParameters.imageWidth(), mParameters.imageHeight());
+  }
+
+  cv::Mat mapX = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
+  cv::Mat mapY = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
+
+  Eigen::Matrix3f K_rect;
+
+  K_rect << fx, 0, cx < 0 ? imageSize.width / 2 : cx, 0, fy, cy < 0 ? imageSize.height / 2 : cy, 0,
+      0, 1;
+
+  if (fx < 0 || fy < 0) {
+    throw std::string(std::string(__FUNCTION__) + ": Focal length must be specified");
+  }
+
+  Eigen::Matrix3f K_rect_inv = K_rect.inverse();
+
+  Eigen::Matrix3f R, R_inv;
+  cv::cv2eigen(rmat, R);
+  R_inv = R.inverse();
+
+  for (int v = 0; v < imageSize.height; ++v) {
+    for (int u = 0; u < imageSize.width; ++u) {
+      Eigen::Vector3f xo;
+      xo << u, v, 1;
+
+      Eigen::Vector3f uo = R_inv * K_rect_inv * xo;
+
+      Eigen::Vector2d p;
+      spaceToPlane(uo.cast<double>(), p);
+
+      mapX.at<float>(v, u) = p(0);
+      mapY.at<float>(v, u) = p(1);
     }
+  }
 
-    cv::Mat mapX = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
-    cv::Mat mapY = cv::Mat::zeros(imageSize.height, imageSize.width, CV_32F);
+  cv::convertMaps(mapX, mapY, map1, map2, CV_32FC1, false);
 
-    Eigen::Matrix3f K_rect;
-
-    K_rect << fx, 0, cx < 0 ? imageSize.width / 2 : cx,
-              0, fy, cy < 0 ? imageSize.height / 2 : cy,
-              0, 0, 1;
-
-    if (fx < 0 || fy < 0)
-    {
-        throw std::string(std::string(__FUNCTION__) + ": Focal length must be specified");
-    }
-
-    Eigen::Matrix3f K_rect_inv = K_rect.inverse();
-
-    Eigen::Matrix3f R, R_inv;
-    cv::cv2eigen(rmat, R);
-    R_inv = R.inverse();
-
-    for (int v = 0; v < imageSize.height; ++v)
-    {
-        for (int u = 0; u < imageSize.width; ++u)
-        {
-            Eigen::Vector3f xo;
-            xo << u, v, 1;
-
-            Eigen::Vector3f uo = R_inv * K_rect_inv * xo;
-
-            Eigen::Vector2d p;
-            spaceToPlane(uo.cast<double>(), p);
-
-            mapX.at<float>(v,u) = p(0);
-            mapY.at<float>(v,u) = p(1);
-        }
-    }
-
-    cv::convertMaps(mapX, mapY, map1, map2, CV_32FC1, false);
-
-    cv::Mat K_rect_cv;
-    cv::eigen2cv(K_rect, K_rect_cv);
-    return K_rect_cv;
+  cv::Mat K_rect_cv;
+  cv::eigen2cv(K_rect, K_rect_cv);
+  return K_rect_cv;
 }
 
-int
-OCAMCamera::parameterCount(void) const
-{
-    return SCARAMUZZA_CAMERA_NUM_PARAMS;
+int OCAMCamera::parameterCount(void) const { return SCARAMUZZA_CAMERA_NUM_PARAMS; }
+
+const OCAMCamera::Parameters& OCAMCamera::getParameters(void) const { return mParameters; }
+
+void OCAMCamera::setParameters(const OCAMCamera::Parameters& parameters) {
+  mParameters = parameters;
+
+  m_inv_scale = 1.0 / (parameters.C() - parameters.D() * parameters.E());
 }
 
-const OCAMCamera::Parameters&
-OCAMCamera::getParameters(void) const
-{
-    return mParameters;
+void OCAMCamera::readParameters(const std::vector<double>& parameterVec) {
+  if ((int)parameterVec.size() != parameterCount()) {
+    return;
+  }
+
+  Parameters params = getParameters();
+
+  params.C() = parameterVec.at(0);
+  params.D() = parameterVec.at(1);
+  params.E() = parameterVec.at(2);
+  params.center_x() = parameterVec.at(3);
+  params.center_y() = parameterVec.at(4);
+  for (int i = 0; i < SCARAMUZZA_POLY_SIZE; i++) params.poly(i) = parameterVec.at(5 + i);
+  for (int i = 0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
+    params.inv_poly(i) = parameterVec.at(5 + SCARAMUZZA_POLY_SIZE + i);
+
+  setParameters(params);
 }
 
-void
-OCAMCamera::setParameters(const OCAMCamera::Parameters& parameters)
-{
-    mParameters = parameters;
-
-    m_inv_scale = 1.0 / (parameters.C() - parameters.D() * parameters.E());
+void OCAMCamera::writeParameters(std::vector<double>& parameterVec) const {
+  parameterVec.resize(parameterCount());
+  parameterVec.at(0) = mParameters.C();
+  parameterVec.at(1) = mParameters.D();
+  parameterVec.at(2) = mParameters.E();
+  parameterVec.at(3) = mParameters.center_x();
+  parameterVec.at(4) = mParameters.center_y();
+  for (int i = 0; i < SCARAMUZZA_POLY_SIZE; i++) parameterVec.at(5 + i) = mParameters.poly(i);
+  for (int i = 0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
+    parameterVec.at(5 + SCARAMUZZA_POLY_SIZE + i) = mParameters.inv_poly(i);
 }
 
-void
-OCAMCamera::readParameters(const std::vector<double>& parameterVec)
-{
-    if ((int)parameterVec.size() != parameterCount())
-    {
-        return;
-    }
-
-    Parameters params = getParameters();
-
-    params.C() = parameterVec.at(0);
-    params.D() = parameterVec.at(1);
-    params.E() = parameterVec.at(2);
-    params.center_x() = parameterVec.at(3);
-    params.center_y() = parameterVec.at(4);
-    for (int i=0; i < SCARAMUZZA_POLY_SIZE; i++)
-        params.poly(i) = parameterVec.at(5+i);
-    for (int i=0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
-        params.inv_poly(i) = parameterVec.at(5 + SCARAMUZZA_POLY_SIZE + i);
-
-    setParameters(params);
+void OCAMCamera::writeParametersToYamlFile(const std::string& filename) const {
+  mParameters.writeToYamlFile(filename);
 }
 
-void
-OCAMCamera::writeParameters(std::vector<double>& parameterVec) const
-{
-    parameterVec.resize(parameterCount());
-    parameterVec.at(0) = mParameters.C();
-    parameterVec.at(1) = mParameters.D();
-    parameterVec.at(2) = mParameters.E();
-    parameterVec.at(3) = mParameters.center_x();
-    parameterVec.at(4) = mParameters.center_y();
-    for (int i=0; i < SCARAMUZZA_POLY_SIZE; i++)
-        parameterVec.at(5+i) = mParameters.poly(i);
-    for (int i=0; i < SCARAMUZZA_INV_POLY_SIZE; i++)
-        parameterVec.at(5 + SCARAMUZZA_POLY_SIZE + i) = mParameters.inv_poly(i);
+std::string OCAMCamera::parametersToString(void) const {
+  std::ostringstream oss;
+  oss << mParameters;
+
+  return oss.str();
 }
 
-void
-OCAMCamera::writeParametersToYamlFile(const std::string& filename) const
-{
-    mParameters.writeToYamlFile(filename);
-}
-
-std::string
-OCAMCamera::parametersToString(void) const
-{
-    std::ostringstream oss;
-    oss << mParameters;
-
-    return oss.str();
-}
-
-}
+}  // namespace camodocal

--- a/src/frontend/camodocal/gpl/EigenQuaternionParameterization.cc
+++ b/src/frontend/camodocal/gpl/EigenQuaternionParameterization.cc
@@ -2,45 +2,41 @@
 
 #include <cmath>
 
-namespace camodocal
-{
+namespace camodocal {
 
-bool
-EigenQuaternionParameterization::Plus(const double* x,
-                                      const double* delta,
-                                      double* x_plus_delta) const
-{
-    const double norm_delta =
-        sqrt(delta[0] * delta[0] + delta[1] * delta[1] + delta[2] * delta[2]);
-    if (norm_delta > 0.0)
-    {
-        const double sin_delta_by_delta = (sin(norm_delta) / norm_delta);
-        double q_delta[4];
-        q_delta[0] = sin_delta_by_delta * delta[0];
-        q_delta[1] = sin_delta_by_delta * delta[1];
-        q_delta[2] = sin_delta_by_delta * delta[2];
-        q_delta[3] = cos(norm_delta);
-        EigenQuaternionProduct(q_delta, x, x_plus_delta);
+bool EigenQuaternionParameterization::Plus(const double* x, const double* delta,
+                                           double* x_plus_delta) const {
+  const double norm_delta = sqrt(delta[0] * delta[0] + delta[1] * delta[1] + delta[2] * delta[2]);
+  if (norm_delta > 0.0) {
+    const double sin_delta_by_delta = (sin(norm_delta) / norm_delta);
+    double q_delta[4];
+    q_delta[0] = sin_delta_by_delta * delta[0];
+    q_delta[1] = sin_delta_by_delta * delta[1];
+    q_delta[2] = sin_delta_by_delta * delta[2];
+    q_delta[3] = cos(norm_delta);
+    EigenQuaternionProduct(q_delta, x, x_plus_delta);
+  } else {
+    for (int i = 0; i < 4; ++i) {
+      x_plus_delta[i] = x[i];
     }
-    else
-    {
-        for (int i = 0; i < 4; ++i)
-        {
-            x_plus_delta[i] = x[i];
-        }
-    }
-    return true;
+  }
+  return true;
 }
 
-bool
-EigenQuaternionParameterization::ComputeJacobian(const double* x,
-                                                 double* jacobian) const
-{
-    jacobian[0] =  x[3]; jacobian[1]  =  x[2]; jacobian[2]  = -x[1];  // NOLINT
-    jacobian[3] = -x[2]; jacobian[4]  =  x[3]; jacobian[5]  =  x[0];  // NOLINT
-    jacobian[6] =  x[1]; jacobian[7] = -x[0]; jacobian[8] =  x[3];  // NOLINT
-    jacobian[9] = -x[0]; jacobian[10]  = -x[1]; jacobian[11]  = -x[2];  // NOLINT
-    return true;
+bool EigenQuaternionParameterization::ComputeJacobian(const double* x, double* jacobian) const {
+  jacobian[0] = x[3];
+  jacobian[1] = x[2];
+  jacobian[2] = -x[1];  // NOLINT
+  jacobian[3] = -x[2];
+  jacobian[4] = x[3];
+  jacobian[5] = x[0];  // NOLINT
+  jacobian[6] = x[1];
+  jacobian[7] = -x[0];
+  jacobian[8] = x[3];  // NOLINT
+  jacobian[9] = -x[0];
+  jacobian[10] = -x[1];
+  jacobian[11] = -x[2];  // NOLINT
+  return true;
 }
 
-}
+}  // namespace camodocal

--- a/src/frontend/camodocal/gpl/gpl.cc
+++ b/src/frontend/camodocal/gpl/gpl.cc
@@ -7,7 +7,6 @@
 #include <time.h>
 #endif
 
-
 // source: https://stackoverflow.com/questions/5167269/clock-gettime-alternative-in-mac-os-x
 #ifdef __APPLE__
 #include <mach/mach_time.h>
@@ -20,7 +19,7 @@ static uint64_t orwl_timestart = 0;
 struct timespec orwl_gettime(void) {
   // be more careful in a multithreaded environement
   if (!orwl_timestart) {
-    mach_timebase_info_data_t tb = { 0 };
+    mach_timebase_info_data_t tb = {0};
     mach_timebase_info(&tb);
     orwl_timebase = tb.numer;
     orwl_timebase /= tb.denom;
@@ -32,8 +31,7 @@ struct timespec orwl_gettime(void) {
   t.tv_nsec = diff - (t.tv_sec * ORWL_GIGA);
   return t;
 }
-#endif // __APPLE__
-
+#endif  // __APPLE__
 
 const double WGS84_A = 6378137.0;
 const double WGS84_ECCSQ = 0.00669437999013;
@@ -43,886 +41,637 @@ const double WGS84_ECCSQ = 0.00669437999013;
 #define fminf(x, y) (((x) < (y)) ? (x) : (y))
 #endif
 
-namespace camodocal
-{
+namespace camodocal {
 
-double hypot3(double x, double y, double z)
-{
-	return sqrt(square(x) + square(y) + square(z));
-}
+double hypot3(double x, double y, double z) { return sqrt(square(x) + square(y) + square(z)); }
 
-float hypot3f(float x, float y, float z)
-{
-	return sqrtf(square(x) + square(y) + square(z));
-}
+float hypot3f(float x, float y, float z) { return sqrtf(square(x) + square(y) + square(z)); }
 
-double d2r(double deg)
-{
-	return deg / 180.0 * M_PI;
-}
+double d2r(double deg) { return deg / 180.0 * M_PI; }
 
-float d2r(float deg)
-{
-	return deg / 180.0f * M_PI;
-}
+float d2r(float deg) { return deg / 180.0f * M_PI; }
 
-double r2d(double rad)
-{
-	return rad / M_PI * 180.0;
-}
+double r2d(double rad) { return rad / M_PI * 180.0; }
 
-float r2d(float rad)
-{
-	return rad / M_PI * 180.0f;
-}
+float r2d(float rad) { return rad / M_PI * 180.0f; }
 
-double sinc(double theta)
-{
-    return sin(theta) / theta;
-}
+double sinc(double theta) { return sin(theta) / theta; }
 
 #ifdef _WIN32
 #include <sys/timeb.h>
 #include <sys/types.h>
 #include <winsock.h>
 LARGE_INTEGER
-getFILETIMEoffset()
-{
-    SYSTEMTIME s;
-    FILETIME f;
-    LARGE_INTEGER t;
+getFILETIMEoffset() {
+  SYSTEMTIME s;
+  FILETIME f;
+  LARGE_INTEGER t;
 
-    s.wYear = 1970;
-    s.wMonth = 1;
-    s.wDay = 1;
-    s.wHour = 0;
-    s.wMinute = 0;
-    s.wSecond = 0;
-    s.wMilliseconds = 0;
-    SystemTimeToFileTime(&s, &f);
+  s.wYear = 1970;
+  s.wMonth = 1;
+  s.wDay = 1;
+  s.wHour = 0;
+  s.wMinute = 0;
+  s.wSecond = 0;
+  s.wMilliseconds = 0;
+  SystemTimeToFileTime(&s, &f);
+  t.QuadPart = f.dwHighDateTime;
+  t.QuadPart <<= 32;
+  t.QuadPart |= f.dwLowDateTime;
+  return (t);
+}
+
+int clock_gettime(int X, struct timespec* tp) {
+  LARGE_INTEGER t;
+  FILETIME f;
+  double microseconds;
+  static LARGE_INTEGER offset;
+  static double frequencyToMicroseconds;
+  static int initialized = 0;
+  static BOOL usePerformanceCounter = 0;
+
+  if (!initialized) {
+    LARGE_INTEGER performanceFrequency;
+    initialized = 1;
+    usePerformanceCounter = QueryPerformanceFrequency(&performanceFrequency);
+    if (usePerformanceCounter) {
+      QueryPerformanceCounter(&offset);
+      frequencyToMicroseconds = (double)performanceFrequency.QuadPart / 1000000.;
+    } else {
+      offset = getFILETIMEoffset();
+      frequencyToMicroseconds = 10.;
+    }
+  }
+  if (usePerformanceCounter)
+    QueryPerformanceCounter(&t);
+  else {
+    GetSystemTimeAsFileTime(&f);
     t.QuadPart = f.dwHighDateTime;
     t.QuadPart <<= 32;
     t.QuadPart |= f.dwLowDateTime;
-    return (t);
-}
+  }
 
-int
-clock_gettime(int X, struct timespec *tp)
-{
-    LARGE_INTEGER           t;
-    FILETIME            f;
-    double                  microseconds;
-    static LARGE_INTEGER    offset;
-    static double           frequencyToMicroseconds;
-    static int              initialized = 0;
-    static BOOL             usePerformanceCounter = 0;
-
-    if (!initialized) {
-        LARGE_INTEGER performanceFrequency;
-        initialized = 1;
-        usePerformanceCounter = QueryPerformanceFrequency(&performanceFrequency);
-        if (usePerformanceCounter) {
-            QueryPerformanceCounter(&offset);
-            frequencyToMicroseconds = (double)performanceFrequency.QuadPart / 1000000.;
-        } else {
-            offset = getFILETIMEoffset();
-            frequencyToMicroseconds = 10.;
-        }
-    }
-    if (usePerformanceCounter) QueryPerformanceCounter(&t);
-    else {
-        GetSystemTimeAsFileTime(&f);
-        t.QuadPart = f.dwHighDateTime;
-        t.QuadPart <<= 32;
-        t.QuadPart |= f.dwLowDateTime;
-    }
-
-    t.QuadPart -= offset.QuadPart;
-    microseconds = (double)t.QuadPart / frequencyToMicroseconds;
-    t.QuadPart = microseconds;
-    tp->tv_sec = t.QuadPart / 1000000;
-    tp->tv_nsec = (t.QuadPart % 1000000) * 1000;
-    return (0);
+  t.QuadPart -= offset.QuadPart;
+  microseconds = (double)t.QuadPart / frequencyToMicroseconds;
+  t.QuadPart = microseconds;
+  tp->tv_sec = t.QuadPart / 1000000;
+  tp->tv_nsec = (t.QuadPart % 1000000) * 1000;
+  return (0);
 }
 #endif
 
-unsigned long long timeInMicroseconds(void)
-{
-	 struct timespec tp;
+unsigned long long timeInMicroseconds(void) {
+  struct timespec tp;
 #ifdef __APPLE__
-     tp = orwl_gettime();
+  tp = orwl_gettime();
 #else
-	 clock_gettime(CLOCK_REALTIME, &tp);
+  clock_gettime(CLOCK_REALTIME, &tp);
 #endif
 
-	 return tp.tv_sec * 1000000 + tp.tv_nsec / 1000;
+  return tp.tv_sec * 1000000 + tp.tv_nsec / 1000;
 }
 
-double timeInSeconds(void)
-{
-    struct timespec tp;
+double timeInSeconds(void) {
+  struct timespec tp;
 #ifdef __APPLE__
-     tp = orwl_gettime();
+  tp = orwl_gettime();
 #else
-	 clock_gettime(CLOCK_REALTIME, &tp);
+  clock_gettime(CLOCK_REALTIME, &tp);
 #endif
 
-	 return static_cast<double>(tp.tv_sec) +
-			 static_cast<double>(tp.tv_nsec) / 1000000000.0;
+  return static_cast<double>(tp.tv_sec) + static_cast<double>(tp.tv_nsec) / 1000000000.0;
 }
 
-float colormapAutumn[128][3] =
-{
-		{1.0f,0.f,0.f},
-		{1.0f,0.007874f,0.f},
-		{1.0f,0.015748f,0.f},
-		{1.0f,0.023622f,0.f},
-		{1.0f,0.031496f,0.f},
-		{1.0f,0.03937f,0.f},
-		{1.0f,0.047244f,0.f},
-		{1.0f,0.055118f,0.f},
-		{1.0f,0.062992f,0.f},
-		{1.0f,0.070866f,0.f},
-		{1.0f,0.07874f,0.f},
-		{1.0f,0.086614f,0.f},
-		{1.0f,0.094488f,0.f},
-		{1.0f,0.10236f,0.f},
-		{1.0f,0.11024f,0.f},
-		{1.0f,0.11811f,0.f},
-		{1.0f,0.12598f,0.f},
-		{1.0f,0.13386f,0.f},
-		{1.0f,0.14173f,0.f},
-		{1.0f,0.14961f,0.f},
-		{1.0f,0.15748f,0.f},
-		{1.0f,0.16535f,0.f},
-		{1.0f,0.17323f,0.f},
-		{1.0f,0.1811f,0.f},
-		{1.0f,0.18898f,0.f},
-		{1.0f,0.19685f,0.f},
-		{1.0f,0.20472f,0.f},
-		{1.0f,0.2126f,0.f},
-		{1.0f,0.22047f,0.f},
-		{1.0f,0.22835f,0.f},
-		{1.0f,0.23622f,0.f},
-		{1.0f,0.24409f,0.f},
-		{1.0f,0.25197f,0.f},
-		{1.0f,0.25984f,0.f},
-		{1.0f,0.26772f,0.f},
-		{1.0f,0.27559f,0.f},
-		{1.0f,0.28346f,0.f},
-		{1.0f,0.29134f,0.f},
-		{1.0f,0.29921f,0.f},
-		{1.0f,0.30709f,0.f},
-		{1.0f,0.31496f,0.f},
-		{1.0f,0.32283f,0.f},
-		{1.0f,0.33071f,0.f},
-		{1.0f,0.33858f,0.f},
-		{1.0f,0.34646f,0.f},
-		{1.0f,0.35433f,0.f},
-		{1.0f,0.3622f,0.f},
-		{1.0f,0.37008f,0.f},
-		{1.0f,0.37795f,0.f},
-		{1.0f,0.38583f,0.f},
-		{1.0f,0.3937f,0.f},
-		{1.0f,0.40157f,0.f},
-		{1.0f,0.40945f,0.f},
-		{1.0f,0.41732f,0.f},
-		{1.0f,0.4252f,0.f},
-		{1.0f,0.43307f,0.f},
-		{1.0f,0.44094f,0.f},
-		{1.0f,0.44882f,0.f},
-		{1.0f,0.45669f,0.f},
-		{1.0f,0.46457f,0.f},
-		{1.0f,0.47244f,0.f},
-		{1.0f,0.48031f,0.f},
-		{1.0f,0.48819f,0.f},
-		{1.0f,0.49606f,0.f},
-		{1.0f,0.50394f,0.f},
-		{1.0f,0.51181f,0.f},
-		{1.0f,0.51969f,0.f},
-		{1.0f,0.52756f,0.f},
-		{1.0f,0.53543f,0.f},
-		{1.0f,0.54331f,0.f},
-		{1.0f,0.55118f,0.f},
-		{1.0f,0.55906f,0.f},
-		{1.0f,0.56693f,0.f},
-		{1.0f,0.5748f,0.f},
-		{1.0f,0.58268f,0.f},
-		{1.0f,0.59055f,0.f},
-		{1.0f,0.59843f,0.f},
-		{1.0f,0.6063f,0.f},
-		{1.0f,0.61417f,0.f},
-		{1.0f,0.62205f,0.f},
-		{1.0f,0.62992f,0.f},
-		{1.0f,0.6378f,0.f},
-		{1.0f,0.64567f,0.f},
-		{1.0f,0.65354f,0.f},
-		{1.0f,0.66142f,0.f},
-		{1.0f,0.66929f,0.f},
-		{1.0f,0.67717f,0.f},
-		{1.0f,0.68504f,0.f},
-		{1.0f,0.69291f,0.f},
-		{1.0f,0.70079f,0.f},
-		{1.0f,0.70866f,0.f},
-		{1.0f,0.71654f,0.f},
-		{1.0f,0.72441f,0.f},
-		{1.0f,0.73228f,0.f},
-		{1.0f,0.74016f,0.f},
-		{1.0f,0.74803f,0.f},
-		{1.0f,0.75591f,0.f},
-		{1.0f,0.76378f,0.f},
-		{1.0f,0.77165f,0.f},
-		{1.0f,0.77953f,0.f},
-		{1.0f,0.7874f,0.f},
-		{1.0f,0.79528f,0.f},
-		{1.0f,0.80315f,0.f},
-		{1.0f,0.81102f,0.f},
-		{1.0f,0.8189f,0.f},
-		{1.0f,0.82677f,0.f},
-		{1.0f,0.83465f,0.f},
-		{1.0f,0.84252f,0.f},
-		{1.0f,0.85039f,0.f},
-		{1.0f,0.85827f,0.f},
-		{1.0f,0.86614f,0.f},
-		{1.0f,0.87402f,0.f},
-		{1.0f,0.88189f,0.f},
-		{1.0f,0.88976f,0.f},
-		{1.0f,0.89764f,0.f},
-		{1.0f,0.90551f,0.f},
-		{1.0f,0.91339f,0.f},
-		{1.0f,0.92126f,0.f},
-		{1.0f,0.92913f,0.f},
-		{1.0f,0.93701f,0.f},
-		{1.0f,0.94488f,0.f},
-		{1.0f,0.95276f,0.f},
-		{1.0f,0.96063f,0.f},
-		{1.0f,0.9685f,0.f},
-		{1.0f,0.97638f,0.f},
-		{1.0f,0.98425f,0.f},
-		{1.0f,0.99213f,0.f},
-		{1.0f,1.0f,0.0f}
-};
+float colormapAutumn[128][3] = {
+    {1.0f, 0.f, 0.f},       {1.0f, 0.007874f, 0.f}, {1.0f, 0.015748f, 0.f}, {1.0f, 0.023622f, 0.f},
+    {1.0f, 0.031496f, 0.f}, {1.0f, 0.03937f, 0.f},  {1.0f, 0.047244f, 0.f}, {1.0f, 0.055118f, 0.f},
+    {1.0f, 0.062992f, 0.f}, {1.0f, 0.070866f, 0.f}, {1.0f, 0.07874f, 0.f},  {1.0f, 0.086614f, 0.f},
+    {1.0f, 0.094488f, 0.f}, {1.0f, 0.10236f, 0.f},  {1.0f, 0.11024f, 0.f},  {1.0f, 0.11811f, 0.f},
+    {1.0f, 0.12598f, 0.f},  {1.0f, 0.13386f, 0.f},  {1.0f, 0.14173f, 0.f},  {1.0f, 0.14961f, 0.f},
+    {1.0f, 0.15748f, 0.f},  {1.0f, 0.16535f, 0.f},  {1.0f, 0.17323f, 0.f},  {1.0f, 0.1811f, 0.f},
+    {1.0f, 0.18898f, 0.f},  {1.0f, 0.19685f, 0.f},  {1.0f, 0.20472f, 0.f},  {1.0f, 0.2126f, 0.f},
+    {1.0f, 0.22047f, 0.f},  {1.0f, 0.22835f, 0.f},  {1.0f, 0.23622f, 0.f},  {1.0f, 0.24409f, 0.f},
+    {1.0f, 0.25197f, 0.f},  {1.0f, 0.25984f, 0.f},  {1.0f, 0.26772f, 0.f},  {1.0f, 0.27559f, 0.f},
+    {1.0f, 0.28346f, 0.f},  {1.0f, 0.29134f, 0.f},  {1.0f, 0.29921f, 0.f},  {1.0f, 0.30709f, 0.f},
+    {1.0f, 0.31496f, 0.f},  {1.0f, 0.32283f, 0.f},  {1.0f, 0.33071f, 0.f},  {1.0f, 0.33858f, 0.f},
+    {1.0f, 0.34646f, 0.f},  {1.0f, 0.35433f, 0.f},  {1.0f, 0.3622f, 0.f},   {1.0f, 0.37008f, 0.f},
+    {1.0f, 0.37795f, 0.f},  {1.0f, 0.38583f, 0.f},  {1.0f, 0.3937f, 0.f},   {1.0f, 0.40157f, 0.f},
+    {1.0f, 0.40945f, 0.f},  {1.0f, 0.41732f, 0.f},  {1.0f, 0.4252f, 0.f},   {1.0f, 0.43307f, 0.f},
+    {1.0f, 0.44094f, 0.f},  {1.0f, 0.44882f, 0.f},  {1.0f, 0.45669f, 0.f},  {1.0f, 0.46457f, 0.f},
+    {1.0f, 0.47244f, 0.f},  {1.0f, 0.48031f, 0.f},  {1.0f, 0.48819f, 0.f},  {1.0f, 0.49606f, 0.f},
+    {1.0f, 0.50394f, 0.f},  {1.0f, 0.51181f, 0.f},  {1.0f, 0.51969f, 0.f},  {1.0f, 0.52756f, 0.f},
+    {1.0f, 0.53543f, 0.f},  {1.0f, 0.54331f, 0.f},  {1.0f, 0.55118f, 0.f},  {1.0f, 0.55906f, 0.f},
+    {1.0f, 0.56693f, 0.f},  {1.0f, 0.5748f, 0.f},   {1.0f, 0.58268f, 0.f},  {1.0f, 0.59055f, 0.f},
+    {1.0f, 0.59843f, 0.f},  {1.0f, 0.6063f, 0.f},   {1.0f, 0.61417f, 0.f},  {1.0f, 0.62205f, 0.f},
+    {1.0f, 0.62992f, 0.f},  {1.0f, 0.6378f, 0.f},   {1.0f, 0.64567f, 0.f},  {1.0f, 0.65354f, 0.f},
+    {1.0f, 0.66142f, 0.f},  {1.0f, 0.66929f, 0.f},  {1.0f, 0.67717f, 0.f},  {1.0f, 0.68504f, 0.f},
+    {1.0f, 0.69291f, 0.f},  {1.0f, 0.70079f, 0.f},  {1.0f, 0.70866f, 0.f},  {1.0f, 0.71654f, 0.f},
+    {1.0f, 0.72441f, 0.f},  {1.0f, 0.73228f, 0.f},  {1.0f, 0.74016f, 0.f},  {1.0f, 0.74803f, 0.f},
+    {1.0f, 0.75591f, 0.f},  {1.0f, 0.76378f, 0.f},  {1.0f, 0.77165f, 0.f},  {1.0f, 0.77953f, 0.f},
+    {1.0f, 0.7874f, 0.f},   {1.0f, 0.79528f, 0.f},  {1.0f, 0.80315f, 0.f},  {1.0f, 0.81102f, 0.f},
+    {1.0f, 0.8189f, 0.f},   {1.0f, 0.82677f, 0.f},  {1.0f, 0.83465f, 0.f},  {1.0f, 0.84252f, 0.f},
+    {1.0f, 0.85039f, 0.f},  {1.0f, 0.85827f, 0.f},  {1.0f, 0.86614f, 0.f},  {1.0f, 0.87402f, 0.f},
+    {1.0f, 0.88189f, 0.f},  {1.0f, 0.88976f, 0.f},  {1.0f, 0.89764f, 0.f},  {1.0f, 0.90551f, 0.f},
+    {1.0f, 0.91339f, 0.f},  {1.0f, 0.92126f, 0.f},  {1.0f, 0.92913f, 0.f},  {1.0f, 0.93701f, 0.f},
+    {1.0f, 0.94488f, 0.f},  {1.0f, 0.95276f, 0.f},  {1.0f, 0.96063f, 0.f},  {1.0f, 0.9685f, 0.f},
+    {1.0f, 0.97638f, 0.f},  {1.0f, 0.98425f, 0.f},  {1.0f, 0.99213f, 0.f},  {1.0f, 1.0f, 0.0f}};
 
+float colormapJet[128][3] = {
+    {0.0f, 0.0f, 0.53125f},     {0.0f, 0.0f, 0.5625f},      {0.0f, 0.0f, 0.59375f},
+    {0.0f, 0.0f, 0.625f},       {0.0f, 0.0f, 0.65625f},     {0.0f, 0.0f, 0.6875f},
+    {0.0f, 0.0f, 0.71875f},     {0.0f, 0.0f, 0.75f},        {0.0f, 0.0f, 0.78125f},
+    {0.0f, 0.0f, 0.8125f},      {0.0f, 0.0f, 0.84375f},     {0.0f, 0.0f, 0.875f},
+    {0.0f, 0.0f, 0.90625f},     {0.0f, 0.0f, 0.9375f},      {0.0f, 0.0f, 0.96875f},
+    {0.0f, 0.0f, 1.0f},         {0.0f, 0.03125f, 1.0f},     {0.0f, 0.0625f, 1.0f},
+    {0.0f, 0.09375f, 1.0f},     {0.0f, 0.125f, 1.0f},       {0.0f, 0.15625f, 1.0f},
+    {0.0f, 0.1875f, 1.0f},      {0.0f, 0.21875f, 1.0f},     {0.0f, 0.25f, 1.0f},
+    {0.0f, 0.28125f, 1.0f},     {0.0f, 0.3125f, 1.0f},      {0.0f, 0.34375f, 1.0f},
+    {0.0f, 0.375f, 1.0f},       {0.0f, 0.40625f, 1.0f},     {0.0f, 0.4375f, 1.0f},
+    {0.0f, 0.46875f, 1.0f},     {0.0f, 0.5f, 1.0f},         {0.0f, 0.53125f, 1.0f},
+    {0.0f, 0.5625f, 1.0f},      {0.0f, 0.59375f, 1.0f},     {0.0f, 0.625f, 1.0f},
+    {0.0f, 0.65625f, 1.0f},     {0.0f, 0.6875f, 1.0f},      {0.0f, 0.71875f, 1.0f},
+    {0.0f, 0.75f, 1.0f},        {0.0f, 0.78125f, 1.0f},     {0.0f, 0.8125f, 1.0f},
+    {0.0f, 0.84375f, 1.0f},     {0.0f, 0.875f, 1.0f},       {0.0f, 0.90625f, 1.0f},
+    {0.0f, 0.9375f, 1.0f},      {0.0f, 0.96875f, 1.0f},     {0.0f, 1.0f, 1.0f},
+    {0.03125f, 1.0f, 0.96875f}, {0.0625f, 1.0f, 0.9375f},   {0.09375f, 1.0f, 0.90625f},
+    {0.125f, 1.0f, 0.875f},     {0.15625f, 1.0f, 0.84375f}, {0.1875f, 1.0f, 0.8125f},
+    {0.21875f, 1.0f, 0.78125f}, {0.25f, 1.0f, 0.75f},       {0.28125f, 1.0f, 0.71875f},
+    {0.3125f, 1.0f, 0.6875f},   {0.34375f, 1.0f, 0.65625f}, {0.375f, 1.0f, 0.625f},
+    {0.40625f, 1.0f, 0.59375f}, {0.4375f, 1.0f, 0.5625f},   {0.46875f, 1.0f, 0.53125f},
+    {0.5f, 1.0f, 0.5f},         {0.53125f, 1.0f, 0.46875f}, {0.5625f, 1.0f, 0.4375f},
+    {0.59375f, 1.0f, 0.40625f}, {0.625f, 1.0f, 0.375f},     {0.65625f, 1.0f, 0.34375f},
+    {0.6875f, 1.0f, 0.3125f},   {0.71875f, 1.0f, 0.28125f}, {0.75f, 1.0f, 0.25f},
+    {0.78125f, 1.0f, 0.21875f}, {0.8125f, 1.0f, 0.1875f},   {0.84375f, 1.0f, 0.15625f},
+    {0.875f, 1.0f, 0.125f},     {0.90625f, 1.0f, 0.09375f}, {0.9375f, 1.0f, 0.0625f},
+    {0.96875f, 1.0f, 0.03125f}, {1.0f, 1.0f, 0.0f},         {1.0f, 0.96875f, 0.0f},
+    {1.0f, 0.9375f, 0.0f},      {1.0f, 0.90625f, 0.0f},     {1.0f, 0.875f, 0.0f},
+    {1.0f, 0.84375f, 0.0f},     {1.0f, 0.8125f, 0.0f},      {1.0f, 0.78125f, 0.0f},
+    {1.0f, 0.75f, 0.0f},        {1.0f, 0.71875f, 0.0f},     {1.0f, 0.6875f, 0.0f},
+    {1.0f, 0.65625f, 0.0f},     {1.0f, 0.625f, 0.0f},       {1.0f, 0.59375f, 0.0f},
+    {1.0f, 0.5625f, 0.0f},      {1.0f, 0.53125f, 0.0f},     {1.0f, 0.5f, 0.0f},
+    {1.0f, 0.46875f, 0.0f},     {1.0f, 0.4375f, 0.0f},      {1.0f, 0.40625f, 0.0f},
+    {1.0f, 0.375f, 0.0f},       {1.0f, 0.34375f, 0.0f},     {1.0f, 0.3125f, 0.0f},
+    {1.0f, 0.28125f, 0.0f},     {1.0f, 0.25f, 0.0f},        {1.0f, 0.21875f, 0.0f},
+    {1.0f, 0.1875f, 0.0f},      {1.0f, 0.15625f, 0.0f},     {1.0f, 0.125f, 0.0f},
+    {1.0f, 0.09375f, 0.0f},     {1.0f, 0.0625f, 0.0f},      {1.0f, 0.03125f, 0.0f},
+    {1.0f, 0.0f, 0.0f},         {0.96875f, 0.0f, 0.0f},     {0.9375f, 0.0f, 0.0f},
+    {0.90625f, 0.0f, 0.0f},     {0.875f, 0.0f, 0.0f},       {0.84375f, 0.0f, 0.0f},
+    {0.8125f, 0.0f, 0.0f},      {0.78125f, 0.0f, 0.0f},     {0.75f, 0.0f, 0.0f},
+    {0.71875f, 0.0f, 0.0f},     {0.6875f, 0.0f, 0.0f},      {0.65625f, 0.0f, 0.0f},
+    {0.625f, 0.0f, 0.0f},       {0.59375f, 0.0f, 0.0f},     {0.5625f, 0.0f, 0.0f},
+    {0.53125f, 0.0f, 0.0f},     {0.5f, 0.0f, 0.0f}};
 
-float colormapJet[128][3] =
-{
-		{0.0f,0.0f,0.53125f},
-		{0.0f,0.0f,0.5625f},
-		{0.0f,0.0f,0.59375f},
-		{0.0f,0.0f,0.625f},
-		{0.0f,0.0f,0.65625f},
-		{0.0f,0.0f,0.6875f},
-		{0.0f,0.0f,0.71875f},
-		{0.0f,0.0f,0.75f},
-		{0.0f,0.0f,0.78125f},
-		{0.0f,0.0f,0.8125f},
-		{0.0f,0.0f,0.84375f},
-		{0.0f,0.0f,0.875f},
-		{0.0f,0.0f,0.90625f},
-		{0.0f,0.0f,0.9375f},
-		{0.0f,0.0f,0.96875f},
-		{0.0f,0.0f,1.0f},
-		{0.0f,0.03125f,1.0f},
-		{0.0f,0.0625f,1.0f},
-		{0.0f,0.09375f,1.0f},
-		{0.0f,0.125f,1.0f},
-		{0.0f,0.15625f,1.0f},
-		{0.0f,0.1875f,1.0f},
-		{0.0f,0.21875f,1.0f},
-		{0.0f,0.25f,1.0f},
-		{0.0f,0.28125f,1.0f},
-		{0.0f,0.3125f,1.0f},
-		{0.0f,0.34375f,1.0f},
-		{0.0f,0.375f,1.0f},
-		{0.0f,0.40625f,1.0f},
-		{0.0f,0.4375f,1.0f},
-		{0.0f,0.46875f,1.0f},
-		{0.0f,0.5f,1.0f},
-		{0.0f,0.53125f,1.0f},
-		{0.0f,0.5625f,1.0f},
-		{0.0f,0.59375f,1.0f},
-		{0.0f,0.625f,1.0f},
-		{0.0f,0.65625f,1.0f},
-		{0.0f,0.6875f,1.0f},
-		{0.0f,0.71875f,1.0f},
-		{0.0f,0.75f,1.0f},
-		{0.0f,0.78125f,1.0f},
-		{0.0f,0.8125f,1.0f},
-		{0.0f,0.84375f,1.0f},
-		{0.0f,0.875f,1.0f},
-		{0.0f,0.90625f,1.0f},
-		{0.0f,0.9375f,1.0f},
-		{0.0f,0.96875f,1.0f},
-		{0.0f,1.0f,1.0f},
-		{0.03125f,1.0f,0.96875f},
-		{0.0625f,1.0f,0.9375f},
-		{0.09375f,1.0f,0.90625f},
-		{0.125f,1.0f,0.875f},
-		{0.15625f,1.0f,0.84375f},
-		{0.1875f,1.0f,0.8125f},
-		{0.21875f,1.0f,0.78125f},
-		{0.25f,1.0f,0.75f},
-		{0.28125f,1.0f,0.71875f},
-		{0.3125f,1.0f,0.6875f},
-		{0.34375f,1.0f,0.65625f},
-		{0.375f,1.0f,0.625f},
-		{0.40625f,1.0f,0.59375f},
-		{0.4375f,1.0f,0.5625f},
-		{0.46875f,1.0f,0.53125f},
-		{0.5f,1.0f,0.5f},
-		{0.53125f,1.0f,0.46875f},
-		{0.5625f,1.0f,0.4375f},
-		{0.59375f,1.0f,0.40625f},
-		{0.625f,1.0f,0.375f},
-		{0.65625f,1.0f,0.34375f},
-		{0.6875f,1.0f,0.3125f},
-		{0.71875f,1.0f,0.28125f},
-		{0.75f,1.0f,0.25f},
-		{0.78125f,1.0f,0.21875f},
-		{0.8125f,1.0f,0.1875f},
-		{0.84375f,1.0f,0.15625f},
-		{0.875f,1.0f,0.125f},
-		{0.90625f,1.0f,0.09375f},
-		{0.9375f,1.0f,0.0625f},
-		{0.96875f,1.0f,0.03125f},
-		{1.0f,1.0f,0.0f},
-		{1.0f,0.96875f,0.0f},
-		{1.0f,0.9375f,0.0f},
-		{1.0f,0.90625f,0.0f},
-		{1.0f,0.875f,0.0f},
-		{1.0f,0.84375f,0.0f},
-		{1.0f,0.8125f,0.0f},
-		{1.0f,0.78125f,0.0f},
-		{1.0f,0.75f,0.0f},
-		{1.0f,0.71875f,0.0f},
-		{1.0f,0.6875f,0.0f},
-		{1.0f,0.65625f,0.0f},
-		{1.0f,0.625f,0.0f},
-		{1.0f,0.59375f,0.0f},
-		{1.0f,0.5625f,0.0f},
-		{1.0f,0.53125f,0.0f},
-		{1.0f,0.5f,0.0f},
-		{1.0f,0.46875f,0.0f},
-		{1.0f,0.4375f,0.0f},
-		{1.0f,0.40625f,0.0f},
-		{1.0f,0.375f,0.0f},
-		{1.0f,0.34375f,0.0f},
-		{1.0f,0.3125f,0.0f},
-		{1.0f,0.28125f,0.0f},
-		{1.0f,0.25f,0.0f},
-		{1.0f,0.21875f,0.0f},
-		{1.0f,0.1875f,0.0f},
-		{1.0f,0.15625f,0.0f},
-		{1.0f,0.125f,0.0f},
-		{1.0f,0.09375f,0.0f},
-		{1.0f,0.0625f,0.0f},
-		{1.0f,0.03125f,0.0f},
-		{1.0f,0.0f,0.0f},
-		{0.96875f,0.0f,0.0f},
-		{0.9375f,0.0f,0.0f},
-		{0.90625f,0.0f,0.0f},
-		{0.875f,0.0f,0.0f},
-		{0.84375f,0.0f,0.0f},
-		{0.8125f,0.0f,0.0f},
-		{0.78125f,0.0f,0.0f},
-		{0.75f,0.0f,0.0f},
-		{0.71875f,0.0f,0.0f},
-		{0.6875f,0.0f,0.0f},
-		{0.65625f,0.0f,0.0f},
-		{0.625f,0.0f,0.0f},
-		{0.59375f,0.0f,0.0f},
-		{0.5625f,0.0f,0.0f},
-		{0.53125f,0.0f,0.0f},
-		{0.5f,0.0f,0.0f}
-};
+void colorDepthImage(cv::Mat& imgDepth, cv::Mat& imgColoredDepth, float minRange, float maxRange) {
+  imgColoredDepth = cv::Mat::zeros(imgDepth.size(), CV_8UC3);
 
-void colorDepthImage(cv::Mat& imgDepth, cv::Mat& imgColoredDepth,
-					 float minRange, float maxRange)
-{
-	imgColoredDepth = cv::Mat::zeros(imgDepth.size(), CV_8UC3);
+  for (int i = 0; i < imgColoredDepth.rows; ++i) {
+    const float* depth = imgDepth.ptr<float>(i);
+    unsigned char* pixel = imgColoredDepth.ptr<unsigned char>(i);
+    for (int j = 0; j < imgColoredDepth.cols; ++j) {
+      if (depth[j] != 0) {
+        int idx = fminf(depth[j] - minRange, maxRange - minRange) / (maxRange - minRange) * 127.0f;
+        idx = 127 - idx;
 
-	for (int i = 0; i < imgColoredDepth.rows; ++i)
-	{
-		const float* depth = imgDepth.ptr<float>(i);
-		unsigned char* pixel = imgColoredDepth.ptr<unsigned char>(i);
-		for (int j = 0; j < imgColoredDepth.cols; ++j)
-		{
-			if (depth[j] != 0)
-			{
-				int idx = fminf(depth[j] - minRange, maxRange - minRange) / (maxRange - minRange) * 127.0f;
-				idx = 127 - idx;
+        pixel[0] = colormapJet[idx][2] * 255.0f;
+        pixel[1] = colormapJet[idx][1] * 255.0f;
+        pixel[2] = colormapJet[idx][0] * 255.0f;
+      }
 
-				pixel[0] = colormapJet[idx][2] * 255.0f;
-				pixel[1] = colormapJet[idx][1] * 255.0f;
-				pixel[2] = colormapJet[idx][0] * 255.0f;
-			}
-
-			pixel += 3;
-		}
-	}
+      pixel += 3;
+    }
+  }
 }
 
-bool colormap(const std::string& name, unsigned char idx,
-			  float& r, float& g, float& b)
-{
-	if (name.compare("jet") == 0)
-	{
-		float* color = colormapJet[idx];
+bool colormap(const std::string& name, unsigned char idx, float& r, float& g, float& b) {
+  if (name.compare("jet") == 0) {
+    float* color = colormapJet[idx];
 
-		r = color[0];
-		g = color[1];
-		b = color[2];
+    r = color[0];
+    g = color[1];
+    b = color[2];
 
-		return true;
-	}
-	else if (name.compare("autumn") == 0)
-	{
-		float* color = colormapAutumn[idx];
+    return true;
+  } else if (name.compare("autumn") == 0) {
+    float* color = colormapAutumn[idx];
 
-		r = color[0];
-		g = color[1];
-		b = color[2];
+    r = color[0];
+    g = color[1];
+    b = color[2];
 
-		return true;
-	}
+    return true;
+  }
 
-	return false;
+  return false;
 }
 
-std::vector<cv::Point2i> bresLine(int x0, int y0, int x1, int y1)
-{
-	// Bresenham's line algorithm
-	// Find cells intersected by line between (x0,y0) and (x1,y1)
+std::vector<cv::Point2i> bresLine(int x0, int y0, int x1, int y1) {
+  // Bresenham's line algorithm
+  // Find cells intersected by line between (x0,y0) and (x1,y1)
 
-	std::vector<cv::Point2i> cells;
+  std::vector<cv::Point2i> cells;
 
-	int dx = std::abs(x1 - x0);
-	int dy = std::abs(y1 - y0);
+  int dx = std::abs(x1 - x0);
+  int dy = std::abs(y1 - y0);
 
-	int sx = (x0 < x1) ? 1 : -1;
-	int sy = (y0 < y1) ? 1 : -1;
+  int sx = (x0 < x1) ? 1 : -1;
+  int sy = (y0 < y1) ? 1 : -1;
 
-	int err = dx - dy;
+  int err = dx - dy;
 
-	while (1)
-	{
-		cells.push_back(cv::Point2i(x0, y0));
+  while (1) {
+    cells.push_back(cv::Point2i(x0, y0));
 
-		if (x0 == x1 && y0 == y1)
-		{
-			break;
-		}
-
-		int e2 = 2 * err;
-		if (e2 > -dy)
-		{
-			err -= dy;
-			x0 += sx;
-		}
-		if (e2 < dx)
-		{
-			err += dx;
-			y0 += sy;
-		}
-	}
-
-	return cells;
-}
-
-std::vector<cv::Point2i> bresCircle(int x0, int y0, int r)
-{
-	// Bresenham's circle algorithm
-	// Find cells intersected by circle with center (x0,y0) and radius r
-
-	std::vector< std::vector<bool> > mask(2 * r + 1);
-	
-	for (int i = 0; i < 2 * r + 1; ++i)
-	{
-		mask[i].resize(2 * r + 1);
-		for (int j = 0; j < 2 * r + 1; ++j)
-		{
-			mask[i][j] = false;
-		}
-	}
-
-	int f = 1 - r;
-	int ddF_x = 1;
-	int ddF_y = -2 * r;
-	int x = 0;
-	int y = r;
-
-	std::vector<cv::Point2i> line;
-
-	line = bresLine(x0, y0 - r, x0, y0 + r);
-	for (std::vector<cv::Point2i>::iterator it = line.begin(); it != line.end(); ++it)
-	{
-		mask[it->x - x0 + r][it->y - y0 + r] = true;
-	}
-
-	line = bresLine(x0 - r, y0, x0 + r, y0);
-	for (std::vector<cv::Point2i>::iterator it = line.begin(); it != line.end(); ++it)
-	{
-		mask[it->x - x0 + r][it->y - y0 + r] = true;
-	}
-
-	while (x < y)
-	{
-		if (f >= 0)
-		{
-			y--;
-			ddF_y += 2;
-			f += ddF_y;
-		}
-
-		x++;
-		ddF_x += 2;
-		f += ddF_x;
-
-		line = bresLine(x0 - x, y0 + y, x0 + x, y0 + y);
-		for (std::vector<cv::Point2i>::iterator it = line.begin(); it != line.end(); ++it)
-		{
-			mask[it->x - x0 + r][it->y - y0 + r] = true;
-		}
-
-		line = bresLine(x0 - x, y0 - y, x0 + x, y0 - y);
-		for (std::vector<cv::Point2i>::iterator it = line.begin(); it != line.end(); ++it)
-		{
-			mask[it->x - x0 + r][it->y - y0 + r] = true;
-		}
-
-		line = bresLine(x0 - y, y0 + x, x0 + y, y0 + x);
-		for (std::vector<cv::Point2i>::iterator it = line.begin(); it != line.end(); ++it)
-		{
-			mask[it->x - x0 + r][it->y - y0 + r] = true;
-		}
-
-		line = bresLine(x0 - y, y0 - x, x0 + y, y0 - x);
-		for (std::vector<cv::Point2i>::iterator it = line.begin(); it != line.end(); ++it)
-		{
-			mask[it->x - x0 + r][it->y - y0 + r] = true;
-		}
-	}
-
-	std::vector<cv::Point2i> cells;
-	for (int i = 0; i < 2 * r + 1; ++i)
-	{
-		for (int j = 0; j < 2 * r + 1; ++j)
-		{
-			if (mask[i][j])
-			{
-				cells.push_back(cv::Point2i(i - r + x0, j - r + y0));
-			}
-		}
-	}
-
-	return cells;
-}
-
-void
-fitCircle(const std::vector<cv::Point2d>& points,
-          double& centerX, double& centerY, double& radius)
-{
-    // D. Umbach, and K. Jones, A Few Methods for Fitting Circles to Data,
-    // IEEE Transactions on Instrumentation and Measurement, 2000
-    // We use the modified least squares method.
-    double sum_x = 0.0;
-    double sum_y = 0.0;
-    double sum_xx = 0.0;
-    double sum_xy = 0.0;
-    double sum_yy = 0.0;
-    double sum_xxx = 0.0;
-    double sum_xxy = 0.0;
-    double sum_xyy = 0.0;
-    double sum_yyy = 0.0;
-
-    int n = points.size();
-    for (int i = 0; i < n; ++i)
-    {
-        double x = points.at(i).x;
-        double y = points.at(i).y;
-
-        sum_x += x;
-        sum_y += y;
-        sum_xx += x * x;
-        sum_xy += x * y;
-        sum_yy += y * y;
-        sum_xxx += x * x * x;
-        sum_xxy += x * x * y;
-        sum_xyy += x * y * y;
-        sum_yyy += y * y * y;
+    if (x0 == x1 && y0 == y1) {
+      break;
     }
 
-    double A = n * sum_xx - square(sum_x);
-    double B = n * sum_xy - sum_x * sum_y;
-    double C = n * sum_yy - square(sum_y);
-    double D = 0.5 * (n * sum_xyy - sum_x * sum_yy + n * sum_xxx - sum_x * sum_xx);
-    double E = 0.5 * (n * sum_xxy - sum_y * sum_xx + n * sum_yyy - sum_y * sum_yy);
-
-    centerX = (D * C - B * E) / (A * C - square(B));
-    centerY = (A * E - B * D) / (A * C - square(B));
-
-    double sum_r = 0.0;
-    for (int i = 0; i < n; ++i)
-    {
-        double x = points.at(i).x;
-        double y = points.at(i).y;
-
-        sum_r += hypot(x - centerX, y - centerY);
+    int e2 = 2 * err;
+    if (e2 > -dy) {
+      err -= dy;
+      x0 += sx;
     }
+    if (e2 < dx) {
+      err += dx;
+      y0 += sy;
+    }
+  }
 
-    radius = sum_r / n;
+  return cells;
 }
 
-std::vector<cv::Point2d>
-intersectCircles(double x1, double y1, double r1,
-                 double x2, double y2, double r2)
-{
-    std::vector<cv::Point2d> ipts;
+std::vector<cv::Point2i> bresCircle(int x0, int y0, int r) {
+  // Bresenham's circle algorithm
+  // Find cells intersected by circle with center (x0,y0) and radius r
 
-    double d = hypot(x1 - x2, y1 - y2);
-    if (d > r1 + r2)
-    {
-        // circles are separate
-        return ipts;
+  std::vector<std::vector<bool> > mask(2 * r + 1);
+
+  for (int i = 0; i < 2 * r + 1; ++i) {
+    mask[i].resize(2 * r + 1);
+    for (int j = 0; j < 2 * r + 1; ++j) {
+      mask[i][j] = false;
     }
-    if (d < fabs(r1 - r2))
-    {
-        // one circle is contained within the other
-        return ipts;
+  }
+
+  int f = 1 - r;
+  int ddF_x = 1;
+  int ddF_y = -2 * r;
+  int x = 0;
+  int y = r;
+
+  std::vector<cv::Point2i> line;
+
+  line = bresLine(x0, y0 - r, x0, y0 + r);
+  for (std::vector<cv::Point2i>::iterator it = line.begin(); it != line.end(); ++it) {
+    mask[it->x - x0 + r][it->y - y0 + r] = true;
+  }
+
+  line = bresLine(x0 - r, y0, x0 + r, y0);
+  for (std::vector<cv::Point2i>::iterator it = line.begin(); it != line.end(); ++it) {
+    mask[it->x - x0 + r][it->y - y0 + r] = true;
+  }
+
+  while (x < y) {
+    if (f >= 0) {
+      y--;
+      ddF_y += 2;
+      f += ddF_y;
     }
 
-    double a = (square(r1) - square(r2) + square(d)) / (2.0 * d);
-    double h = sqrt(square(r1) - square(a));
+    x++;
+    ddF_x += 2;
+    f += ddF_x;
 
-    double x3 = x1 + a * (x2 - x1) / d;
-    double y3 = y1 + a * (y2 - y1) / d;
-
-    if (h < 1e-10)
-    {
-        // two circles touch at one point
-        ipts.push_back(cv::Point2d(x3, y3));
-        return ipts;
+    line = bresLine(x0 - x, y0 + y, x0 + x, y0 + y);
+    for (std::vector<cv::Point2i>::iterator it = line.begin(); it != line.end(); ++it) {
+      mask[it->x - x0 + r][it->y - y0 + r] = true;
     }
 
-    ipts.push_back(cv::Point2d(x3 + h * (y2 - y1) / d,
-                               y3 - h * (x2 - x1) / d));
-    ipts.push_back(cv::Point2d(x3 - h * (y2 - y1) / d,
-                               y3 + h * (x2 - x1) / d));
+    line = bresLine(x0 - x, y0 - y, x0 + x, y0 - y);
+    for (std::vector<cv::Point2i>::iterator it = line.begin(); it != line.end(); ++it) {
+      mask[it->x - x0 + r][it->y - y0 + r] = true;
+    }
+
+    line = bresLine(x0 - y, y0 + x, x0 + y, y0 + x);
+    for (std::vector<cv::Point2i>::iterator it = line.begin(); it != line.end(); ++it) {
+      mask[it->x - x0 + r][it->y - y0 + r] = true;
+    }
+
+    line = bresLine(x0 - y, y0 - x, x0 + y, y0 - x);
+    for (std::vector<cv::Point2i>::iterator it = line.begin(); it != line.end(); ++it) {
+      mask[it->x - x0 + r][it->y - y0 + r] = true;
+    }
+  }
+
+  std::vector<cv::Point2i> cells;
+  for (int i = 0; i < 2 * r + 1; ++i) {
+    for (int j = 0; j < 2 * r + 1; ++j) {
+      if (mask[i][j]) {
+        cells.push_back(cv::Point2i(i - r + x0, j - r + y0));
+      }
+    }
+  }
+
+  return cells;
+}
+
+void fitCircle(const std::vector<cv::Point2d>& points, double& centerX, double& centerY,
+               double& radius) {
+  // D. Umbach, and K. Jones, A Few Methods for Fitting Circles to Data,
+  // IEEE Transactions on Instrumentation and Measurement, 2000
+  // We use the modified least squares method.
+  double sum_x = 0.0;
+  double sum_y = 0.0;
+  double sum_xx = 0.0;
+  double sum_xy = 0.0;
+  double sum_yy = 0.0;
+  double sum_xxx = 0.0;
+  double sum_xxy = 0.0;
+  double sum_xyy = 0.0;
+  double sum_yyy = 0.0;
+
+  int n = points.size();
+  for (int i = 0; i < n; ++i) {
+    double x = points.at(i).x;
+    double y = points.at(i).y;
+
+    sum_x += x;
+    sum_y += y;
+    sum_xx += x * x;
+    sum_xy += x * y;
+    sum_yy += y * y;
+    sum_xxx += x * x * x;
+    sum_xxy += x * x * y;
+    sum_xyy += x * y * y;
+    sum_yyy += y * y * y;
+  }
+
+  double A = n * sum_xx - square(sum_x);
+  double B = n * sum_xy - sum_x * sum_y;
+  double C = n * sum_yy - square(sum_y);
+  double D = 0.5 * (n * sum_xyy - sum_x * sum_yy + n * sum_xxx - sum_x * sum_xx);
+  double E = 0.5 * (n * sum_xxy - sum_y * sum_xx + n * sum_yyy - sum_y * sum_yy);
+
+  centerX = (D * C - B * E) / (A * C - square(B));
+  centerY = (A * E - B * D) / (A * C - square(B));
+
+  double sum_r = 0.0;
+  for (int i = 0; i < n; ++i) {
+    double x = points.at(i).x;
+    double y = points.at(i).y;
+
+    sum_r += hypot(x - centerX, y - centerY);
+  }
+
+  radius = sum_r / n;
+}
+
+std::vector<cv::Point2d> intersectCircles(double x1, double y1, double r1, double x2, double y2,
+                                          double r2) {
+  std::vector<cv::Point2d> ipts;
+
+  double d = hypot(x1 - x2, y1 - y2);
+  if (d > r1 + r2) {
+    // circles are separate
     return ipts;
+  }
+  if (d < fabs(r1 - r2)) {
+    // one circle is contained within the other
+    return ipts;
+  }
+
+  double a = (square(r1) - square(r2) + square(d)) / (2.0 * d);
+  double h = sqrt(square(r1) - square(a));
+
+  double x3 = x1 + a * (x2 - x1) / d;
+  double y3 = y1 + a * (y2 - y1) / d;
+
+  if (h < 1e-10) {
+    // two circles touch at one point
+    ipts.push_back(cv::Point2d(x3, y3));
+    return ipts;
+  }
+
+  ipts.push_back(cv::Point2d(x3 + h * (y2 - y1) / d, y3 - h * (x2 - x1) / d));
+  ipts.push_back(cv::Point2d(x3 - h * (y2 - y1) / d, y3 + h * (x2 - x1) / d));
+  return ipts;
 }
 
-char
-UTMLetterDesignator(double latitude)
-{
-    // This routine determines the correct UTM letter designator for the given latitude
-    // returns 'Z' if latitude is outside the UTM limits of 84N to 80S
-    // Written by Chuck Gantz- chuck.gantz@globalstar.com
-    char letterDesignator;
+char UTMLetterDesignator(double latitude) {
+  // This routine determines the correct UTM letter designator for the given latitude
+  // returns 'Z' if latitude is outside the UTM limits of 84N to 80S
+  // Written by Chuck Gantz- chuck.gantz@globalstar.com
+  char letterDesignator;
 
-    if ((84.0 >= latitude) && (latitude >= 72.0)) letterDesignator = 'X';
-    else if ((72.0 > latitude) && (latitude >= 64.0)) letterDesignator = 'W';
-    else if ((64.0 > latitude) && (latitude >= 56.0)) letterDesignator = 'V';
-    else if ((56.0 > latitude) && (latitude >= 48.0)) letterDesignator = 'U';
-    else if ((48.0 > latitude) && (latitude >= 40.0)) letterDesignator = 'T';
-    else if ((40.0 > latitude) && (latitude >= 32.0)) letterDesignator = 'S';
-    else if ((32.0 > latitude) && (latitude >= 24.0)) letterDesignator = 'R';
-    else if ((24.0 > latitude) && (latitude >= 16.0)) letterDesignator = 'Q';
-    else if ((16.0 > latitude) && (latitude >= 8.0)) letterDesignator = 'P';
-    else if (( 8.0 > latitude) && (latitude >= 0.0)) letterDesignator = 'N';
-    else if (( 0.0 > latitude) && (latitude >= -8.0)) letterDesignator = 'M';
-    else if ((-8.0 > latitude) && (latitude >= -16.0)) letterDesignator = 'L';
-    else if ((-16.0 > latitude) && (latitude >= -24.0)) letterDesignator = 'K';
-    else if ((-24.0 > latitude) && (latitude >= -32.0)) letterDesignator = 'J';
-    else if ((-32.0 > latitude) && (latitude >= -40.0)) letterDesignator = 'H';
-    else if ((-40.0 > latitude) && (latitude >= -48.0)) letterDesignator = 'G';
-    else if ((-48.0 > latitude) && (latitude >= -56.0)) letterDesignator = 'F';
-    else if ((-56.0 > latitude) && (latitude >= -64.0)) letterDesignator = 'E';
-    else if ((-64.0 > latitude) && (latitude >= -72.0)) letterDesignator = 'D';
-    else if ((-72.0 > latitude) && (latitude >= -80.0)) letterDesignator = 'C';
-    else letterDesignator = 'Z'; //This is here as an error flag to show that the Latitude is outside the UTM limits
+  if ((84.0 >= latitude) && (latitude >= 72.0))
+    letterDesignator = 'X';
+  else if ((72.0 > latitude) && (latitude >= 64.0))
+    letterDesignator = 'W';
+  else if ((64.0 > latitude) && (latitude >= 56.0))
+    letterDesignator = 'V';
+  else if ((56.0 > latitude) && (latitude >= 48.0))
+    letterDesignator = 'U';
+  else if ((48.0 > latitude) && (latitude >= 40.0))
+    letterDesignator = 'T';
+  else if ((40.0 > latitude) && (latitude >= 32.0))
+    letterDesignator = 'S';
+  else if ((32.0 > latitude) && (latitude >= 24.0))
+    letterDesignator = 'R';
+  else if ((24.0 > latitude) && (latitude >= 16.0))
+    letterDesignator = 'Q';
+  else if ((16.0 > latitude) && (latitude >= 8.0))
+    letterDesignator = 'P';
+  else if ((8.0 > latitude) && (latitude >= 0.0))
+    letterDesignator = 'N';
+  else if ((0.0 > latitude) && (latitude >= -8.0))
+    letterDesignator = 'M';
+  else if ((-8.0 > latitude) && (latitude >= -16.0))
+    letterDesignator = 'L';
+  else if ((-16.0 > latitude) && (latitude >= -24.0))
+    letterDesignator = 'K';
+  else if ((-24.0 > latitude) && (latitude >= -32.0))
+    letterDesignator = 'J';
+  else if ((-32.0 > latitude) && (latitude >= -40.0))
+    letterDesignator = 'H';
+  else if ((-40.0 > latitude) && (latitude >= -48.0))
+    letterDesignator = 'G';
+  else if ((-48.0 > latitude) && (latitude >= -56.0))
+    letterDesignator = 'F';
+  else if ((-56.0 > latitude) && (latitude >= -64.0))
+    letterDesignator = 'E';
+  else if ((-64.0 > latitude) && (latitude >= -72.0))
+    letterDesignator = 'D';
+  else if ((-72.0 > latitude) && (latitude >= -80.0))
+    letterDesignator = 'C';
+  else
+    letterDesignator =
+        'Z';  // This is here as an error flag to show that the Latitude is outside the UTM limits
 
-    return letterDesignator;
+  return letterDesignator;
 }
 
-void
-LLtoUTM(double latitude, double longitude,
-        double& utmNorthing, double& utmEasting, std::string& utmZone)
-{
-    // converts lat/long to UTM coords.  Equations from USGS Bulletin 1532
-    // East Longitudes are positive, West longitudes are negative.
-    // North latitudes are positive, South latitudes are negative
-    // Lat and Long are in decimal degrees
-    // Written by Chuck Gantz- chuck.gantz@globalstar.com
+void LLtoUTM(double latitude, double longitude, double& utmNorthing, double& utmEasting,
+             std::string& utmZone) {
+  // converts lat/long to UTM coords.  Equations from USGS Bulletin 1532
+  // East Longitudes are positive, West longitudes are negative.
+  // North latitudes are positive, South latitudes are negative
+  // Lat and Long are in decimal degrees
+  // Written by Chuck Gantz- chuck.gantz@globalstar.com
 
-    double k0 = 0.9996;
+  double k0 = 0.9996;
 
-    double LongOrigin;
-    double eccPrimeSquared;
-    double N, T, C, A, M;
+  double LongOrigin;
+  double eccPrimeSquared;
+  double N, T, C, A, M;
 
-    double LatRad = latitude * M_PI / 180.0;
-    double LongRad = longitude * M_PI / 180.0;
-    double LongOriginRad;
+  double LatRad = latitude * M_PI / 180.0;
+  double LongRad = longitude * M_PI / 180.0;
+  double LongOriginRad;
 
-    int ZoneNumber = static_cast<int>((longitude + 180.0) / 6.0) + 1;
+  int ZoneNumber = static_cast<int>((longitude + 180.0) / 6.0) + 1;
 
-    if (latitude >= 56.0 && latitude < 64.0 &&
-            longitude >= 3.0 && longitude < 12.0) {
-        ZoneNumber = 32;
-    }
+  if (latitude >= 56.0 && latitude < 64.0 && longitude >= 3.0 && longitude < 12.0) {
+    ZoneNumber = 32;
+  }
 
-    // Special zones for Svalbard
-    if (latitude >= 72.0 && latitude < 84.0) {
-        if (     longitude >= 0.0  && longitude <  9.0) ZoneNumber = 31;
-        else if (longitude >= 9.0  && longitude < 21.0) ZoneNumber = 33;
-        else if (longitude >= 21.0 && longitude < 33.0) ZoneNumber = 35;
-        else if (longitude >= 33.0 && longitude < 42.0) ZoneNumber = 37;
-    }
-    LongOrigin = static_cast<double>((ZoneNumber - 1) * 6 - 180 + 3);  //+3 puts origin in middle of zone
-    LongOriginRad = LongOrigin * M_PI / 180.0;
+  // Special zones for Svalbard
+  if (latitude >= 72.0 && latitude < 84.0) {
+    if (longitude >= 0.0 && longitude < 9.0)
+      ZoneNumber = 31;
+    else if (longitude >= 9.0 && longitude < 21.0)
+      ZoneNumber = 33;
+    else if (longitude >= 21.0 && longitude < 33.0)
+      ZoneNumber = 35;
+    else if (longitude >= 33.0 && longitude < 42.0)
+      ZoneNumber = 37;
+  }
+  LongOrigin =
+      static_cast<double>((ZoneNumber - 1) * 6 - 180 + 3);  //+3 puts origin in middle of zone
+  LongOriginRad = LongOrigin * M_PI / 180.0;
 
-    // compute the UTM Zone from the latitude and longitude
-    std::ostringstream oss;
-    oss << ZoneNumber << UTMLetterDesignator(latitude);
-    utmZone = oss.str();
+  // compute the UTM Zone from the latitude and longitude
+  std::ostringstream oss;
+  oss << ZoneNumber << UTMLetterDesignator(latitude);
+  utmZone = oss.str();
 
-    eccPrimeSquared = WGS84_ECCSQ / (1.0 - WGS84_ECCSQ);
+  eccPrimeSquared = WGS84_ECCSQ / (1.0 - WGS84_ECCSQ);
 
-    N = WGS84_A / sqrt(1.0 - WGS84_ECCSQ * sin(LatRad) * sin(LatRad));
-    T = tan(LatRad) * tan(LatRad);
-    C = eccPrimeSquared * cos(LatRad) * cos(LatRad);
-    A = cos(LatRad) * (LongRad - LongOriginRad);
+  N = WGS84_A / sqrt(1.0 - WGS84_ECCSQ * sin(LatRad) * sin(LatRad));
+  T = tan(LatRad) * tan(LatRad);
+  C = eccPrimeSquared * cos(LatRad) * cos(LatRad);
+  A = cos(LatRad) * (LongRad - LongOriginRad);
 
-    M = WGS84_A * ((1.0 - WGS84_ECCSQ / 4.0
-                    - 3.0 * WGS84_ECCSQ * WGS84_ECCSQ / 64.0
-                    - 5.0 * WGS84_ECCSQ * WGS84_ECCSQ * WGS84_ECCSQ / 256.0)
-                   * LatRad
-                   - (3.0 * WGS84_ECCSQ / 8.0
-                      + 3.0 * WGS84_ECCSQ * WGS84_ECCSQ / 32.0
-                      + 45.0 * WGS84_ECCSQ * WGS84_ECCSQ * WGS84_ECCSQ / 1024.0)
-                   * sin(2.0 * LatRad)
-                   + (15.0 * WGS84_ECCSQ * WGS84_ECCSQ / 256.0
-                      + 45.0 * WGS84_ECCSQ * WGS84_ECCSQ * WGS84_ECCSQ / 1024.0)
-                   * sin(4.0 * LatRad)
-                   - (35.0 * WGS84_ECCSQ * WGS84_ECCSQ * WGS84_ECCSQ / 3072.0)
-                   * sin(6.0 * LatRad));
+  M = WGS84_A * ((1.0 - WGS84_ECCSQ / 4.0 - 3.0 * WGS84_ECCSQ * WGS84_ECCSQ / 64.0 -
+                  5.0 * WGS84_ECCSQ * WGS84_ECCSQ * WGS84_ECCSQ / 256.0) *
+                     LatRad -
+                 (3.0 * WGS84_ECCSQ / 8.0 + 3.0 * WGS84_ECCSQ * WGS84_ECCSQ / 32.0 +
+                  45.0 * WGS84_ECCSQ * WGS84_ECCSQ * WGS84_ECCSQ / 1024.0) *
+                     sin(2.0 * LatRad) +
+                 (15.0 * WGS84_ECCSQ * WGS84_ECCSQ / 256.0 +
+                  45.0 * WGS84_ECCSQ * WGS84_ECCSQ * WGS84_ECCSQ / 1024.0) *
+                     sin(4.0 * LatRad) -
+                 (35.0 * WGS84_ECCSQ * WGS84_ECCSQ * WGS84_ECCSQ / 3072.0) * sin(6.0 * LatRad));
 
-    utmEasting = k0 * N * (A + (1.0 - T + C) * A * A * A / 6.0
-                           + (5.0 - 18.0 * T + T * T + 72.0 * C
-                              - 58.0 * eccPrimeSquared)
-                           * A * A * A * A * A / 120.0)
-                 + 500000.0;
+  utmEasting = k0 * N *
+                   (A + (1.0 - T + C) * A * A * A / 6.0 +
+                    (5.0 - 18.0 * T + T * T + 72.0 * C - 58.0 * eccPrimeSquared) * A * A * A * A *
+                        A / 120.0) +
+               500000.0;
 
-    utmNorthing = k0 * (M + N * tan(LatRad) *
-                        (A * A / 2.0 +
-                         (5.0 - T + 9.0 * C + 4.0 * C * C) * A * A * A * A / 24.0
-                         + (61.0 - 58.0 * T + T * T + 600.0 * C
-                            - 330.0 * eccPrimeSquared)
-                         * A * A * A * A * A * A / 720.0));
-    if (latitude < 0.0) {
-        utmNorthing += 10000000.0; //10000000 meter offset for southern hemisphere
-    }
+  utmNorthing =
+      k0 * (M + N * tan(LatRad) *
+                    (A * A / 2.0 + (5.0 - T + 9.0 * C + 4.0 * C * C) * A * A * A * A / 24.0 +
+                     (61.0 - 58.0 * T + T * T + 600.0 * C - 330.0 * eccPrimeSquared) * A * A * A *
+                         A * A * A / 720.0));
+  if (latitude < 0.0) {
+    utmNorthing += 10000000.0;  // 10000000 meter offset for southern hemisphere
+  }
 }
 
-void
-UTMtoLL(double utmNorthing, double utmEasting, const std::string& utmZone,
-        double& latitude, double& longitude)
-{
-    // converts UTM coords to lat/long.  Equations from USGS Bulletin 1532
-    // East Longitudes are positive, West longitudes are negative.
-    // North latitudes are positive, South latitudes are negative
-    // Lat and Long are in decimal degrees.
-    // Written by Chuck Gantz- chuck.gantz@globalstar.com
+void UTMtoLL(double utmNorthing, double utmEasting, const std::string& utmZone, double& latitude,
+             double& longitude) {
+  // converts UTM coords to lat/long.  Equations from USGS Bulletin 1532
+  // East Longitudes are positive, West longitudes are negative.
+  // North latitudes are positive, South latitudes are negative
+  // Lat and Long are in decimal degrees.
+  // Written by Chuck Gantz- chuck.gantz@globalstar.com
 
-    double k0 = 0.9996;
-    double eccPrimeSquared;
-    double e1 = (1.0 - sqrt(1.0 - WGS84_ECCSQ)) / (1.0 + sqrt(1.0 - WGS84_ECCSQ));
-    double N1, T1, C1, R1, D, M;
-    double LongOrigin;
-    double mu, phi1, phi1Rad;
-    double x, y;
-    int ZoneNumber;
-    char ZoneLetter;
-    bool NorthernHemisphere;
+  double k0 = 0.9996;
+  double eccPrimeSquared;
+  double e1 = (1.0 - sqrt(1.0 - WGS84_ECCSQ)) / (1.0 + sqrt(1.0 - WGS84_ECCSQ));
+  double N1, T1, C1, R1, D, M;
+  double LongOrigin;
+  double mu, phi1, phi1Rad;
+  double x, y;
+  int ZoneNumber;
+  char ZoneLetter;
+  bool NorthernHemisphere;
 
-    x = utmEasting - 500000.0; //remove 500,000 meter offset for longitude
-    y = utmNorthing;
+  x = utmEasting - 500000.0;  // remove 500,000 meter offset for longitude
+  y = utmNorthing;
 
-    std::istringstream iss(utmZone);
-    iss >> ZoneNumber >> ZoneLetter;
-    if ((static_cast<int>(ZoneLetter) - static_cast<int>('N')) >= 0) {
-        NorthernHemisphere = true;//point is in northern hemisphere
+  std::istringstream iss(utmZone);
+  iss >> ZoneNumber >> ZoneLetter;
+  if ((static_cast<int>(ZoneLetter) - static_cast<int>('N')) >= 0) {
+    NorthernHemisphere = true;  // point is in northern hemisphere
+  } else {
+    NorthernHemisphere = false;  // point is in southern hemisphere
+    y -= 10000000.0;             // remove 10,000,000 meter offset used for southern hemisphere
+  }
+
+  LongOrigin = (ZoneNumber - 1.0) * 6.0 - 180.0 + 3.0;  //+3 puts origin in middle of zone
+
+  eccPrimeSquared = WGS84_ECCSQ / (1.0 - WGS84_ECCSQ);
+
+  M = y / k0;
+  mu = M / (WGS84_A * (1.0 - WGS84_ECCSQ / 4.0 - 3.0 * WGS84_ECCSQ * WGS84_ECCSQ / 64.0 -
+                       5.0 * WGS84_ECCSQ * WGS84_ECCSQ * WGS84_ECCSQ / 256.0));
+
+  phi1Rad = mu + (3.0 * e1 / 2.0 - 27.0 * e1 * e1 * e1 / 32.0) * sin(2.0 * mu) +
+            (21.0 * e1 * e1 / 16.0 - 55.0 * e1 * e1 * e1 * e1 / 32.0) * sin(4.0 * mu) +
+            (151.0 * e1 * e1 * e1 / 96.0) * sin(6.0 * mu);
+  phi1 = phi1Rad / M_PI * 180.0;
+
+  N1 = WGS84_A / sqrt(1.0 - WGS84_ECCSQ * sin(phi1Rad) * sin(phi1Rad));
+  T1 = tan(phi1Rad) * tan(phi1Rad);
+  C1 = eccPrimeSquared * cos(phi1Rad) * cos(phi1Rad);
+  R1 = WGS84_A * (1.0 - WGS84_ECCSQ) / pow(1.0 - WGS84_ECCSQ * sin(phi1Rad) * sin(phi1Rad), 1.5);
+  D = x / (N1 * k0);
+
+  latitude = phi1Rad - (N1 * tan(phi1Rad) / R1) *
+                           (D * D / 2.0 -
+                            (5.0 + 3.0 * T1 + 10.0 * C1 - 4.0 * C1 * C1 - 9.0 * eccPrimeSquared) *
+                                D * D * D * D / 24.0 +
+                            (61.0 + 90.0 * T1 + 298.0 * C1 + 45.0 * T1 * T1 -
+                             252.0 * eccPrimeSquared - 3.0 * C1 * C1) *
+                                D * D * D * D * D * D / 720.0);
+  latitude *= 180.0 / M_PI;
+
+  longitude =
+      (D - (1.0 + 2.0 * T1 + C1) * D * D * D / 6.0 +
+       (5.0 - 2.0 * C1 + 28.0 * T1 - 3.0 * C1 * C1 + 8.0 * eccPrimeSquared + 24.0 * T1 * T1) * D *
+           D * D * D * D / 120.0) /
+      cos(phi1Rad);
+  longitude = LongOrigin + longitude / M_PI * 180.0;
+}
+
+long int timestampDiff(uint64_t t1, uint64_t t2) {
+  if (t2 > t1) {
+    uint64_t d = t2 - t1;
+
+    if (d > std::numeric_limits<long int>::max()) {
+      return std::numeric_limits<long int>::max();
     } else {
-        NorthernHemisphere = false;//point is in southern hemisphere
-        y -= 10000000.0;//remove 10,000,000 meter offset used for southern hemisphere
+      return d;
     }
+  } else {
+    uint64_t d = t1 - t2;
 
-    LongOrigin = (ZoneNumber - 1.0) * 6.0 - 180.0 + 3.0;  //+3 puts origin in middle of zone
-
-    eccPrimeSquared = WGS84_ECCSQ / (1.0 - WGS84_ECCSQ);
-
-    M = y / k0;
-    mu = M / (WGS84_A * (1.0 - WGS84_ECCSQ / 4.0
-                         - 3.0 * WGS84_ECCSQ * WGS84_ECCSQ / 64.0
-                         - 5.0 * WGS84_ECCSQ * WGS84_ECCSQ * WGS84_ECCSQ / 256.0));
-
-    phi1Rad = mu + (3.0 * e1 / 2.0 - 27.0 * e1 * e1 * e1 / 32.0) * sin(2.0 * mu)
-              + (21.0 * e1 * e1 / 16.0 - 55.0 * e1 * e1 * e1 * e1 / 32.0)
-              * sin(4.0 * mu)
-              + (151.0 * e1 * e1 * e1 / 96.0) * sin(6.0 * mu);
-    phi1 = phi1Rad / M_PI * 180.0;
-
-    N1 = WGS84_A / sqrt(1.0 - WGS84_ECCSQ * sin(phi1Rad) * sin(phi1Rad));
-    T1 = tan(phi1Rad) * tan(phi1Rad);
-    C1 = eccPrimeSquared * cos(phi1Rad) * cos(phi1Rad);
-    R1 = WGS84_A * (1.0 - WGS84_ECCSQ) /
-         pow(1.0 - WGS84_ECCSQ * sin(phi1Rad) * sin(phi1Rad), 1.5);
-    D = x / (N1 * k0);
-
-    latitude = phi1Rad - (N1 * tan(phi1Rad) / R1)
-               * (D * D / 2.0 - (5.0 + 3.0 * T1 + 10.0 * C1 - 4.0 * C1 * C1
-                                 - 9.0 * eccPrimeSquared) * D * D * D * D / 24.0
-                  + (61.0 + 90.0 * T1 + 298.0 * C1 + 45.0 * T1 * T1
-                     - 252.0 * eccPrimeSquared - 3.0 * C1 * C1)
-                  * D * D * D * D * D * D / 720.0);
-    latitude *= 180.0 / M_PI;
-
-    longitude = (D - (1.0 + 2.0 * T1 + C1) * D * D * D / 6.0
-                 + (5.0 - 2.0 * C1 + 28.0 * T1 - 3.0 * C1 * C1
-                    + 8.0 * eccPrimeSquared + 24.0 * T1 * T1)
-                 * D * D * D * D * D / 120.0) / cos(phi1Rad);
-    longitude = LongOrigin + longitude / M_PI * 180.0;
+    if (d > std::numeric_limits<long int>::max()) {
+      return std::numeric_limits<long int>::min();
+    } else {
+      return -static_cast<long int>(d);
+    }
+  }
 }
 
-long int
-timestampDiff(uint64_t t1, uint64_t t2)
-{
-    if (t2 > t1)
-    {
-        uint64_t d = t2 - t1;
-
-        if (d > std::numeric_limits<long int>::max())
-        {
-            return std::numeric_limits<long int>::max();
-        }
-        else
-        {
-            return d;
-        }
-    }
-    else
-    {
-        uint64_t d = t1 - t2;
-
-        if (d > std::numeric_limits<long int>::max())
-        {
-            return std::numeric_limits<long int>::min();
-        }
-        else
-        {
-            return - static_cast<long int>(d);
-        }
-    }
-}
-
-}
+}  // namespace camodocal

--- a/src/frontend/failure_detector.cpp
+++ b/src/frontend/failure_detector.cpp
@@ -1,100 +1,99 @@
 #include "frontend/failure_detector.h"
 
-FailureDetector::FailureDetector(backend::SlidingWindow* sliding_window, FeatureManager* feature_manager)
-    : sliding_window_(sliding_window)
-    , feature_manager_(feature_manager)
-    , feature_threshold_(2)
-    , acc_bias_threshold_(2.5)
-    , gyr_bias_threshold_(1.0)
-    , translation_threshold_(5.0)
-    , z_translation_threshold_(1.0)
-    , rotation_threshold_(50.0) {
-}
+FailureDetector::FailureDetector(backend::SlidingWindow* sliding_window,
+                                 FeatureManager* feature_manager)
+    : sliding_window_(sliding_window),
+      feature_manager_(feature_manager),
+      feature_threshold_(2),
+      acc_bias_threshold_(2.5),
+      gyr_bias_threshold_(1.0),
+      translation_threshold_(5.0),
+      z_translation_threshold_(1.0),
+      rotation_threshold_(50.0) {}
 
 bool FailureDetector::detectFailure(const Vector3d& last_P_end, const Matrix3d& last_R_end) {
-    
-    // Check feature failure
-    if (detectFeatureFailure()) {
-        return true;
-    }
-    
-    // Check IMU bias failures
-    if (detectIMUAccBiasFailure()) {
-        return true;
-    }
-    
-    if (detectIMUGyrBiasFailure()) {
-        return true;
-    }
-    
-    // Check translation failures
-    if (detectTranslationFailure(last_P_end)) {
-        return true;
-    }
-    
-    if (detectZTranslationFailure(last_P_end)) {
-        return true;
-    }
-    
-    // Check rotation failure
-    if (detectRotationFailure(last_R_end)) {
-        return true;
-    }
-    
-    return false;
+  // Check feature failure
+  if (detectFeatureFailure()) {
+    return true;
+  }
+
+  // Check IMU bias failures
+  if (detectIMUAccBiasFailure()) {
+    return true;
+  }
+
+  if (detectIMUGyrBiasFailure()) {
+    return true;
+  }
+
+  // Check translation failures
+  if (detectTranslationFailure(last_P_end)) {
+    return true;
+  }
+
+  if (detectZTranslationFailure(last_P_end)) {
+    return true;
+  }
+
+  // Check rotation failure
+  if (detectRotationFailure(last_R_end)) {
+    return true;
+  }
+
+  return false;
 }
 
 bool FailureDetector::detectFeatureFailure() {
-    if (feature_manager_->last_track_num < feature_threshold_) {
-        std::cout << " little feature " << feature_manager_->last_track_num << std::endl;
-        // return true; // Currently commented out in original code
-    }
-    return false;
+  if (feature_manager_->last_track_num < feature_threshold_) {
+    std::cout << " little feature " << feature_manager_->last_track_num << std::endl;
+    // return true; // Currently commented out in original code
+  }
+  return false;
 }
 
 bool FailureDetector::detectIMUAccBiasFailure() {
-    if (sliding_window_->back().Ba.norm() > acc_bias_threshold_) {
-        std::cout << " big IMU acc bias estimation " << sliding_window_->back().Ba.norm() << std::endl;
-        return true;
-    }
-    return false;
+  if (sliding_window_->back().Ba.norm() > acc_bias_threshold_) {
+    std::cout << " big IMU acc bias estimation " << sliding_window_->back().Ba.norm() << std::endl;
+    return true;
+  }
+  return false;
 }
 
 bool FailureDetector::detectIMUGyrBiasFailure() {
-    if (sliding_window_->back().Bg.norm() > gyr_bias_threshold_) {
-        std::cout << " big IMU gyr bias estimation " << sliding_window_->back().Bg.norm() << std::endl;
-        return true;
-    }
-    return false;
+  if (sliding_window_->back().Bg.norm() > gyr_bias_threshold_) {
+    std::cout << " big IMU gyr bias estimation " << sliding_window_->back().Bg.norm() << std::endl;
+    return true;
+  }
+  return false;
 }
 
 bool FailureDetector::detectTranslationFailure(const Vector3d& last_P_end) {
-    Vector3d tmp_P = sliding_window_->back().P;
-    if ((tmp_P - last_P_end).norm() > translation_threshold_) {
-        std::cout << " big translation" << std::endl;
-        return true;
-    }
-    return false;
+  Vector3d tmp_P = sliding_window_->back().P;
+  if ((tmp_P - last_P_end).norm() > translation_threshold_) {
+    std::cout << " big translation" << std::endl;
+    return true;
+  }
+  return false;
 }
 
 bool FailureDetector::detectZTranslationFailure(const Vector3d& last_P_end) {
-    Vector3d tmp_P = sliding_window_->back().P;
-    if (abs(tmp_P.z() - last_P_end.z()) > z_translation_threshold_) {
-        std::cout << " big z translation" << std::endl;
-        return true;
-    }
-    return false;
+  Vector3d tmp_P = sliding_window_->back().P;
+  if (abs(tmp_P.z() - last_P_end.z()) > z_translation_threshold_) {
+    std::cout << " big z translation" << std::endl;
+    return true;
+  }
+  return false;
 }
 
 bool FailureDetector::detectRotationFailure(const Matrix3d& last_R_end) {
-    Matrix3d tmp_R = sliding_window_->back().R;
-    Matrix3d delta_R = tmp_R.transpose() * last_R_end;
-    Quaterniond delta_Q(delta_R);
-    double delta_angle = acos(delta_Q.w()) * 2.0 / 3.14 * 180.0;
-    
-    if (delta_angle > rotation_threshold_) {
-        std::cout << " big delta_angle " << std::endl;
-        // return true; // Currently commented out in original code
-    }
-    return false;
-} 
+  Matrix3d tmp_R = sliding_window_->back().R;
+  Matrix3d delta_R = tmp_R.transpose() * last_R_end;
+  Quaterniond delta_Q(delta_R);
+  double delta_angle = acos(delta_Q.w()) * 2.0 / 3.14 * 180.0;
+
+  if (delta_angle > rotation_threshold_) {
+    std::cout << " big delta_angle " << std::endl;
+    // return true; // Currently commented out in original code
+  }
+  return false;
+}

--- a/src/frontend/feature_manager.cpp
+++ b/src/frontend/feature_manager.cpp
@@ -1,287 +1,278 @@
 #include "frontend/feature_manager.h"
+
 #include "utility/config.h"
 
-int FeaturePerId::endFrame() {
-    return start_frame + feature_per_frame.size() - 1;
-}
+int FeaturePerId::endFrame() { return start_frame + feature_per_frame.size() - 1; }
 
-FeatureManager::FeatureManager() {
-}
+FeatureManager::FeatureManager() {}
 
-
-void FeatureManager::clearState() {
-    feature.clear();
-}
+void FeatureManager::clearState() { feature.clear(); }
 
 int FeatureManager::getFeatureCount() {
-    int cnt = 0;
-    for (auto &it : feature) {
-        it.used_num = it.feature_per_frame.size();
+  int cnt = 0;
+  for (auto &it : feature) {
+    it.used_num = it.feature_per_frame.size();
 
-        if (it.used_num >= 2 && it.start_frame < WINDOW_SIZE - 2) {
-            cnt++;
-        }
+    if (it.used_num >= 2 && it.start_frame < WINDOW_SIZE - 2) {
+      cnt++;
     }
-    return cnt;
+  }
+  return cnt;
 }
 
-bool FeatureManager::addFeatureCheckParallax(int frame_count,
-                                             const ImageData &image) {
-    // std::cout << "input feature: " << (int)image.size() << std::endl;
-    // std::cout << "num of feature: " << getFeatureCount() << std::endl;
-    double parallax_sum = 0;
-    int parallax_num = 0;
-    last_track_num = 0;
-    for (auto &id_pts : image) {
-        FeaturePerFrame f_per_fra(id_pts.second[0]);
+bool FeatureManager::addFeatureCheckParallax(int frame_count, const ImageData &image) {
+  // std::cout << "input feature: " << (int)image.size() << std::endl;
+  // std::cout << "num of feature: " << getFeatureCount() << std::endl;
+  double parallax_sum = 0;
+  int parallax_num = 0;
+  last_track_num = 0;
+  for (auto &id_pts : image) {
+    FeaturePerFrame f_per_fra(id_pts.second[0]);
 
-        int feature_id = id_pts.first;
-        auto it = find_if(feature.begin(), feature.end(),
-                          [feature_id](const FeaturePerId &it) { return it.feature_id == feature_id; });
+    int feature_id = id_pts.first;
+    auto it = find_if(feature.begin(), feature.end(),
+                      [feature_id](const FeaturePerId &it) { return it.feature_id == feature_id; });
 
-        if (it == feature.end()) {
-            feature.push_back(FeaturePerId(feature_id, frame_count));
-            feature.back().feature_per_frame.push_back(f_per_fra);
-        } else if (it->feature_id == feature_id) {
-            it->feature_per_frame.push_back(f_per_fra);
-            last_track_num++;
-        }
+    if (it == feature.end()) {
+      feature.push_back(FeaturePerId(feature_id, frame_count));
+      feature.back().feature_per_frame.push_back(f_per_fra);
+    } else if (it->feature_id == feature_id) {
+      it->feature_per_frame.push_back(f_per_fra);
+      last_track_num++;
     }
+  }
 
-    if (frame_count < 2 || last_track_num < 20)
-        return true;
+  if (frame_count < 2 || last_track_num < 20) return true;
 
-    for (auto &it_per_id : feature) {
-        if (it_per_id.start_frame <= frame_count - 2 &&
-            it_per_id.start_frame + int(it_per_id.feature_per_frame.size()) - 1 >= frame_count - 1) {
-            parallax_sum += compensatedParallax2(it_per_id, frame_count);
-            parallax_num++;
-        }
+  for (auto &it_per_id : feature) {
+    if (it_per_id.start_frame <= frame_count - 2 &&
+        it_per_id.start_frame + int(it_per_id.feature_per_frame.size()) - 1 >= frame_count - 1) {
+      parallax_sum += compensatedParallax2(it_per_id, frame_count);
+      parallax_num++;
     }
+  }
 
-    if (parallax_num == 0) {
-        return true;
-    } else {
-        std::cout << "parallax_sum: " << parallax_sum << ", parallax_num: " << parallax_num << std::endl;
-        std::cout << "current parallax: " << parallax_sum / parallax_num * g_config.camera.focal_length << std::endl;
-        return parallax_sum / parallax_num >= (g_config.estimator.min_parallax/g_config.camera.focal_length);
-    }
+  if (parallax_num == 0) {
+    return true;
+  } else {
+    std::cout << "parallax_sum: " << parallax_sum << ", parallax_num: " << parallax_num
+              << std::endl;
+    std::cout << "current parallax: " << parallax_sum / parallax_num * g_config.camera.focal_length
+              << std::endl;
+    return parallax_sum / parallax_num >=
+           (g_config.estimator.min_parallax / g_config.camera.focal_length);
+  }
 }
 
-vector<pair<Vector3d, Vector3d>> FeatureManager::getCorresponding(int frame_count_l, int frame_count_r) {
-    vector<pair<Vector3d, Vector3d>> corres;
-    for (auto &it : feature) {
-        if (it.start_frame <= frame_count_l && it.endFrame() >= frame_count_r) {
-            Vector3d a = Vector3d::Zero(), b = Vector3d::Zero();
-            int idx_l = frame_count_l - it.start_frame;
-            int idx_r = frame_count_r - it.start_frame;
+vector<pair<Vector3d, Vector3d>> FeatureManager::getCorresponding(int frame_count_l,
+                                                                  int frame_count_r) {
+  vector<pair<Vector3d, Vector3d>> corres;
+  for (auto &it : feature) {
+    if (it.start_frame <= frame_count_l && it.endFrame() >= frame_count_r) {
+      Vector3d a = Vector3d::Zero(), b = Vector3d::Zero();
+      int idx_l = frame_count_l - it.start_frame;
+      int idx_r = frame_count_r - it.start_frame;
 
-            a = it.feature_per_frame[idx_l].point;
+      a = it.feature_per_frame[idx_l].point;
 
-            b = it.feature_per_frame[idx_r].point;
+      b = it.feature_per_frame[idx_r].point;
 
-            corres.push_back(make_pair(a, b));
-        }
+      corres.push_back(make_pair(a, b));
     }
-    return corres;
+  }
+  return corres;
 }
 
 void FeatureManager::setDepth(const VectorXd &x) {
-    int feature_index = -1;
-    for (auto &it_per_id : feature) {
-        it_per_id.used_num = it_per_id.feature_per_frame.size();
-        if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2))
-            continue;
+  int feature_index = -1;
+  for (auto &it_per_id : feature) {
+    it_per_id.used_num = it_per_id.feature_per_frame.size();
+    if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2)) continue;
 
-        it_per_id.estimated_depth = 1.0 / x(++feature_index);
-        // ROS_INFO("feature id %d , start_frame %d, depth %f ",
-        // it_per_id->feature_id, it_per_id-> start_frame,
-        // it_per_id->estimated_depth);
-        if (it_per_id.estimated_depth < 0) {
-            it_per_id.solve_flag = 2;
-        } else
-            it_per_id.solve_flag = 1;
-    }
+    it_per_id.estimated_depth = 1.0 / x(++feature_index);
+    // ROS_INFO("feature id %d , start_frame %d, depth %f ",
+    // it_per_id->feature_id, it_per_id-> start_frame,
+    // it_per_id->estimated_depth);
+    if (it_per_id.estimated_depth < 0) {
+      it_per_id.solve_flag = 2;
+    } else
+      it_per_id.solve_flag = 1;
+  }
 }
 
 void FeatureManager::removeFailures() {
-    for (auto it = feature.begin(), it_next = feature.begin(); it != feature.end(); it = it_next) {
-        it_next++;
-        if (it->solve_flag == 2)
-            feature.erase(it);
-    }
+  for (auto it = feature.begin(), it_next = feature.begin(); it != feature.end(); it = it_next) {
+    it_next++;
+    if (it->solve_flag == 2) feature.erase(it);
+  }
 }
 
 void FeatureManager::clearDepth(const VectorXd &x) {
-    int feature_index = -1;
-    for (auto &it_per_id : feature) {
-        it_per_id.used_num = it_per_id.feature_per_frame.size();
-        if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2))
-            continue;
-        it_per_id.estimated_depth = 1.0 / x(++feature_index);
-    }
+  int feature_index = -1;
+  for (auto &it_per_id : feature) {
+    it_per_id.used_num = it_per_id.feature_per_frame.size();
+    if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2)) continue;
+    it_per_id.estimated_depth = 1.0 / x(++feature_index);
+  }
 }
 
 VectorXd FeatureManager::getDepthVector() {
-    VectorXd dep_vec(getFeatureCount());
-    int feature_index = -1;
-    for (auto &it_per_id : feature) {
-        it_per_id.used_num = it_per_id.feature_per_frame.size();
-        if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2))
-            continue;
-        dep_vec(++feature_index) = 1. / it_per_id.estimated_depth;
-    }
-    return dep_vec;
+  VectorXd dep_vec(getFeatureCount());
+  int feature_index = -1;
+  for (auto &it_per_id : feature) {
+    it_per_id.used_num = it_per_id.feature_per_frame.size();
+    if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2)) continue;
+    dep_vec(++feature_index) = 1. / it_per_id.estimated_depth;
+  }
+  return dep_vec;
 }
 
-void FeatureManager::triangulate(const backend::SlidingWindow &sliding_window, const Vector3d &t_ic, const Matrix3d &r_ic) {
-    for (auto &it_per_id : feature) {
-        it_per_id.used_num = it_per_id.feature_per_frame.size();
-        if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2))
-            continue;
+void FeatureManager::triangulate(const backend::SlidingWindow &sliding_window, const Vector3d &t_ic,
+                                 const Matrix3d &r_ic) {
+  for (auto &it_per_id : feature) {
+    it_per_id.used_num = it_per_id.feature_per_frame.size();
+    if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2)) continue;
 
-        if (it_per_id.estimated_depth > 0)
-            continue;
-        int imu_i = it_per_id.start_frame, imu_j = imu_i - 1;
+    if (it_per_id.estimated_depth > 0) continue;
+    int imu_i = it_per_id.start_frame, imu_j = imu_i - 1;
 
-        Eigen::MatrixXd svd_A(2 * it_per_id.feature_per_frame.size(), 4);
-        int svd_idx = 0;
+    Eigen::MatrixXd svd_A(2 * it_per_id.feature_per_frame.size(), 4);
+    int svd_idx = 0;
 
-        Eigen::Matrix<double, 3, 4> P0;
-        Eigen::Vector3d t0 = sliding_window[imu_i].P + sliding_window[imu_i].R * t_ic;
-        Eigen::Matrix3d R0 = sliding_window[imu_i].R * r_ic;
-        P0.leftCols<3>() = Eigen::Matrix3d::Identity();
-        P0.rightCols<1>() = Eigen::Vector3d::Zero();
+    Eigen::Matrix<double, 3, 4> P0;
+    Eigen::Vector3d t0 = sliding_window[imu_i].P + sliding_window[imu_i].R * t_ic;
+    Eigen::Matrix3d R0 = sliding_window[imu_i].R * r_ic;
+    P0.leftCols<3>() = Eigen::Matrix3d::Identity();
+    P0.rightCols<1>() = Eigen::Vector3d::Zero();
 
-        for (auto &it_per_frame : it_per_id.feature_per_frame) {
-            imu_j++;
+    for (auto &it_per_frame : it_per_id.feature_per_frame) {
+      imu_j++;
 
-            Eigen::Vector3d t1 = sliding_window[imu_j].P + sliding_window[imu_j].R * t_ic;
-            Eigen::Matrix3d R1 = sliding_window[imu_j].R * r_ic;
-            Eigen::Vector3d t = R0.transpose() * (t1 - t0);
-            Eigen::Matrix3d R = R0.transpose() * R1;
-            Eigen::Matrix<double, 3, 4> P;
-            P.leftCols<3>() = R.transpose();
-            P.rightCols<1>() = -R.transpose() * t;
-            Eigen::Vector3d f = it_per_frame.point.normalized();
-            svd_A.row(svd_idx++) = f[0] * P.row(2) - f[2] * P.row(0);
-            svd_A.row(svd_idx++) = f[1] * P.row(2) - f[2] * P.row(1);
+      Eigen::Vector3d t1 = sliding_window[imu_j].P + sliding_window[imu_j].R * t_ic;
+      Eigen::Matrix3d R1 = sliding_window[imu_j].R * r_ic;
+      Eigen::Vector3d t = R0.transpose() * (t1 - t0);
+      Eigen::Matrix3d R = R0.transpose() * R1;
+      Eigen::Matrix<double, 3, 4> P;
+      P.leftCols<3>() = R.transpose();
+      P.rightCols<1>() = -R.transpose() * t;
+      Eigen::Vector3d f = it_per_frame.point.normalized();
+      svd_A.row(svd_idx++) = f[0] * P.row(2) - f[2] * P.row(0);
+      svd_A.row(svd_idx++) = f[1] * P.row(2) - f[2] * P.row(1);
 
-            if (imu_i == imu_j)
-                continue;
-        }
-        assert(svd_idx == svd_A.rows());
-        Eigen::Vector4d svd_V = Eigen::JacobiSVD<Eigen::MatrixXd>(svd_A, Eigen::ComputeThinV).matrixV().rightCols<1>();
-        double svd_method = svd_V[2] / svd_V[3];
-        // it_per_id->estimated_depth = -b / A;
-        // it_per_id->estimated_depth = svd_V[2] / svd_V[3];
-
-        it_per_id.estimated_depth = svd_method;
-        // it_per_id->estimated_depth = INIT_DEPTH;
-
-        if (it_per_id.estimated_depth < 0.1) {
-            it_per_id.estimated_depth = g_config.estimator.init_depth;
-        }
+      if (imu_i == imu_j) continue;
     }
+    assert(svd_idx == svd_A.rows());
+    Eigen::Vector4d svd_V =
+        Eigen::JacobiSVD<Eigen::MatrixXd>(svd_A, Eigen::ComputeThinV).matrixV().rightCols<1>();
+    double svd_method = svd_V[2] / svd_V[3];
+    // it_per_id->estimated_depth = -b / A;
+    // it_per_id->estimated_depth = svd_V[2] / svd_V[3];
+
+    it_per_id.estimated_depth = svd_method;
+    // it_per_id->estimated_depth = INIT_DEPTH;
+
+    if (it_per_id.estimated_depth < 0.1) {
+      it_per_id.estimated_depth = g_config.estimator.init_depth;
+    }
+  }
 }
 
 void FeatureManager::removeOutlier() {
-    assert(false);
-    int i = -1;
-    for (auto it = feature.begin(), it_next = feature.begin(); it != feature.end(); it = it_next) {
-        it_next++;
-        i += it->used_num != 0;
-        if (it->used_num != 0 && it->is_outlier == true) {
-            feature.erase(it);
-        }
+  assert(false);
+  int i = -1;
+  for (auto it = feature.begin(), it_next = feature.begin(); it != feature.end(); it = it_next) {
+    it_next++;
+    i += it->used_num != 0;
+    if (it->used_num != 0 && it->is_outlier == true) {
+      feature.erase(it);
     }
+  }
 }
 
-void FeatureManager::removeBackShiftDepth(Eigen::Matrix3d marg_R, Eigen::Vector3d marg_P, Eigen::Matrix3d new_R,
-                                          Eigen::Vector3d new_P) {
-    for (auto it = feature.begin(), it_next = feature.begin(); it != feature.end(); it = it_next) {
-        it_next++;
+void FeatureManager::removeBackShiftDepth(Eigen::Matrix3d marg_R, Eigen::Vector3d marg_P,
+                                          Eigen::Matrix3d new_R, Eigen::Vector3d new_P) {
+  for (auto it = feature.begin(), it_next = feature.begin(); it != feature.end(); it = it_next) {
+    it_next++;
 
-        if (it->start_frame != 0)
-            it->start_frame--;
-        else {
-            Eigen::Vector3d uv_i = it->feature_per_frame[0].point;
-            it->feature_per_frame.erase(it->feature_per_frame.begin());
-            if (it->feature_per_frame.size() < 2) {
-                feature.erase(it);
-                continue;
-            } else {
-                Eigen::Vector3d pts_i = uv_i * it->estimated_depth;
-                Eigen::Vector3d w_pts_i = marg_R * pts_i + marg_P;
-                Eigen::Vector3d pts_j = new_R.transpose() * (w_pts_i - new_P);
-                double dep_j = pts_j(2);
-                if (dep_j > 0)
-                    it->estimated_depth = dep_j;
-                else
-                    it->estimated_depth = g_config.estimator.init_depth;
-            }
-        }
+    if (it->start_frame != 0)
+      it->start_frame--;
+    else {
+      Eigen::Vector3d uv_i = it->feature_per_frame[0].point;
+      it->feature_per_frame.erase(it->feature_per_frame.begin());
+      if (it->feature_per_frame.size() < 2) {
+        feature.erase(it);
+        continue;
+      } else {
+        Eigen::Vector3d pts_i = uv_i * it->estimated_depth;
+        Eigen::Vector3d w_pts_i = marg_R * pts_i + marg_P;
+        Eigen::Vector3d pts_j = new_R.transpose() * (w_pts_i - new_P);
+        double dep_j = pts_j(2);
+        if (dep_j > 0)
+          it->estimated_depth = dep_j;
+        else
+          it->estimated_depth = g_config.estimator.init_depth;
+      }
     }
+  }
 }
 
 void FeatureManager::removeBack() {
-    for (auto it = feature.begin(), it_next = feature.begin(); it != feature.end(); it = it_next) {
-        it_next++;
+  for (auto it = feature.begin(), it_next = feature.begin(); it != feature.end(); it = it_next) {
+    it_next++;
 
-        if (it->start_frame != 0)
-            it->start_frame--;
-        else {
-            it->feature_per_frame.erase(it->feature_per_frame.begin());
-            if (it->feature_per_frame.size() == 0)
-                feature.erase(it);
-        }
+    if (it->start_frame != 0)
+      it->start_frame--;
+    else {
+      it->feature_per_frame.erase(it->feature_per_frame.begin());
+      if (it->feature_per_frame.size() == 0) feature.erase(it);
     }
+  }
 }
 
 void FeatureManager::removeFront(int frame_count) {
-    for (auto it = feature.begin(), it_next = feature.begin(); it != feature.end(); it = it_next) {
-        it_next++;
+  for (auto it = feature.begin(), it_next = feature.begin(); it != feature.end(); it = it_next) {
+    it_next++;
 
-        if (it->start_frame == frame_count) {
-            it->start_frame--;
-        } else {
-            int j = WINDOW_SIZE - 1 - it->start_frame;
-            if (it->endFrame() < frame_count - 1)
-                continue;
-            it->feature_per_frame.erase(it->feature_per_frame.begin() + j);
-            if (it->feature_per_frame.size() == 0)
-                feature.erase(it);
-        }
+    if (it->start_frame == frame_count) {
+      it->start_frame--;
+    } else {
+      int j = WINDOW_SIZE - 1 - it->start_frame;
+      if (it->endFrame() < frame_count - 1) continue;
+      it->feature_per_frame.erase(it->feature_per_frame.begin() + j);
+      if (it->feature_per_frame.size() == 0) feature.erase(it);
     }
+  }
 }
 
 double FeatureManager::compensatedParallax2(const FeaturePerId &it_per_id, int frame_count) {
-    // check the second last frame is keyframe or not
-    // parallax betwwen seconde last frame and third last frame
-    const FeaturePerFrame &frame_i = it_per_id.feature_per_frame[frame_count - 2 - it_per_id.start_frame];
-    const FeaturePerFrame &frame_j = it_per_id.feature_per_frame[frame_count - 1 - it_per_id.start_frame];
+  // check the second last frame is keyframe or not
+  // parallax betwwen seconde last frame and third last frame
+  const FeaturePerFrame &frame_i =
+      it_per_id.feature_per_frame[frame_count - 2 - it_per_id.start_frame];
+  const FeaturePerFrame &frame_j =
+      it_per_id.feature_per_frame[frame_count - 1 - it_per_id.start_frame];
 
-    double ans = 0;
-    Vector3d p_j = frame_j.point;
+  double ans = 0;
+  Vector3d p_j = frame_j.point;
 
-    double u_j = p_j(0);
-    double v_j = p_j(1);
+  double u_j = p_j(0);
+  double v_j = p_j(1);
 
-    Vector3d p_i = frame_i.point;
-    Vector3d p_i_comp;
+  Vector3d p_i = frame_i.point;
+  Vector3d p_i_comp;
 
-    p_i_comp = p_i;
-    double dep_i = p_i(2);
-    double u_i = p_i(0) / dep_i;
-    double v_i = p_i(1) / dep_i;
-    double du = u_i - u_j, dv = v_i - v_j;
+  p_i_comp = p_i;
+  double dep_i = p_i(2);
+  double u_i = p_i(0) / dep_i;
+  double v_i = p_i(1) / dep_i;
+  double du = u_i - u_j, dv = v_i - v_j;
 
-    double dep_i_comp = p_i_comp(2);
-    double u_i_comp = p_i_comp(0) / dep_i_comp;
-    double v_i_comp = p_i_comp(1) / dep_i_comp;
-    double du_comp = u_i_comp - u_j, dv_comp = v_i_comp - v_j;
+  double dep_i_comp = p_i_comp(2);
+  double u_i_comp = p_i_comp(0) / dep_i_comp;
+  double v_i_comp = p_i_comp(1) / dep_i_comp;
+  double du_comp = u_i_comp - u_j, dv_comp = v_i_comp - v_j;
 
-    ans = max(ans, sqrt(min(du * du + dv * dv, du_comp * du_comp + dv_comp * dv_comp)));
+  ans = max(ans, sqrt(min(du * du + dv * dv, du_comp * du_comp + dv_comp * dv_comp)));
 
-    return ans;
+  return ans;
 }

--- a/src/frontend/feature_tracker.cpp
+++ b/src/frontend/feature_tracker.cpp
@@ -1,4 +1,5 @@
 #include "frontend/feature_tracker.h"
+
 #include "utility/config.h"
 
 using namespace utility;
@@ -7,252 +8,208 @@ namespace feature_tracker {
 
 int FeatureTracker::n_id = 0;
 
-bool inBorder(const cv::Point2f &pt)
-{
-    const int BORDER_SIZE = 1;
-    int img_x = cvRound(pt.x);
-    int img_y = cvRound(pt.y);
-    return BORDER_SIZE <= img_x && img_x < g_config.camera.col - BORDER_SIZE && BORDER_SIZE <= img_y && img_y < g_config.camera.row - BORDER_SIZE;
+bool inBorder(const cv::Point2f &pt) {
+  const int BORDER_SIZE = 1;
+  int img_x = cvRound(pt.x);
+  int img_y = cvRound(pt.y);
+  return BORDER_SIZE <= img_x && img_x < g_config.camera.col - BORDER_SIZE &&
+         BORDER_SIZE <= img_y && img_y < g_config.camera.row - BORDER_SIZE;
 }
 
-void reduceVector(vector<cv::Point2f> &v, vector<uchar> status)
-{
-    int j = 0;
-    for (int i = 0; i < int(v.size()); i++)
-        if (status[i])
-            v[j++] = v[i];
-    v.resize(j);
+void reduceVector(vector<cv::Point2f> &v, vector<uchar> status) {
+  int j = 0;
+  for (int i = 0; i < int(v.size()); i++)
+    if (status[i]) v[j++] = v[i];
+  v.resize(j);
 }
 
-void reduceVector(vector<int> &v, vector<uchar> status)
-{
-    int j = 0;
-    for (int i = 0; i < int(v.size()); i++)
-        if (status[i])
-            v[j++] = v[i];
-    v.resize(j);
+void reduceVector(vector<int> &v, vector<uchar> status) {
+  int j = 0;
+  for (int i = 0; i < int(v.size()); i++)
+    if (status[i]) v[j++] = v[i];
+  v.resize(j);
 }
 
+FeatureTracker::FeatureTracker() {}
 
-FeatureTracker::FeatureTracker()
-{
+void FeatureTracker::setMask() {
+  if (g_config.feature_tracker.fisheye)
+    mask = fisheye_mask.clone();
+  else
+    mask = cv::Mat(g_config.camera.row, g_config.camera.col, CV_8UC1, cv::Scalar(255));
+
+  // prefer to keep features that are tracked for long time
+  vector<pair<int, pair<cv::Point2f, int>>> cnt_pts_id;
+
+  for (unsigned int i = 0; i < forw_pts.size(); i++)
+    cnt_pts_id.push_back(make_pair(track_cnt[i], make_pair(forw_pts[i], ids[i])));
+
+  sort(cnt_pts_id.begin(), cnt_pts_id.end(),
+       [](const pair<int, pair<cv::Point2f, int>> &a, const pair<int, pair<cv::Point2f, int>> &b) {
+         return a.first > b.first;
+       });
+
+  forw_pts.clear();
+  ids.clear();
+  track_cnt.clear();
+
+  for (auto &it : cnt_pts_id) {
+    if (mask.at<uchar>(it.second.first) == 255) {
+      forw_pts.push_back(it.second.first);
+      ids.push_back(it.second.second);
+      track_cnt.push_back(it.first);
+      cv::circle(mask, it.second.first, g_config.feature_tracker.min_dist, 0, -1);
+    }
+  }
 }
 
-void FeatureTracker::setMask()
-{
-    if(g_config.feature_tracker.fisheye)
-        mask = fisheye_mask.clone();
-    else
-        mask = cv::Mat(g_config.camera.row, g_config.camera.col, CV_8UC1, cv::Scalar(255));
-    
-
-    // prefer to keep features that are tracked for long time
-    vector<pair<int, pair<cv::Point2f, int>>> cnt_pts_id;
-
-    for (unsigned int i = 0; i < forw_pts.size(); i++)
-        cnt_pts_id.push_back(make_pair(track_cnt[i], make_pair(forw_pts[i], ids[i])));
-
-    sort(cnt_pts_id.begin(), cnt_pts_id.end(), [](const pair<int, pair<cv::Point2f, int>> &a, const pair<int, pair<cv::Point2f, int>> &b)
-         {
-            return a.first > b.first;
-         });
-
-    forw_pts.clear();
-    ids.clear();
-    track_cnt.clear();
-
-    for (auto &it : cnt_pts_id)
-    {
-        if (mask.at<uchar>(it.second.first) == 255)
-        {
-            forw_pts.push_back(it.second.first);
-            ids.push_back(it.second.second);
-            track_cnt.push_back(it.first);
-            cv::circle(mask, it.second.first, g_config.feature_tracker.min_dist, 0, -1);
-        }
-    }
+void FeatureTracker::addPoints() {
+  for (auto &p : n_pts) {
+    forw_pts.push_back(p);
+    ids.push_back(-1);
+    track_cnt.push_back(1);
+  }
 }
 
-void FeatureTracker::addPoints()
-{
-    for (auto &p : n_pts)
-    {
-        forw_pts.push_back(p);
-        ids.push_back(-1);
-        track_cnt.push_back(1);
-    }
+void FeatureTracker::readImage(const cv::Mat &_img, double _cur_time) {
+  cv::Mat img;
+  cur_time = _cur_time;
+
+  if (g_config.feature_tracker.equalize) {
+    cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE(3.0, cv::Size(8, 8));
+    clahe->apply(_img, img);
+  } else
+    img = _img;
+
+  if (next_img.empty()) {
+    prev_img = cur_img = next_img = img;
+  } else {
+    next_img = img;
+  }
+
+  forw_pts.clear();
+
+  if (cur_pts.size() > 0) {
+    vector<uchar> status;
+    vector<float> err;
+    cv::calcOpticalFlowPyrLK(cur_img, next_img, cur_pts, forw_pts, status, err, cv::Size(21, 21),
+                             3);
+
+    for (int i = 0; i < int(forw_pts.size()); i++)
+      if (status[i] && !inBorder(forw_pts[i])) status[i] = 0;
+    reduceVector(prev_pts, status);
+    reduceVector(cur_pts, status);
+    reduceVector(forw_pts, status);
+    reduceVector(ids, status);
+    reduceVector(cur_un_pts, status);
+    reduceVector(track_cnt, status);
+
+    std::cout << "forw_pts.size(): " << forw_pts.size() << std::endl;
+  }
+
+  for (auto &n : track_cnt) n++;
+
+  rejectWithFundamentalMatrix();
+  setMask();
+
+  int n_max_cnt = g_config.feature_tracker.max_cnt - static_cast<int>(forw_pts.size());
+  if (n_max_cnt > 0) {
+    if (mask.empty()) cout << "mask is empty " << endl;
+    if (mask.type() != CV_8UC1) cout << "mask type wrong " << endl;
+    if (mask.size() != next_img.size()) cout << "wrong size " << endl;
+    cv::goodFeaturesToTrack(next_img, n_pts, g_config.feature_tracker.max_cnt - forw_pts.size(),
+                            0.01, g_config.feature_tracker.min_dist, mask);
+  } else
+    n_pts.clear();
+
+  addPoints();
+
+  prev_img = cur_img;
+  prev_pts = cur_pts;
+  prev_un_pts = cur_un_pts;
+  cur_img = next_img;
+  cur_pts = forw_pts;
+  undistortedPoints();
+  prev_time = cur_time;
 }
 
-void FeatureTracker::readImage(const cv::Mat &_img, double _cur_time)
-{
-    cv::Mat img;
-    cur_time = _cur_time;
+void FeatureTracker::rejectWithFundamentalMatrix() {
+  if (forw_pts.size() >= 8) {
+    vector<cv::Point2f> un_cur_pts(cur_pts.size()), un_forw_pts(forw_pts.size());
+    for (unsigned int i = 0; i < cur_pts.size(); i++) {
+      Eigen::Vector3d tmp_p;
+      m_camera->liftProjective(Eigen::Vector2d(cur_pts[i].x, cur_pts[i].y), tmp_p);
+      tmp_p.x() = g_config.camera.focal_length * tmp_p.x() / tmp_p.z() + g_config.camera.col / 2.0;
+      tmp_p.y() = g_config.camera.focal_length * tmp_p.y() / tmp_p.z() + g_config.camera.row / 2.0;
+      un_cur_pts[i] = cv::Point2f(tmp_p.x(), tmp_p.y());
 
-    if (g_config.feature_tracker.equalize)
-    {
-        cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE(3.0, cv::Size(8, 8));
-        clahe->apply(_img, img);
-    }
-    else
-        img = _img;
-
-    if (next_img.empty())
-    {
-        prev_img = cur_img = next_img = img;
-    }
-    else
-    {
-        next_img = img;
+      m_camera->liftProjective(Eigen::Vector2d(forw_pts[i].x, forw_pts[i].y), tmp_p);
+      tmp_p.x() = g_config.camera.focal_length * tmp_p.x() / tmp_p.z() + g_config.camera.col / 2.0;
+      tmp_p.y() = g_config.camera.focal_length * tmp_p.y() / tmp_p.z() + g_config.camera.row / 2.0;
+      un_forw_pts[i] = cv::Point2f(tmp_p.x(), tmp_p.y());
     }
 
-    forw_pts.clear();
-
-    if (cur_pts.size() > 0)
-    {
-        vector<uchar> status;
-        vector<float> err;
-        cv::calcOpticalFlowPyrLK(cur_img, next_img, cur_pts, forw_pts, status, err, cv::Size(21, 21), 3);
-
-        for (int i = 0; i < int(forw_pts.size()); i++)
-            if (status[i] && !inBorder(forw_pts[i]))
-                status[i] = 0;
-        reduceVector(prev_pts, status);
-        reduceVector(cur_pts, status);
-        reduceVector(forw_pts, status);
-        reduceVector(ids, status);
-        reduceVector(cur_un_pts, status);
-        reduceVector(track_cnt, status);
-
-        std::cout << "forw_pts.size(): " << forw_pts.size() << std::endl;
-    }
-
-    for (auto &n : track_cnt)
-        n++;
-
-    rejectWithFundamentalMatrix();
-    setMask();
-
-    int n_max_cnt = g_config.feature_tracker.max_cnt - static_cast<int>(forw_pts.size());
-    if (n_max_cnt > 0)
-    {
-        if(mask.empty())
-            cout << "mask is empty " << endl;
-        if (mask.type() != CV_8UC1)
-            cout << "mask type wrong " << endl;
-        if (mask.size() != next_img.size())
-            cout << "wrong size " << endl;
-        cv::goodFeaturesToTrack(next_img, n_pts, g_config.feature_tracker.max_cnt - forw_pts.size(), 0.01, g_config.feature_tracker.min_dist, mask);
-    }
-    else
-        n_pts.clear();
-
-    addPoints();
-
-    prev_img = cur_img;
-    prev_pts = cur_pts;
-    prev_un_pts = cur_un_pts;
-    cur_img = next_img;
-    cur_pts = forw_pts;
-    undistortedPoints();
-    prev_time = cur_time;
+    vector<uchar> status;
+    cv::findFundamentalMat(un_cur_pts, un_forw_pts, cv::FM_RANSAC,
+                           g_config.feature_tracker.f_threshold, 0.99, status);
+    int size_a = cur_pts.size();
+    reduceVector(prev_pts, status);
+    reduceVector(cur_pts, status);
+    reduceVector(forw_pts, status);
+    reduceVector(cur_un_pts, status);
+    reduceVector(ids, status);
+    reduceVector(track_cnt, status);
+  }
 }
 
-void FeatureTracker::rejectWithFundamentalMatrix()
-{
-    if (forw_pts.size() >= 8)
-    {
-        vector<cv::Point2f> un_cur_pts(cur_pts.size()), un_forw_pts(forw_pts.size());
-        for (unsigned int i = 0; i < cur_pts.size(); i++)
-        {
-            Eigen::Vector3d tmp_p;
-            m_camera->liftProjective(Eigen::Vector2d(cur_pts[i].x, cur_pts[i].y), tmp_p);
-            tmp_p.x() = g_config.camera.focal_length * tmp_p.x() / tmp_p.z() + g_config.camera.col / 2.0;
-            tmp_p.y() = g_config.camera.focal_length * tmp_p.y() / tmp_p.z() + g_config.camera.row / 2.0;
-            un_cur_pts[i] = cv::Point2f(tmp_p.x(), tmp_p.y());
-
-            m_camera->liftProjective(Eigen::Vector2d(forw_pts[i].x, forw_pts[i].y), tmp_p);
-            tmp_p.x() = g_config.camera.focal_length * tmp_p.x() / tmp_p.z() + g_config.camera.col / 2.0;
-            tmp_p.y() = g_config.camera.focal_length * tmp_p.y() / tmp_p.z() + g_config.camera.row / 2.0;
-            un_forw_pts[i] = cv::Point2f(tmp_p.x(), tmp_p.y());
-        }
-
-        vector<uchar> status;
-        cv::findFundamentalMat(un_cur_pts, un_forw_pts, cv::FM_RANSAC, g_config.feature_tracker.f_threshold, 0.99, status);
-        int size_a = cur_pts.size();
-        reduceVector(prev_pts, status);
-        reduceVector(cur_pts, status);
-        reduceVector(forw_pts, status);
-        reduceVector(cur_un_pts, status);
-        reduceVector(ids, status);
-        reduceVector(track_cnt, status);
-    }
+bool FeatureTracker::updateID(unsigned int i) {
+  if (i < ids.size()) {
+    if (ids[i] == -1) ids[i] = n_id++;
+    return true;
+  } else
+    return false;
 }
 
-bool FeatureTracker::updateID(unsigned int i)
-{
-    if (i < ids.size())
-    {
-        if (ids[i] == -1)
-            ids[i] = n_id++;
-        return true;
-    }
-    else
-        return false;
+void FeatureTracker::readIntrinsicParameter(const string &calib_file) {
+  m_camera = CameraFactory::instance()->generateCameraFromYamlFile(calib_file);
 }
 
-void FeatureTracker::readIntrinsicParameter(const string &calib_file)
-{
-    m_camera = CameraFactory::instance()->generateCameraFromYamlFile(calib_file);
+void FeatureTracker::undistortedPoints() {
+  cur_un_pts.clear();
+  cur_un_pts_map.clear();
+  // cv::undistortPoints(cur_pts, un_pts, K, cv::Mat());
+  for (unsigned int i = 0; i < cur_pts.size(); i++) {
+    Eigen::Vector2d a(cur_pts[i].x, cur_pts[i].y);
+    Eigen::Vector3d b;
+    m_camera->liftProjective(a, b);
+    cur_un_pts.push_back(cv::Point2f(b.x() / b.z(), b.y() / b.z()));
+    cur_un_pts_map.insert(make_pair(ids[i], cv::Point2f(b.x() / b.z(), b.y() / b.z())));
+    // printf("cur pts id %d %f %f", ids[i], cur_un_pts[i].x, cur_un_pts[i].y);
+  }
+  // caculate points velocity
+  if (!prev_un_pts_map.empty()) {
+    double dt = cur_time - prev_time;
+    pts_velocity.clear();
+    for (unsigned int i = 0; i < cur_un_pts.size(); i++) {
+      if (ids[i] != -1) {
+        std::map<int, cv::Point2f>::iterator it;
+        it = prev_un_pts_map.find(ids[i]);
+        if (it != prev_un_pts_map.end()) {
+          double v_x = (cur_un_pts[i].x - it->second.x) / dt;
+          double v_y = (cur_un_pts[i].y - it->second.y) / dt;
+          pts_velocity.push_back(cv::Point2f(v_x, v_y));
+        } else
+          pts_velocity.push_back(cv::Point2f(0, 0));
+      } else {
+        pts_velocity.push_back(cv::Point2f(0, 0));
+      }
+    }
+  } else {
+    for (unsigned int i = 0; i < cur_pts.size(); i++) {
+      pts_velocity.push_back(cv::Point2f(0, 0));
+    }
+  }
+  prev_un_pts_map = cur_un_pts_map;
 }
 
-void FeatureTracker::undistortedPoints()
-{
-    cur_un_pts.clear();
-    cur_un_pts_map.clear();
-    //cv::undistortPoints(cur_pts, un_pts, K, cv::Mat());
-    for (unsigned int i = 0; i < cur_pts.size(); i++)
-    {
-        Eigen::Vector2d a(cur_pts[i].x, cur_pts[i].y);
-        Eigen::Vector3d b;
-        m_camera->liftProjective(a, b);
-        cur_un_pts.push_back(cv::Point2f(b.x() / b.z(), b.y() / b.z()));
-        cur_un_pts_map.insert(make_pair(ids[i], cv::Point2f(b.x() / b.z(), b.y() / b.z())));
-        //printf("cur pts id %d %f %f", ids[i], cur_un_pts[i].x, cur_un_pts[i].y);
-    }
-    // caculate points velocity
-    if (!prev_un_pts_map.empty())
-    {
-        double dt = cur_time - prev_time;
-        pts_velocity.clear();
-        for (unsigned int i = 0; i < cur_un_pts.size(); i++)
-        {
-            if (ids[i] != -1)
-            {
-                std::map<int, cv::Point2f>::iterator it;
-                it = prev_un_pts_map.find(ids[i]);
-                if (it != prev_un_pts_map.end())
-                {
-                    double v_x = (cur_un_pts[i].x - it->second.x) / dt;
-                    double v_y = (cur_un_pts[i].y - it->second.y) / dt;
-                    pts_velocity.push_back(cv::Point2f(v_x, v_y));
-                }
-                else
-                    pts_velocity.push_back(cv::Point2f(0, 0));
-            }
-            else
-            {
-                pts_velocity.push_back(cv::Point2f(0, 0));
-            }
-        }
-    }
-    else
-    {
-        for (unsigned int i = 0; i < cur_pts.size(); i++)
-        {
-            pts_velocity.push_back(cv::Point2f(0, 0));
-        }
-    }
-    prev_un_pts_map = cur_un_pts_map;
-}
-
-}
+}  // namespace feature_tracker

--- a/src/frontend/initialization/initial_alignment.cpp
+++ b/src/frontend/initialization/initial_alignment.cpp
@@ -1,208 +1,217 @@
 #include "frontend/initialization/initial_alignment.h"
-#include "utility/config.h"
-#include <fstream>
-#include <iostream>
+
 #include <sys/stat.h>
+
 #include <chrono>
+#include <fstream>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
 
+#include "utility/config.h"
 
 namespace initial_alignment {
 
-void solveGyroscopeBias(map<double, ImageFrame> const &all_image_frame, backend::SlidingWindow &sliding_window) {
-    Matrix3d A;
-    Vector3d b;
-    Vector3d delta_bg;
-    A.setZero();
-    b.setZero();
-    map<double, ImageFrame>::const_iterator frame_i;
-    map<double, ImageFrame>::const_iterator frame_j;
-    for (frame_i = all_image_frame.begin(); next(frame_i) != all_image_frame.end(); frame_i++) {
-        frame_j = next(frame_i);
-        MatrixXd tmp_A(3, 3);
-        tmp_A.setZero();
-        VectorXd tmp_b(3);
-        tmp_b.setZero();
-        Eigen::Quaterniond q_ij(frame_i->second.R.transpose() * frame_j->second.R);
-        tmp_A = frame_j->second.pre_integration->jacobian.template block<3, 3>(O_R, O_BG);
-        tmp_b = 2 * (frame_j->second.pre_integration->delta_q.inverse() * q_ij).vec();
-        A += tmp_A.transpose() * tmp_A;
-        b += tmp_A.transpose() * tmp_b;
-    }
-    delta_bg = A.ldlt().solve(b);
-    std::cout << "gyroscope bias initial calibration " << delta_bg.transpose() << std::endl;
+void solveGyroscopeBias(map<double, ImageFrame> const &all_image_frame,
+                        backend::SlidingWindow &sliding_window) {
+  Matrix3d A;
+  Vector3d b;
+  Vector3d delta_bg;
+  A.setZero();
+  b.setZero();
+  map<double, ImageFrame>::const_iterator frame_i;
+  map<double, ImageFrame>::const_iterator frame_j;
+  for (frame_i = all_image_frame.begin(); next(frame_i) != all_image_frame.end(); frame_i++) {
+    frame_j = next(frame_i);
+    MatrixXd tmp_A(3, 3);
+    tmp_A.setZero();
+    VectorXd tmp_b(3);
+    tmp_b.setZero();
+    Eigen::Quaterniond q_ij(frame_i->second.R.transpose() * frame_j->second.R);
+    tmp_A = frame_j->second.pre_integration->jacobian.template block<3, 3>(O_R, O_BG);
+    tmp_b = 2 * (frame_j->second.pre_integration->delta_q.inverse() * q_ij).vec();
+    A += tmp_A.transpose() * tmp_A;
+    b += tmp_A.transpose() * tmp_b;
+  }
+  delta_bg = A.ldlt().solve(b);
+  std::cout << "gyroscope bias initial calibration " << delta_bg.transpose() << std::endl;
 
-    for (int i = 0; i <= WINDOW_SIZE; i++)
-        sliding_window[i].Bg += delta_bg;
+  for (int i = 0; i <= WINDOW_SIZE; i++) sliding_window[i].Bg += delta_bg;
 
-    for (frame_i = all_image_frame.begin(); next(frame_i) != all_image_frame.end(); frame_i++) {
-        frame_j = next(frame_i);
-        frame_j->second.pre_integration->repropagate(Vector3d::Zero(), sliding_window.front().Bg);
-    }
+  for (frame_i = all_image_frame.begin(); next(frame_i) != all_image_frame.end(); frame_i++) {
+    frame_j = next(frame_i);
+    frame_j->second.pre_integration->repropagate(Vector3d::Zero(), sliding_window.front().Bg);
+  }
 }
 
 MatrixXd TangentBasis(Vector3d &g0) {
-    Vector3d b, c;
-    Vector3d a = g0.normalized();
-    Vector3d tmp(0, 0, 1);
-    if (a == tmp)
-        tmp << 1, 0, 0;
-    b = (tmp - a * (a.transpose() * tmp)).normalized();
-    c = a.cross(b);
-    MatrixXd bc(3, 2);
-    bc.block<3, 1>(0, 0) = b;
-    bc.block<3, 1>(0, 1) = c;
-    return bc;
+  Vector3d b, c;
+  Vector3d a = g0.normalized();
+  Vector3d tmp(0, 0, 1);
+  if (a == tmp) tmp << 1, 0, 0;
+  b = (tmp - a * (a.transpose() * tmp)).normalized();
+  c = a.cross(b);
+  MatrixXd bc(3, 2);
+  bc.block<3, 1>(0, 0) = b;
+  bc.block<3, 1>(0, 1) = c;
+  return bc;
 }
 
 void RefineGravity(map<double, ImageFrame> const &all_image_frame, Vector3d &g, VectorXd &x) {
-    Vector3d g0 = g.normalized() * g_config.estimator.g.norm();
-    Vector3d lx, ly;
-    // VectorXd x;
-    int all_frame_count = all_image_frame.size();
-    int n_state = all_frame_count * 3 + 2 + 1;
+  Vector3d g0 = g.normalized() * g_config.estimator.g.norm();
+  Vector3d lx, ly;
+  // VectorXd x;
+  int all_frame_count = all_image_frame.size();
+  int n_state = all_frame_count * 3 + 2 + 1;
 
-    MatrixXd A{n_state, n_state};
-    A.setZero();
-    VectorXd b{n_state};
-    b.setZero();
+  MatrixXd A{n_state, n_state};
+  A.setZero();
+  VectorXd b{n_state};
+  b.setZero();
 
-    map<double, ImageFrame>::const_iterator frame_i;
-    map<double, ImageFrame>::const_iterator frame_j;
-    for (int k = 0; k < 4; k++) {
-        MatrixXd lxly(3, 2);
-        lxly = TangentBasis(g0);
-        int i = 0;
-        for (frame_i = all_image_frame.begin(); next(frame_i) != all_image_frame.end(); frame_i++, i++) {
-            frame_j = next(frame_i);
-
-            MatrixXd tmp_A(6, 9);
-            tmp_A.setZero();
-            VectorXd tmp_b(6);
-            tmp_b.setZero();
-
-            double dt = frame_j->second.pre_integration->sum_dt;
-
-            tmp_A.block<3, 3>(0, 0) = -dt * Matrix3d::Identity();
-            tmp_A.block<3, 2>(0, 6) = frame_i->second.R.transpose() * dt * dt / 2 * Matrix3d::Identity() * lxly;
-            tmp_A.block<3, 1>(0, 8) = frame_i->second.R.transpose() * (frame_j->second.T - frame_i->second.T) / 100.0;
-            tmp_b.block<3, 1>(0, 0) = frame_j->second.pre_integration->delta_p +
-                                      frame_i->second.R.transpose() * frame_j->second.R * g_config.camera.t_ic - g_config.camera.t_ic -
-                                      frame_i->second.R.transpose() * dt * dt / 2 * g0;
-
-            tmp_A.block<3, 3>(3, 0) = -Matrix3d::Identity();
-            tmp_A.block<3, 3>(3, 3) = frame_i->second.R.transpose() * frame_j->second.R;
-            tmp_A.block<3, 2>(3, 6) = frame_i->second.R.transpose() * dt * Matrix3d::Identity() * lxly;
-            tmp_b.block<3, 1>(3, 0) = frame_j->second.pre_integration->delta_v -
-                                      frame_i->second.R.transpose() * dt * Matrix3d::Identity() * g0;
-
-            Matrix<double, 6, 6> cov_inv = Matrix<double, 6, 6>::Zero();
-            // cov.block<6, 6>(0, 0) = IMU_cov[i + 1];
-            // MatrixXd cov_inv = cov.inverse();
-            cov_inv.setIdentity();
-
-            MatrixXd r_A = tmp_A.transpose() * cov_inv * tmp_A;
-            VectorXd r_b = tmp_A.transpose() * cov_inv * tmp_b;
-
-            A.block<6, 6>(i * 3, i * 3) += r_A.topLeftCorner<6, 6>();
-            b.segment<6>(i * 3) += r_b.head<6>();
-
-            A.bottomRightCorner<3, 3>() += r_A.bottomRightCorner<3, 3>();
-            b.tail<3>() += r_b.tail<3>();
-
-            A.block<6, 3>(i * 3, n_state - 3) += r_A.topRightCorner<6, 3>();
-            A.block<3, 6>(n_state - 3, i * 3) += r_A.bottomLeftCorner<3, 6>();
-        }
-        A = A * 1000.0;
-        b = b * 1000.0;
-        x = A.ldlt().solve(b);
-        VectorXd dg = x.segment<2>(n_state - 3);
-        g0 = (g0 + lxly * dg).normalized() * g_config.estimator.g.norm();
-        // double s = x(n_state - 1);
-    }
-    g = g0;
-}
-
-bool LinearAlignment(map<double, ImageFrame> const &all_image_frame, Vector3d &g, VectorXd &x) {
-    int all_frame_count = all_image_frame.size();
-    int n_state = all_frame_count * 3 + 3 + 1;
-
-    MatrixXd A{n_state, n_state};
-    A.setZero();
-    VectorXd b{n_state};
-    b.setZero();
-
-    map<double, ImageFrame>::const_iterator frame_i;
-    map<double, ImageFrame>::const_iterator frame_j;
+  map<double, ImageFrame>::const_iterator frame_i;
+  map<double, ImageFrame>::const_iterator frame_j;
+  for (int k = 0; k < 4; k++) {
+    MatrixXd lxly(3, 2);
+    lxly = TangentBasis(g0);
     int i = 0;
-    for (frame_i = all_image_frame.begin(); next(frame_i) != all_image_frame.end(); frame_i++, i++) {
-        frame_j = next(frame_i);
+    for (frame_i = all_image_frame.begin(); next(frame_i) != all_image_frame.end();
+         frame_i++, i++) {
+      frame_j = next(frame_i);
 
-        MatrixXd tmp_A(6, 10);
-        tmp_A.setZero();
-        VectorXd tmp_b(6);
-        tmp_b.setZero();
+      MatrixXd tmp_A(6, 9);
+      tmp_A.setZero();
+      VectorXd tmp_b(6);
+      tmp_b.setZero();
 
-        double dt = frame_j->second.pre_integration->sum_dt;
+      double dt = frame_j->second.pre_integration->sum_dt;
 
-        tmp_A.block<3, 3>(0, 0) = -dt * Matrix3d::Identity();
-        tmp_A.block<3, 3>(0, 6) = frame_i->second.R.transpose() * dt * dt / 2 * Matrix3d::Identity();
-        tmp_A.block<3, 1>(0, 9) = frame_i->second.R.transpose() * (frame_j->second.T - frame_i->second.T) / 100.0;
-        tmp_b.block<3, 1>(0, 0) = frame_j->second.pre_integration->delta_p +
-                                  frame_i->second.R.transpose() * frame_j->second.R * g_config.camera.t_ic - g_config.camera.t_ic;
-        // cout << "delta_p   " <<
-        // frame_j->second.pre_integration->delta_p.transpose() << endl;
-        tmp_A.block<3, 3>(3, 0) = -Matrix3d::Identity();
-        tmp_A.block<3, 3>(3, 3) = frame_i->second.R.transpose() * frame_j->second.R;
-        tmp_A.block<3, 3>(3, 6) = frame_i->second.R.transpose() * dt * Matrix3d::Identity();
-        tmp_b.block<3, 1>(3, 0) = frame_j->second.pre_integration->delta_v;
-        // cout << "delta_v   " <<
-        // frame_j->second.pre_integration->delta_v.transpose() << endl;
+      tmp_A.block<3, 3>(0, 0) = -dt * Matrix3d::Identity();
+      tmp_A.block<3, 2>(0, 6) =
+          frame_i->second.R.transpose() * dt * dt / 2 * Matrix3d::Identity() * lxly;
+      tmp_A.block<3, 1>(0, 8) =
+          frame_i->second.R.transpose() * (frame_j->second.T - frame_i->second.T) / 100.0;
+      tmp_b.block<3, 1>(0, 0) =
+          frame_j->second.pre_integration->delta_p +
+          frame_i->second.R.transpose() * frame_j->second.R * g_config.camera.t_ic -
+          g_config.camera.t_ic - frame_i->second.R.transpose() * dt * dt / 2 * g0;
 
-        Matrix<double, 6, 6> cov_inv = Matrix<double, 6, 6>::Zero();
-        // cov.block<6, 6>(0, 0) = IMU_cov[i + 1];
-        // MatrixXd cov_inv = cov.inverse();
-        cov_inv.setIdentity();
+      tmp_A.block<3, 3>(3, 0) = -Matrix3d::Identity();
+      tmp_A.block<3, 3>(3, 3) = frame_i->second.R.transpose() * frame_j->second.R;
+      tmp_A.block<3, 2>(3, 6) = frame_i->second.R.transpose() * dt * Matrix3d::Identity() * lxly;
+      tmp_b.block<3, 1>(3, 0) = frame_j->second.pre_integration->delta_v -
+                                frame_i->second.R.transpose() * dt * Matrix3d::Identity() * g0;
 
-        MatrixXd r_A = tmp_A.transpose() * cov_inv * tmp_A;
-        VectorXd r_b = tmp_A.transpose() * cov_inv * tmp_b;
+      Matrix<double, 6, 6> cov_inv = Matrix<double, 6, 6>::Zero();
+      // cov.block<6, 6>(0, 0) = IMU_cov[i + 1];
+      // MatrixXd cov_inv = cov.inverse();
+      cov_inv.setIdentity();
 
-        A.block<6, 6>(i * 3, i * 3) += r_A.topLeftCorner<6, 6>();
-        b.segment<6>(i * 3) += r_b.head<6>();
+      MatrixXd r_A = tmp_A.transpose() * cov_inv * tmp_A;
+      VectorXd r_b = tmp_A.transpose() * cov_inv * tmp_b;
 
-        A.bottomRightCorner<4, 4>() += r_A.bottomRightCorner<4, 4>();
-        b.tail<4>() += r_b.tail<4>();
+      A.block<6, 6>(i * 3, i * 3) += r_A.topLeftCorner<6, 6>();
+      b.segment<6>(i * 3) += r_b.head<6>();
 
-        A.block<6, 4>(i * 3, n_state - 4) += r_A.topRightCorner<6, 4>();
-        A.block<4, 6>(n_state - 4, i * 3) += r_A.bottomLeftCorner<4, 6>();
+      A.bottomRightCorner<3, 3>() += r_A.bottomRightCorner<3, 3>();
+      b.tail<3>() += r_b.tail<3>();
+
+      A.block<6, 3>(i * 3, n_state - 3) += r_A.topRightCorner<6, 3>();
+      A.block<3, 6>(n_state - 3, i * 3) += r_A.bottomLeftCorner<3, 6>();
     }
     A = A * 1000.0;
     b = b * 1000.0;
     x = A.ldlt().solve(b);
-    double s = x(n_state - 1) / 100.0;
-    std::cout << "estimated scale: " << s << std::endl;
-    g = x.segment<3>(n_state - 4);
-    std::cout << " result g     " << g.norm() << " " << g.transpose() << std::endl;
-    if (fabs(g.norm() - g_config.estimator.g.norm()) > 1.0 || s < 0) {
-        return false;
-    }
-
-    RefineGravity(all_image_frame, g, x);
-    s = (x.tail<1>())(0) / 100.0;
-    (x.tail<1>())(0) = s;
-    std::cout << " refine     " << g.norm() << " " << g.transpose() << std::endl;
-    if (s < 0.0)
-        return false;
-    else
-        return true;
+    VectorXd dg = x.segment<2>(n_state - 3);
+    g0 = (g0 + lxly * dg).normalized() * g_config.estimator.g.norm();
+    // double s = x(n_state - 1);
+  }
+  g = g0;
 }
 
-bool VisualIMUAlignment(map<double, ImageFrame> const &all_image_frame, backend::SlidingWindow &sliding_window, Vector3d &g, VectorXd &x) {
-    solveGyroscopeBias(all_image_frame, sliding_window);
-    if (LinearAlignment(all_image_frame, g, x))
-        return true;
-    else
-        return false;
+bool LinearAlignment(map<double, ImageFrame> const &all_image_frame, Vector3d &g, VectorXd &x) {
+  int all_frame_count = all_image_frame.size();
+  int n_state = all_frame_count * 3 + 3 + 1;
+
+  MatrixXd A{n_state, n_state};
+  A.setZero();
+  VectorXd b{n_state};
+  b.setZero();
+
+  map<double, ImageFrame>::const_iterator frame_i;
+  map<double, ImageFrame>::const_iterator frame_j;
+  int i = 0;
+  for (frame_i = all_image_frame.begin(); next(frame_i) != all_image_frame.end(); frame_i++, i++) {
+    frame_j = next(frame_i);
+
+    MatrixXd tmp_A(6, 10);
+    tmp_A.setZero();
+    VectorXd tmp_b(6);
+    tmp_b.setZero();
+
+    double dt = frame_j->second.pre_integration->sum_dt;
+
+    tmp_A.block<3, 3>(0, 0) = -dt * Matrix3d::Identity();
+    tmp_A.block<3, 3>(0, 6) = frame_i->second.R.transpose() * dt * dt / 2 * Matrix3d::Identity();
+    tmp_A.block<3, 1>(0, 9) =
+        frame_i->second.R.transpose() * (frame_j->second.T - frame_i->second.T) / 100.0;
+    tmp_b.block<3, 1>(0, 0) =
+        frame_j->second.pre_integration->delta_p +
+        frame_i->second.R.transpose() * frame_j->second.R * g_config.camera.t_ic -
+        g_config.camera.t_ic;
+    // cout << "delta_p   " <<
+    // frame_j->second.pre_integration->delta_p.transpose() << endl;
+    tmp_A.block<3, 3>(3, 0) = -Matrix3d::Identity();
+    tmp_A.block<3, 3>(3, 3) = frame_i->second.R.transpose() * frame_j->second.R;
+    tmp_A.block<3, 3>(3, 6) = frame_i->second.R.transpose() * dt * Matrix3d::Identity();
+    tmp_b.block<3, 1>(3, 0) = frame_j->second.pre_integration->delta_v;
+    // cout << "delta_v   " <<
+    // frame_j->second.pre_integration->delta_v.transpose() << endl;
+
+    Matrix<double, 6, 6> cov_inv = Matrix<double, 6, 6>::Zero();
+    // cov.block<6, 6>(0, 0) = IMU_cov[i + 1];
+    // MatrixXd cov_inv = cov.inverse();
+    cov_inv.setIdentity();
+
+    MatrixXd r_A = tmp_A.transpose() * cov_inv * tmp_A;
+    VectorXd r_b = tmp_A.transpose() * cov_inv * tmp_b;
+
+    A.block<6, 6>(i * 3, i * 3) += r_A.topLeftCorner<6, 6>();
+    b.segment<6>(i * 3) += r_b.head<6>();
+
+    A.bottomRightCorner<4, 4>() += r_A.bottomRightCorner<4, 4>();
+    b.tail<4>() += r_b.tail<4>();
+
+    A.block<6, 4>(i * 3, n_state - 4) += r_A.topRightCorner<6, 4>();
+    A.block<4, 6>(n_state - 4, i * 3) += r_A.bottomLeftCorner<4, 6>();
+  }
+  A = A * 1000.0;
+  b = b * 1000.0;
+  x = A.ldlt().solve(b);
+  double s = x(n_state - 1) / 100.0;
+  std::cout << "estimated scale: " << s << std::endl;
+  g = x.segment<3>(n_state - 4);
+  std::cout << " result g     " << g.norm() << " " << g.transpose() << std::endl;
+  if (fabs(g.norm() - g_config.estimator.g.norm()) > 1.0 || s < 0) {
+    return false;
+  }
+
+  RefineGravity(all_image_frame, g, x);
+  s = (x.tail<1>())(0) / 100.0;
+  (x.tail<1>())(0) = s;
+  std::cout << " refine     " << g.norm() << " " << g.transpose() << std::endl;
+  if (s < 0.0)
+    return false;
+  else
+    return true;
 }
-} // namespace initial_alignment
+
+bool VisualIMUAlignment(map<double, ImageFrame> const &all_image_frame,
+                        backend::SlidingWindow &sliding_window, Vector3d &g, VectorXd &x) {
+  solveGyroscopeBias(all_image_frame, sliding_window);
+  if (LinearAlignment(all_image_frame, g, x))
+    return true;
+  else
+    return false;
+}
+}  // namespace initial_alignment

--- a/src/frontend/initialization/initial_sfm.cpp
+++ b/src/frontend/initialization/initial_sfm.cpp
@@ -2,94 +2,94 @@
 
 GlobalSFM::GlobalSFM() {}
 
-void GlobalSFM::triangulatePoint(Eigen::Matrix<double, 3, 4> &Pose0, Eigen::Matrix<double, 3, 4> &Pose1,
-                                 Vector2d &point0, Vector2d &point1, Vector3d &point_3d) {
-    Matrix4d design_matrix = Matrix4d::Zero();
-    design_matrix.row(0) = point0[0] * Pose0.row(2) - Pose0.row(0);
-    design_matrix.row(1) = point0[1] * Pose0.row(2) - Pose0.row(1);
-    design_matrix.row(2) = point1[0] * Pose1.row(2) - Pose1.row(0);
-    design_matrix.row(3) = point1[1] * Pose1.row(2) - Pose1.row(1);
-    Vector4d triangulated_point;
-    triangulated_point = design_matrix.jacobiSvd(Eigen::ComputeFullV).matrixV().rightCols<1>();
-    point_3d(0) = triangulated_point(0) / triangulated_point(3);
-    point_3d(1) = triangulated_point(1) / triangulated_point(3);
-    point_3d(2) = triangulated_point(2) / triangulated_point(3);
+void GlobalSFM::triangulatePoint(Eigen::Matrix<double, 3, 4> &Pose0,
+                                 Eigen::Matrix<double, 3, 4> &Pose1, Vector2d &point0,
+                                 Vector2d &point1, Vector3d &point_3d) {
+  Matrix4d design_matrix = Matrix4d::Zero();
+  design_matrix.row(0) = point0[0] * Pose0.row(2) - Pose0.row(0);
+  design_matrix.row(1) = point0[1] * Pose0.row(2) - Pose0.row(1);
+  design_matrix.row(2) = point1[0] * Pose1.row(2) - Pose1.row(0);
+  design_matrix.row(3) = point1[1] * Pose1.row(2) - Pose1.row(1);
+  Vector4d triangulated_point;
+  triangulated_point = design_matrix.jacobiSvd(Eigen::ComputeFullV).matrixV().rightCols<1>();
+  point_3d(0) = triangulated_point(0) / triangulated_point(3);
+  point_3d(1) = triangulated_point(1) / triangulated_point(3);
+  point_3d(2) = triangulated_point(2) / triangulated_point(3);
 }
 
-bool GlobalSFM::solveFrameByPnP(Matrix3d &R_initial, Vector3d &P_initial, int i, vector<SFMFeature> &sfm_f) {
-    vector<cv::Point2f> pts_2_vector;
-    vector<cv::Point3f> pts_3_vector;
-    for (int j = 0; j < feature_num; j++) {
-        if (sfm_f[j].state != true)
-            continue;
-        Vector2d point2d;
-        for (int k = 0; k < (int)sfm_f[j].observation.size(); k++) {
-            if (sfm_f[j].observation[k].first == i) {
-                Vector2d img_pts = sfm_f[j].observation[k].second;
-                cv::Point2f pts_2(img_pts(0), img_pts(1));
-                pts_2_vector.push_back(pts_2);
-                cv::Point3f pts_3(sfm_f[j].position[0], sfm_f[j].position[1], sfm_f[j].position[2]);
-                pts_3_vector.push_back(pts_3);
-                break;
-            }
-        }
+bool GlobalSFM::solveFrameByPnP(Matrix3d &R_initial, Vector3d &P_initial, int i,
+                                vector<SFMFeature> &sfm_f) {
+  vector<cv::Point2f> pts_2_vector;
+  vector<cv::Point3f> pts_3_vector;
+  for (int j = 0; j < feature_num; j++) {
+    if (sfm_f[j].state != true) continue;
+    Vector2d point2d;
+    for (int k = 0; k < (int)sfm_f[j].observation.size(); k++) {
+      if (sfm_f[j].observation[k].first == i) {
+        Vector2d img_pts = sfm_f[j].observation[k].second;
+        cv::Point2f pts_2(img_pts(0), img_pts(1));
+        pts_2_vector.push_back(pts_2);
+        cv::Point3f pts_3(sfm_f[j].position[0], sfm_f[j].position[1], sfm_f[j].position[2]);
+        pts_3_vector.push_back(pts_3);
+        break;
+      }
     }
-    if (int(pts_2_vector.size()) < 15) {
-        printf("unstable features tracking, please slowly move you device!\n");
-        if (int(pts_2_vector.size()) < 10)
-            return false;
-    }
-    cv::Mat r, rvec, t, D, tmp_r;
-    cv::eigen2cv(R_initial, tmp_r);
-    cv::Rodrigues(tmp_r, rvec);
-    cv::eigen2cv(P_initial, t);
-    cv::Mat K = (cv::Mat_<double>(3, 3) << 1, 0, 0, 0, 1, 0, 0, 0, 1);
-    bool pnp_succ;
-    pnp_succ = cv::solvePnP(pts_3_vector, pts_2_vector, K, D, rvec, t, 1);
-    if (!pnp_succ) {
-        return false;
-    }
-    cv::Rodrigues(rvec, r);
-    // cout << "r " << endl << r << endl;
-    MatrixXd R_pnp;
-    cv::cv2eigen(r, R_pnp);
-    MatrixXd T_pnp;
-    cv::cv2eigen(t, T_pnp);
-    R_initial = R_pnp;
-    P_initial = T_pnp;
-    return true;
+  }
+  if (int(pts_2_vector.size()) < 15) {
+    printf("unstable features tracking, please slowly move you device!\n");
+    if (int(pts_2_vector.size()) < 10) return false;
+  }
+  cv::Mat r, rvec, t, D, tmp_r;
+  cv::eigen2cv(R_initial, tmp_r);
+  cv::Rodrigues(tmp_r, rvec);
+  cv::eigen2cv(P_initial, t);
+  cv::Mat K = (cv::Mat_<double>(3, 3) << 1, 0, 0, 0, 1, 0, 0, 0, 1);
+  bool pnp_succ;
+  pnp_succ = cv::solvePnP(pts_3_vector, pts_2_vector, K, D, rvec, t, 1);
+  if (!pnp_succ) {
+    return false;
+  }
+  cv::Rodrigues(rvec, r);
+  // cout << "r " << endl << r << endl;
+  MatrixXd R_pnp;
+  cv::cv2eigen(r, R_pnp);
+  MatrixXd T_pnp;
+  cv::cv2eigen(t, T_pnp);
+  R_initial = R_pnp;
+  P_initial = T_pnp;
+  return true;
 }
 
 void GlobalSFM::triangulateTwoFrames(int frame0, Eigen::Matrix<double, 3, 4> &Pose0, int frame1,
-                                     Eigen::Matrix<double, 3, 4> &Pose1, vector<SFMFeature> &sfm_f) {
-    assert(frame0 != frame1);
-    for (int j = 0; j < feature_num; j++) {
-        if (sfm_f[j].state == true)
-            continue;
-        bool has_0 = false, has_1 = false;
-        Vector2d point0;
-        Vector2d point1;
-        for (int k = 0; k < (int)sfm_f[j].observation.size(); k++) {
-            if (sfm_f[j].observation[k].first == frame0) {
-                point0 = sfm_f[j].observation[k].second;
-                has_0 = true;
-            }
-            if (sfm_f[j].observation[k].first == frame1) {
-                point1 = sfm_f[j].observation[k].second;
-                has_1 = true;
-            }
-        }
-        if (has_0 && has_1) {
-            Vector3d point_3d;
-            triangulatePoint(Pose0, Pose1, point0, point1, point_3d);
-            sfm_f[j].state = true;
-            sfm_f[j].position[0] = point_3d(0);
-            sfm_f[j].position[1] = point_3d(1);
-            sfm_f[j].position[2] = point_3d(2);
-            // cout << "trangulated : " << frame1 << "  3d point : "  << j << "  " <<
-            // point_3d.transpose() << endl;
-        }
+                                     Eigen::Matrix<double, 3, 4> &Pose1,
+                                     vector<SFMFeature> &sfm_f) {
+  assert(frame0 != frame1);
+  for (int j = 0; j < feature_num; j++) {
+    if (sfm_f[j].state == true) continue;
+    bool has_0 = false, has_1 = false;
+    Vector2d point0;
+    Vector2d point1;
+    for (int k = 0; k < (int)sfm_f[j].observation.size(); k++) {
+      if (sfm_f[j].observation[k].first == frame0) {
+        point0 = sfm_f[j].observation[k].second;
+        has_0 = true;
+      }
+      if (sfm_f[j].observation[k].first == frame1) {
+        point1 = sfm_f[j].observation[k].second;
+        has_1 = true;
+      }
     }
+    if (has_0 && has_1) {
+      Vector3d point_3d;
+      triangulatePoint(Pose0, Pose1, point0, point1, point_3d);
+      sfm_f[j].state = true;
+      sfm_f[j].position[0] = point_3d(0);
+      sfm_f[j].position[1] = point_3d(1);
+      sfm_f[j].position[2] = point_3d(2);
+      // cout << "trangulated : " << frame1 << "  3d point : "  << j << "  " <<
+      // point_3d.transpose() << endl;
+    }
+  }
 }
 
 // 	 q w_R_cam t w_R_cam
@@ -97,167 +97,163 @@ void GlobalSFM::triangulateTwoFrames(int frame0, Eigen::Matrix<double, 3, 4> &Po
 //  c_translation cam_R_w
 // relative_q[i][j]  j_q_i
 // relative_t[i][j]  j_t_ji  (j < i)
-bool GlobalSFM::construct(int frame_num, Quaterniond *q, Vector3d *T, int l, const Matrix3d relative_R,
-                          const Vector3d relative_T, vector<SFMFeature> &sfm_f,
-                          map<int, Vector3d> &sfm_tracked_points) {
-    feature_num = sfm_f.size();
-    // cout << "set 0 and " << l << " as known " << endl;
-    // have relative_r relative_t
-    // intial two view
-    q[l].w() = 1;
-    q[l].x() = 0;
-    q[l].y() = 0;
-    q[l].z() = 0;
-    T[l].setZero();
-    q[frame_num - 1] = q[l] * Quaterniond(relative_R);
-    T[frame_num - 1] = relative_T;
-    // cout << "init q_l " << q[l].w() << " " << q[l].vec().transpose() << endl;
-    // cout << "init t_l " << T[l].transpose() << endl;
+bool GlobalSFM::construct(int frame_num, Quaterniond *q, Vector3d *T, int l,
+                          const Matrix3d relative_R, const Vector3d relative_T,
+                          vector<SFMFeature> &sfm_f, map<int, Vector3d> &sfm_tracked_points) {
+  feature_num = sfm_f.size();
+  // cout << "set 0 and " << l << " as known " << endl;
+  // have relative_r relative_t
+  // intial two view
+  q[l].w() = 1;
+  q[l].x() = 0;
+  q[l].y() = 0;
+  q[l].z() = 0;
+  T[l].setZero();
+  q[frame_num - 1] = q[l] * Quaterniond(relative_R);
+  T[frame_num - 1] = relative_T;
+  // cout << "init q_l " << q[l].w() << " " << q[l].vec().transpose() << endl;
+  // cout << "init t_l " << T[l].transpose() << endl;
 
-    // rotate to cam frame
-    Matrix3d c_Rotation[frame_num];
-    Vector3d c_Translation[frame_num];
-    Quaterniond c_Quat[frame_num];
-    double c_rotation[frame_num][4];
-    double c_translation[frame_num][3];
-    Eigen::Matrix<double, 3, 4> Pose[frame_num];
+  // rotate to cam frame
+  Matrix3d c_Rotation[frame_num];
+  Vector3d c_Translation[frame_num];
+  Quaterniond c_Quat[frame_num];
+  double c_rotation[frame_num][4];
+  double c_translation[frame_num][3];
+  Eigen::Matrix<double, 3, 4> Pose[frame_num];
 
-    c_Quat[l] = q[l].inverse();
-    c_Rotation[l] = c_Quat[l].toRotationMatrix();
-    c_Translation[l] = -1 * (c_Rotation[l] * T[l]);
-    Pose[l].block<3, 3>(0, 0) = c_Rotation[l];
-    Pose[l].block<3, 1>(0, 3) = c_Translation[l];
+  c_Quat[l] = q[l].inverse();
+  c_Rotation[l] = c_Quat[l].toRotationMatrix();
+  c_Translation[l] = -1 * (c_Rotation[l] * T[l]);
+  Pose[l].block<3, 3>(0, 0) = c_Rotation[l];
+  Pose[l].block<3, 1>(0, 3) = c_Translation[l];
 
-    c_Quat[frame_num - 1] = q[frame_num - 1].inverse();
-    c_Rotation[frame_num - 1] = c_Quat[frame_num - 1].toRotationMatrix();
-    c_Translation[frame_num - 1] = -1 * (c_Rotation[frame_num - 1] * T[frame_num - 1]);
-    Pose[frame_num - 1].block<3, 3>(0, 0) = c_Rotation[frame_num - 1];
-    Pose[frame_num - 1].block<3, 1>(0, 3) = c_Translation[frame_num - 1];
+  c_Quat[frame_num - 1] = q[frame_num - 1].inverse();
+  c_Rotation[frame_num - 1] = c_Quat[frame_num - 1].toRotationMatrix();
+  c_Translation[frame_num - 1] = -1 * (c_Rotation[frame_num - 1] * T[frame_num - 1]);
+  Pose[frame_num - 1].block<3, 3>(0, 0) = c_Rotation[frame_num - 1];
+  Pose[frame_num - 1].block<3, 1>(0, 3) = c_Translation[frame_num - 1];
 
-    // 1: trangulate between l ----- frame_num - 1
-    // 2: solve pnp l + 1; trangulate l + 1 ------- frame_num - 1;
-    for (int i = l; i < frame_num - 1; i++) {
-        // solve pnp
-        if (i > l) {
-            Matrix3d R_initial = c_Rotation[i - 1];
-            Vector3d P_initial = c_Translation[i - 1];
-            if (!solveFrameByPnP(R_initial, P_initial, i, sfm_f))
-                return false;
-            c_Rotation[i] = R_initial;
-            c_Translation[i] = P_initial;
-            c_Quat[i] = c_Rotation[i];
-            Pose[i].block<3, 3>(0, 0) = c_Rotation[i];
-            Pose[i].block<3, 1>(0, 3) = c_Translation[i];
-        }
-
-        // triangulate point based on the solve pnp result
-        triangulateTwoFrames(i, Pose[i], frame_num - 1, Pose[frame_num - 1], sfm_f);
-    }
-    // 3: triangulate l-----l+1 l+2 ... frame_num -2
-    for (int i = l + 1; i < frame_num - 1; i++)
-        triangulateTwoFrames(l, Pose[l], i, Pose[i], sfm_f);
-    // 4: solve pnp l-1; triangulate l-1 ----- l
-    //             l-2              l-2 ----- l
-    for (int i = l - 1; i >= 0; i--) {
-        // solve pnp
-        Matrix3d R_initial = c_Rotation[i + 1];
-        Vector3d P_initial = c_Translation[i + 1];
-        if (!solveFrameByPnP(R_initial, P_initial, i, sfm_f))
-            return false;
-        c_Rotation[i] = R_initial;
-        c_Translation[i] = P_initial;
-        c_Quat[i] = c_Rotation[i];
-        Pose[i].block<3, 3>(0, 0) = c_Rotation[i];
-        Pose[i].block<3, 1>(0, 3) = c_Translation[i];
-        // triangulate
-        triangulateTwoFrames(i, Pose[i], l, Pose[l], sfm_f);
-    }
-    // 5: triangulate all other points
-    for (int j = 0; j < feature_num; j++) {
-        if (sfm_f[j].state == true)
-            continue;
-        if ((int)sfm_f[j].observation.size() >= 2) {
-            Vector2d point0, point1;
-            int frame_0 = sfm_f[j].observation[0].first;
-            point0 = sfm_f[j].observation[0].second;
-            int frame_1 = sfm_f[j].observation.back().first;
-            point1 = sfm_f[j].observation.back().second;
-            Vector3d point_3d;
-            triangulatePoint(Pose[frame_0], Pose[frame_1], point0, point1, point_3d);
-            sfm_f[j].state = true;
-            sfm_f[j].position[0] = point_3d(0);
-            sfm_f[j].position[1] = point_3d(1);
-            sfm_f[j].position[2] = point_3d(2);
-            // cout << "trangulated : " << frame_0 << " " << frame_1 << "  3d point :
-            // "  << j << "  " << point_3d.transpose() << endl;
-        }
+  // 1: trangulate between l ----- frame_num - 1
+  // 2: solve pnp l + 1; trangulate l + 1 ------- frame_num - 1;
+  for (int i = l; i < frame_num - 1; i++) {
+    // solve pnp
+    if (i > l) {
+      Matrix3d R_initial = c_Rotation[i - 1];
+      Vector3d P_initial = c_Translation[i - 1];
+      if (!solveFrameByPnP(R_initial, P_initial, i, sfm_f)) return false;
+      c_Rotation[i] = R_initial;
+      c_Translation[i] = P_initial;
+      c_Quat[i] = c_Rotation[i];
+      Pose[i].block<3, 3>(0, 0) = c_Rotation[i];
+      Pose[i].block<3, 1>(0, 3) = c_Translation[i];
     }
 
-    // full BA
-    ceres::Problem problem;
-    ceres::LocalParameterization *local_parameterization = new ceres::QuaternionParameterization();
-    // cout << " begin full BA " << endl;
-    for (int i = 0; i < frame_num; i++) {
-        // double array for ceres
-        c_translation[i][0] = c_Translation[i].x();
-        c_translation[i][1] = c_Translation[i].y();
-        c_translation[i][2] = c_Translation[i].z();
-        c_rotation[i][0] = c_Quat[i].w();
-        c_rotation[i][1] = c_Quat[i].x();
-        c_rotation[i][2] = c_Quat[i].y();
-        c_rotation[i][3] = c_Quat[i].z();
-        problem.AddParameterBlock(c_rotation[i], 4, local_parameterization);
-        problem.AddParameterBlock(c_translation[i], 3);
-        if (i == l) {
-            problem.SetParameterBlockConstant(c_rotation[i]);
-        }
-        if (i == l || i == frame_num - 1) {
-            problem.SetParameterBlockConstant(c_translation[i]);
-        }
+    // triangulate point based on the solve pnp result
+    triangulateTwoFrames(i, Pose[i], frame_num - 1, Pose[frame_num - 1], sfm_f);
+  }
+  // 3: triangulate l-----l+1 l+2 ... frame_num -2
+  for (int i = l + 1; i < frame_num - 1; i++) triangulateTwoFrames(l, Pose[l], i, Pose[i], sfm_f);
+  // 4: solve pnp l-1; triangulate l-1 ----- l
+  //             l-2              l-2 ----- l
+  for (int i = l - 1; i >= 0; i--) {
+    // solve pnp
+    Matrix3d R_initial = c_Rotation[i + 1];
+    Vector3d P_initial = c_Translation[i + 1];
+    if (!solveFrameByPnP(R_initial, P_initial, i, sfm_f)) return false;
+    c_Rotation[i] = R_initial;
+    c_Translation[i] = P_initial;
+    c_Quat[i] = c_Rotation[i];
+    Pose[i].block<3, 3>(0, 0) = c_Rotation[i];
+    Pose[i].block<3, 1>(0, 3) = c_Translation[i];
+    // triangulate
+    triangulateTwoFrames(i, Pose[i], l, Pose[l], sfm_f);
+  }
+  // 5: triangulate all other points
+  for (int j = 0; j < feature_num; j++) {
+    if (sfm_f[j].state == true) continue;
+    if ((int)sfm_f[j].observation.size() >= 2) {
+      Vector2d point0, point1;
+      int frame_0 = sfm_f[j].observation[0].first;
+      point0 = sfm_f[j].observation[0].second;
+      int frame_1 = sfm_f[j].observation.back().first;
+      point1 = sfm_f[j].observation.back().second;
+      Vector3d point_3d;
+      triangulatePoint(Pose[frame_0], Pose[frame_1], point0, point1, point_3d);
+      sfm_f[j].state = true;
+      sfm_f[j].position[0] = point_3d(0);
+      sfm_f[j].position[1] = point_3d(1);
+      sfm_f[j].position[2] = point_3d(2);
+      // cout << "trangulated : " << frame_0 << " " << frame_1 << "  3d point :
+      // "  << j << "  " << point_3d.transpose() << endl;
     }
+  }
 
-    for (int i = 0; i < feature_num; i++) {
-        if (sfm_f[i].state != true)
-            continue;
-        for (int j = 0; j < int(sfm_f[i].observation.size()); j++) {
-            int l = sfm_f[i].observation[j].first;
-            ceres::CostFunction *cost_function =
-                ReprojectionError3D::Create(sfm_f[i].observation[j].second.x(), sfm_f[i].observation[j].second.y());
+  // full BA
+  ceres::Problem problem;
+  ceres::LocalParameterization *local_parameterization = new ceres::QuaternionParameterization();
+  // cout << " begin full BA " << endl;
+  for (int i = 0; i < frame_num; i++) {
+    // double array for ceres
+    c_translation[i][0] = c_Translation[i].x();
+    c_translation[i][1] = c_Translation[i].y();
+    c_translation[i][2] = c_Translation[i].z();
+    c_rotation[i][0] = c_Quat[i].w();
+    c_rotation[i][1] = c_Quat[i].x();
+    c_rotation[i][2] = c_Quat[i].y();
+    c_rotation[i][3] = c_Quat[i].z();
+    problem.AddParameterBlock(c_rotation[i], 4, local_parameterization);
+    problem.AddParameterBlock(c_translation[i], 3);
+    if (i == l) {
+      problem.SetParameterBlockConstant(c_rotation[i]);
+    }
+    if (i == l || i == frame_num - 1) {
+      problem.SetParameterBlockConstant(c_translation[i]);
+    }
+  }
 
-            problem.AddResidualBlock(cost_function, NULL, c_rotation[l], c_translation[l], sfm_f[i].position);
-        }
+  for (int i = 0; i < feature_num; i++) {
+    if (sfm_f[i].state != true) continue;
+    for (int j = 0; j < int(sfm_f[i].observation.size()); j++) {
+      int l = sfm_f[i].observation[j].first;
+      ceres::CostFunction *cost_function = ReprojectionError3D::Create(
+          sfm_f[i].observation[j].second.x(), sfm_f[i].observation[j].second.y());
+
+      problem.AddResidualBlock(cost_function, NULL, c_rotation[l], c_translation[l],
+                               sfm_f[i].position);
     }
-    ceres::Solver::Options options;
-    options.linear_solver_type = ceres::DENSE_SCHUR;
-    // options.minimizer_progress_to_stdout = true;
-    options.max_solver_time_in_seconds = 0.2;
-    ceres::Solver::Summary summary;
-    ceres::Solve(options, &problem, &summary);
-    // std::cout << summary.BriefReport() << "\n";
-    if (summary.termination_type == ceres::CONVERGENCE || summary.final_cost < 5e-03) {
-        // cout << "vision only BA converge" << endl;
-    } else {
-        // cout << "vision only BA not converge " << endl;
-        return false;
-    }
-    for (int i = 0; i < frame_num; i++) {
-        q[i].w() = c_rotation[i][0];
-        q[i].x() = c_rotation[i][1];
-        q[i].y() = c_rotation[i][2];
-        q[i].z() = c_rotation[i][3];
-        q[i] = q[i].inverse();
-        // cout << "final  q" << " i " << i <<"  " <<q[i].w() << "  " <<
-        // q[i].vec().transpose() << endl;
-    }
-    for (int i = 0; i < frame_num; i++) {
-        T[i] = -1 * (q[i] * Vector3d(c_translation[i][0], c_translation[i][1], c_translation[i][2]));
-        // cout << "final  t" << " i " << i <<"  " << T[i](0) <<"  "<< T[i](1) <<"
-        // "<< T[i](2) << endl;
-    }
-    for (int i = 0; i < (int)sfm_f.size(); i++) {
-        if (sfm_f[i].state)
-            sfm_tracked_points[sfm_f[i].id] =
-                Vector3d(sfm_f[i].position[0], sfm_f[i].position[1], sfm_f[i].position[2]);
-    }
-    return true;
+  }
+  ceres::Solver::Options options;
+  options.linear_solver_type = ceres::DENSE_SCHUR;
+  // options.minimizer_progress_to_stdout = true;
+  options.max_solver_time_in_seconds = 0.2;
+  ceres::Solver::Summary summary;
+  ceres::Solve(options, &problem, &summary);
+  // std::cout << summary.BriefReport() << "\n";
+  if (summary.termination_type == ceres::CONVERGENCE || summary.final_cost < 5e-03) {
+    // cout << "vision only BA converge" << endl;
+  } else {
+    // cout << "vision only BA not converge " << endl;
+    return false;
+  }
+  for (int i = 0; i < frame_num; i++) {
+    q[i].w() = c_rotation[i][0];
+    q[i].x() = c_rotation[i][1];
+    q[i].y() = c_rotation[i][2];
+    q[i].z() = c_rotation[i][3];
+    q[i] = q[i].inverse();
+    // cout << "final  q" << " i " << i <<"  " <<q[i].w() << "  " <<
+    // q[i].vec().transpose() << endl;
+  }
+  for (int i = 0; i < frame_num; i++) {
+    T[i] = -1 * (q[i] * Vector3d(c_translation[i][0], c_translation[i][1], c_translation[i][2]));
+    // cout << "final  t" << " i " << i <<"  " << T[i](0) <<"  "<< T[i](1) <<"
+    // "<< T[i](2) << endl;
+  }
+  for (int i = 0; i < (int)sfm_f.size(); i++) {
+    if (sfm_f[i].state)
+      sfm_tracked_points[sfm_f[i].id] =
+          Vector3d(sfm_f[i].position[0], sfm_f[i].position[1], sfm_f[i].position[2]);
+  }
+  return true;
 }

--- a/src/frontend/initialization/initializer.cpp
+++ b/src/frontend/initialization/initializer.cpp
@@ -1,10 +1,11 @@
 #include "frontend/initialization/initializer.h"
+
 #include "frontend/initialization/initial_alignment.h"
 
-
-Initializer::Initializer(backend::SlidingWindow* sliding_window, FeatureManager* feature_manager, MotionEstimator* motion_estimator,
+Initializer::Initializer(backend::SlidingWindow* sliding_window, FeatureManager* feature_manager,
+                         MotionEstimator* motion_estimator,
                          std::map<double, ImageFrame>* all_image_frame, int* frame_count,
-                         MarginalizationFlag* marginalization_flag, Vector3d* g, 
+                         MarginalizationFlag* marginalization_flag, Vector3d* g,
                          const Matrix3d* r_ic, const Vector3d* t_ic)
     : sliding_window_(sliding_window),
       feature_manager_(feature_manager),
@@ -17,336 +18,339 @@ Initializer::Initializer(backend::SlidingWindow* sliding_window, FeatureManager*
       t_ic_(t_ic) {}
 
 bool Initializer::initialize() {
-    // Check IMU excitation for initialization readiness
-    if (!checkIMUExcitation(0.25)) {
-        return false;
-    }
+  // Check IMU excitation for initialization readiness
+  if (!checkIMUExcitation(0.25)) {
+    return false;
+  }
 
-    // Perform global SfM reconstruction
-    if (!solveGlobalSfM()) {
-        std::cout << "Global SfM reconstruction failed!" << std::endl;
-        return false;
-    }
+  // Perform global SfM reconstruction
+  if (!solveGlobalSfM()) {
+    std::cout << "Global SfM reconstruction failed!" << std::endl;
+    return false;
+  }
 
-    if (visualInitialAlign()) {
-        std::cout << "visualInertialAlign() success!" << std::endl;
-        return true;
-    } else {
-        std::cout << "misalign visual structure with IMU" << std::endl;
-        return false;
-    }
+  if (visualInitialAlign()) {
+    std::cout << "visualInertialAlign() success!" << std::endl;
+    return true;
+  } else {
+    std::cout << "misalign visual structure with IMU" << std::endl;
+    return false;
+  }
 }
 
 bool Initializer::checkIMUExcitation(double threshold) {
-    if (all_image_frame_->size() <= 1) {
-        std::cout << "Not enough image frames for IMU excitation check!" << std::endl;
-        return false;
+  if (all_image_frame_->size() <= 1) {
+    std::cout << "Not enough image frames for IMU excitation check!" << std::endl;
+    return false;
+  }
+
+  // Calculate average gravity vector from all frames
+  Vector3d sum_g = Vector3d::Zero();
+  int valid_frames = 0;
+
+  for (auto frame_it = all_image_frame_->begin(); frame_it != all_image_frame_->end(); frame_it++) {
+    if (frame_it == all_image_frame_->begin()) continue;  // Skip first frame
+
+    if (frame_it->second.pre_integration != nullptr) {
+      double dt = frame_it->second.pre_integration->sum_dt;
+      if (dt > 0) {
+        Vector3d tmp_g = frame_it->second.pre_integration->delta_v / dt;
+        sum_g += tmp_g;
+        valid_frames++;
+      }
     }
+  }
 
-    // Calculate average gravity vector from all frames
-    Vector3d sum_g = Vector3d::Zero();
-    int valid_frames = 0;
+  if (valid_frames == 0) {
+    std::cout << "No valid frames with pre-integration data!" << std::endl;
+    return false;
+  }
 
-    for (auto frame_it = all_image_frame_->begin(); frame_it != all_image_frame_->end(); frame_it++) {
-        if (frame_it == all_image_frame_->begin())
-            continue; // Skip first frame
+  Vector3d aver_g = sum_g / valid_frames;
 
-        if (frame_it->second.pre_integration != nullptr) {
-            double dt = frame_it->second.pre_integration->sum_dt;
-            if (dt > 0) {
-                Vector3d tmp_g = frame_it->second.pre_integration->delta_v / dt;
-                sum_g += tmp_g;
-                valid_frames++;
-            }
-        }
+  // Calculate variance of gravity vectors
+  double variance = 0.0;
+  int variance_count = 0;
+
+  for (auto frame_it = all_image_frame_->begin(); frame_it != all_image_frame_->end(); frame_it++) {
+    if (frame_it == all_image_frame_->begin()) continue;  // Skip first frame
+
+    if (frame_it->second.pre_integration != nullptr) {
+      double dt = frame_it->second.pre_integration->sum_dt;
+      if (dt > 0) {
+        Vector3d tmp_g = frame_it->second.pre_integration->delta_v / dt;
+        Vector3d diff = tmp_g - aver_g;
+        variance += diff.transpose() * diff;
+        variance_count++;
+      }
     }
+  }
 
-    if (valid_frames == 0) {
-        std::cout << "No valid frames with pre-integration data!" << std::endl;
-        return false;
-    }
+  if (variance_count <= 1) {
+    std::cout << "Not enough frames for variance calculation!" << std::endl;
+    return false;
+  }
 
-    Vector3d aver_g = sum_g / valid_frames;
+  double std_deviation = sqrt(variance / (variance_count - 1));
 
-    // Calculate variance of gravity vectors
-    double variance = 0.0;
-    int variance_count = 0;
+  std::cout << "IMU excitation check: std_deviation = " << std_deviation
+            << ", threshold = " << threshold << std::endl;
 
-    for (auto frame_it = all_image_frame_->begin(); frame_it != all_image_frame_->end(); frame_it++) {
-        if (frame_it == all_image_frame_->begin())
-            continue; // Skip first frame
-
-        if (frame_it->second.pre_integration != nullptr) {
-            double dt = frame_it->second.pre_integration->sum_dt;
-            if (dt > 0) {
-                Vector3d tmp_g = frame_it->second.pre_integration->delta_v / dt;
-                Vector3d diff = tmp_g - aver_g;
-                variance += diff.transpose() * diff;
-                variance_count++;
-            }
-        }
-    }
-
-    if (variance_count <= 1) {
-        std::cout << "Not enough frames for variance calculation!" << std::endl;
-        return false;
-    }
-
-    double std_deviation = sqrt(variance / (variance_count - 1));
-
-    std::cout << "IMU excitation check: std_deviation = " << std_deviation << ", threshold = " << threshold << std::endl;
-
-    if (std_deviation < threshold) {
-        std::cout << "IMU excitation not enough! Please move the device with more "
-                 "rotation." << std::endl;
-        return false;
-    } else {
-        std::cout << "IMU excitation sufficient for initialization." << std::endl;
-        return true;
-    }
+  if (std_deviation < threshold) {
+    std::cout << "IMU excitation not enough! Please move the device with more "
+                 "rotation."
+              << std::endl;
+    return false;
+  } else {
+    std::cout << "IMU excitation sufficient for initialization." << std::endl;
+    return true;
+  }
 }
-
 
 bool Initializer::solveGlobalSfM() {
-    std::cout << "Starting global SfM reconstruction..." << std::endl;
+  std::cout << "Starting global SfM reconstruction..." << std::endl;
 
-    map<int, Vector3d> sfm_tracked_points;
+  map<int, Vector3d> sfm_tracked_points;
 
-    // Prepare SfM features from feature manager
-    vector<SFMFeature> sfm_f;
-    for (auto &it_per_id : feature_manager_->feature) {
-        int imu_j = it_per_id.start_frame - 1;
-        SFMFeature tmp_feature;
-        tmp_feature.state = false;
-        tmp_feature.id = it_per_id.feature_id;
-        tmp_feature.position[0] = 0.0;
-        tmp_feature.position[1] = 0.0;
-        tmp_feature.position[2] = 0.0;
-        tmp_feature.depth = 0.0;
-        for (auto &it_per_frame : it_per_id.feature_per_frame) {
-            imu_j++;
-            Vector3d pts_j = it_per_frame.point;
-            tmp_feature.observation.push_back(make_pair(imu_j, Eigen::Vector2d{pts_j.x(), pts_j.y()}));
-        }
-        sfm_f.push_back(tmp_feature);
+  // Prepare SfM features from feature manager
+  vector<SFMFeature> sfm_f;
+  for (auto& it_per_id : feature_manager_->feature) {
+    int imu_j = it_per_id.start_frame - 1;
+    SFMFeature tmp_feature;
+    tmp_feature.state = false;
+    tmp_feature.id = it_per_id.feature_id;
+    tmp_feature.position[0] = 0.0;
+    tmp_feature.position[1] = 0.0;
+    tmp_feature.position[2] = 0.0;
+    tmp_feature.depth = 0.0;
+    for (auto& it_per_frame : it_per_id.feature_per_frame) {
+      imu_j++;
+      Vector3d pts_j = it_per_frame.point;
+      tmp_feature.observation.push_back(make_pair(imu_j, Eigen::Vector2d{pts_j.x(), pts_j.y()}));
     }
+    sfm_f.push_back(tmp_feature);
+  }
 
-    std::cout << "Prepared " << sfm_f.size() << " SfM features for reconstruction" << std::endl;
+  std::cout << "Prepared " << sfm_f.size() << " SfM features for reconstruction" << std::endl;
 
-    // Find relative pose between frames
-    Matrix3d relative_R;
-    Vector3d relative_T;
-    int index;
-    if (!relativePose(relative_R, relative_T, index)) {
-        std::cout << "Global SfM failed: Not enough features or parallax. Move device "
-                 "around!" << std::endl;
-        return false;
-    }
+  // Find relative pose between frames
+  Matrix3d relative_R;
+  Vector3d relative_T;
+  int index;
+  if (!relativePose(relative_R, relative_T, index)) {
+    std::cout << "Global SfM failed: Not enough features or parallax. Move device "
+                 "around!"
+              << std::endl;
+    return false;
+  }
 
-    std::cout << "Found relative pose between frame " << index << " and latest frame" << std::endl;
+  std::cout << "Found relative pose between frame " << index << " and latest frame" << std::endl;
 
-    // Perform global SfM reconstruction
-    Quaterniond Q[(*frame_count_) + 1];
-    Vector3d T[(*frame_count_) + 1];
+  // Perform global SfM reconstruction
+  Quaterniond Q[(*frame_count_) + 1];
+  Vector3d T[(*frame_count_) + 1];
 
-    GlobalSFM sfm;
-    if (!sfm.construct((*frame_count_) + 1, Q, T, index, relative_R, relative_T, sfm_f, sfm_tracked_points)) {
-        std::cout << "Global SfM reconstruction failed!" << std::endl;
-        *marginalization_flag_ = MarginalizationFlag::MARGIN_OLD_KEYFRAME;
-        return false;
-    }
+  GlobalSFM sfm;
+  if (!sfm.construct((*frame_count_) + 1, Q, T, index, relative_R, relative_T, sfm_f,
+                     sfm_tracked_points)) {
+    std::cout << "Global SfM reconstruction failed!" << std::endl;
+    *marginalization_flag_ = MarginalizationFlag::MARGIN_OLD_KEYFRAME;
+    return false;
+  }
 
-    std::cout << "Global SfM successful! Reconstructed " << sfm_tracked_points.size() << " 3D points" << std::endl;
+  std::cout << "Global SfM successful! Reconstructed " << sfm_tracked_points.size() << " 3D points"
+            << std::endl;
 
-    // Solve PnP for all frames to get camera poses
-    if (!solvePnPForAllFrames(Q, T, sfm_tracked_points)) {
-        std::cout << "PnP solving failed for non-keyframes!" << std::endl;
-        return false;
-    }
+  // Solve PnP for all frames to get camera poses
+  if (!solvePnPForAllFrames(Q, T, sfm_tracked_points)) {
+    std::cout << "PnP solving failed for non-keyframes!" << std::endl;
+    return false;
+  }
 
-    std::cout << "Global SfM completed" << std::endl;
-    return true;
+  std::cout << "Global SfM completed" << std::endl;
+  return true;
 }
 
-bool Initializer::relativePose(Matrix3d &relative_R, Vector3d &relative_T, int &index) {
-    // find previous frame which contians enough correspondance and parallex with
-    // newest frame
-    for (int i = 0; i < WINDOW_SIZE; i++) {
-        vector<pair<Vector3d, Vector3d>> corres;
-        corres = feature_manager_->getCorresponding(i, WINDOW_SIZE);
+bool Initializer::relativePose(Matrix3d& relative_R, Vector3d& relative_T, int& index) {
+  // find previous frame which contians enough correspondance and parallex with
+  // newest frame
+  for (int i = 0; i < WINDOW_SIZE; i++) {
+    vector<pair<Vector3d, Vector3d>> corres;
+    corres = feature_manager_->getCorresponding(i, WINDOW_SIZE);
 
-        if (corres.size() > 20) {
-            double sum_parallax = 0;
-            double average_parallax;
-            for (int j = 0; j < int(corres.size()); j++) {
-                Vector2d pts_0(corres[j].first(0), corres[j].first(1));
-                Vector2d pts_1(corres[j].second(0), corres[j].second(1));
-                double parallax = (pts_0 - pts_1).norm();
-                sum_parallax = sum_parallax + parallax;
-            }
+    if (corres.size() > 20) {
+      double sum_parallax = 0;
+      double average_parallax;
+      for (int j = 0; j < int(corres.size()); j++) {
+        Vector2d pts_0(corres[j].first(0), corres[j].first(1));
+        Vector2d pts_1(corres[j].second(0), corres[j].second(1));
+        double parallax = (pts_0 - pts_1).norm();
+        sum_parallax = sum_parallax + parallax;
+      }
 
-            average_parallax = 1.0 * sum_parallax / int(corres.size());
-            if (motion_estimator_->solveRelativeRT(corres, relative_R, relative_T)) {
-                index = i;
-                std::cout << "average_parallax " << average_parallax * 460 << " choose index " << index << " and newest frame to triangulate "
-                          "the whole structure" << std::endl;
-                return true;
-            }
-        }
+      average_parallax = 1.0 * sum_parallax / int(corres.size());
+      if (motion_estimator_->solveRelativeRT(corres, relative_R, relative_T)) {
+        index = i;
+        std::cout << "average_parallax " << average_parallax * 460 << " choose index " << index
+                  << " and newest frame to triangulate "
+                     "the whole structure"
+                  << std::endl;
+        return true;
+      }
     }
-    return false;
+  }
+  return false;
 }
 
 bool Initializer::solvePnPForAllFrames(const Quaterniond Q[], const Vector3d T[],
-                                     const map<int, Vector3d> &sfm_tracked_points) {
+                                       const map<int, Vector3d>& sfm_tracked_points) {
+  map<double, ImageFrame>::iterator frame_it;
+  map<int, Vector3d>::const_iterator it;
+  frame_it = all_image_frame_->begin();
 
-    map<double, ImageFrame>::iterator frame_it;
-    map<int, Vector3d>::const_iterator it;
-    frame_it = all_image_frame_->begin();
-
-    for (int i = 0; frame_it != all_image_frame_->end(); frame_it++) {
-        // Handle keyframes (those with SfM solutions)
-        if ((frame_it->first) == (*sliding_window_)[i].timestamp) {
-            frame_it->second.is_key_frame = true;
-            auto temp = Q[i].toRotationMatrix() * (*r_ic_).transpose();
-            frame_it->second.R = temp;
-            frame_it->second.T = T[i];
-            i++;
-            continue;
-        }
-
-        // Handle frame timing
-        if ((frame_it->first) > (*sliding_window_)[i].timestamp) {
-            i++;
-        }
-
-        // Solve PnP for non-keyframes
-        Matrix3d R_initial = (Q[i].inverse()).toRotationMatrix();
-        Vector3d P_initial = -R_initial * T[i];
-
-        cv::Mat r, rvec, t, D, tmp_r;
-        cv::eigen2cv(R_initial, tmp_r);
-        cv::Rodrigues(tmp_r, rvec);
-        cv::eigen2cv(P_initial, t);
-
-        frame_it->second.is_key_frame = false;
-
-        // Collect 3D-2D correspondences
-        vector<cv::Point3f> pts_3_vector;
-        vector<cv::Point2f> pts_2_vector;
-
-        for (auto &id_pts : frame_it->second.points) {
-            int feature_id = id_pts.first;
-            for (auto &i_p : id_pts.second) {
-                it = sfm_tracked_points.find(feature_id);
-                if (it != sfm_tracked_points.end()) {
-                    Vector3d world_pts = it->second;
-                    cv::Point3f pts_3(world_pts(0), world_pts(1), world_pts(2));
-                    pts_3_vector.push_back(pts_3);
-                    Vector2d img_pts = i_p.head<2>();
-                    cv::Point2f pts_2(img_pts(0), img_pts(1));
-                    pts_2_vector.push_back(pts_2);
-                }
-            }
-        }
-
-        // Check if we have enough points for PnP
-        if (pts_3_vector.size() < 6) {
-            std::cout << "Not enough 3D-2D correspondences (" << pts_3_vector.size() << ") for PnP at frame " << frame_it->first << std::endl;
-            return false;
-        }
-
-        // Solve PnP
-        cv::Mat K = cv::Mat::eye(3, 3, CV_64F);
-        if (!cv::solvePnP(pts_3_vector, pts_2_vector, K, D, rvec, t, 1)) {
-            std::cout << "PnP solving failed for frame " << frame_it->first << std::endl;
-            return false;
-        }
-
-        // Convert result back to pose
-        cv::Rodrigues(rvec, r);
-        MatrixXd R_pnp, tmp_R_pnp;
-        cv::cv2eigen(r, tmp_R_pnp);
-        R_pnp = tmp_R_pnp.transpose();
-        MatrixXd T_pnp;
-        cv::cv2eigen(t, T_pnp);
-        T_pnp = R_pnp * (-T_pnp);
-
-        frame_it->second.R = R_pnp * (*r_ic_).transpose();
-        frame_it->second.T = T_pnp;
+  for (int i = 0; frame_it != all_image_frame_->end(); frame_it++) {
+    // Handle keyframes (those with SfM solutions)
+    if ((frame_it->first) == (*sliding_window_)[i].timestamp) {
+      frame_it->second.is_key_frame = true;
+      auto temp = Q[i].toRotationMatrix() * (*r_ic_).transpose();
+      frame_it->second.R = temp;
+      frame_it->second.T = T[i];
+      i++;
+      continue;
     }
 
-    std::cout << "PnP solving completed for all frames" << std::endl;
-    return true;
+    // Handle frame timing
+    if ((frame_it->first) > (*sliding_window_)[i].timestamp) {
+      i++;
+    }
+
+    // Solve PnP for non-keyframes
+    Matrix3d R_initial = (Q[i].inverse()).toRotationMatrix();
+    Vector3d P_initial = -R_initial * T[i];
+
+    cv::Mat r, rvec, t, D, tmp_r;
+    cv::eigen2cv(R_initial, tmp_r);
+    cv::Rodrigues(tmp_r, rvec);
+    cv::eigen2cv(P_initial, t);
+
+    frame_it->second.is_key_frame = false;
+
+    // Collect 3D-2D correspondences
+    vector<cv::Point3f> pts_3_vector;
+    vector<cv::Point2f> pts_2_vector;
+
+    for (auto& id_pts : frame_it->second.points) {
+      int feature_id = id_pts.first;
+      for (auto& i_p : id_pts.second) {
+        it = sfm_tracked_points.find(feature_id);
+        if (it != sfm_tracked_points.end()) {
+          Vector3d world_pts = it->second;
+          cv::Point3f pts_3(world_pts(0), world_pts(1), world_pts(2));
+          pts_3_vector.push_back(pts_3);
+          Vector2d img_pts = i_p.head<2>();
+          cv::Point2f pts_2(img_pts(0), img_pts(1));
+          pts_2_vector.push_back(pts_2);
+        }
+      }
+    }
+
+    // Check if we have enough points for PnP
+    if (pts_3_vector.size() < 6) {
+      std::cout << "Not enough 3D-2D correspondences (" << pts_3_vector.size()
+                << ") for PnP at frame " << frame_it->first << std::endl;
+      return false;
+    }
+
+    // Solve PnP
+    cv::Mat K = cv::Mat::eye(3, 3, CV_64F);
+    if (!cv::solvePnP(pts_3_vector, pts_2_vector, K, D, rvec, t, 1)) {
+      std::cout << "PnP solving failed for frame " << frame_it->first << std::endl;
+      return false;
+    }
+
+    // Convert result back to pose
+    cv::Rodrigues(rvec, r);
+    MatrixXd R_pnp, tmp_R_pnp;
+    cv::cv2eigen(r, tmp_R_pnp);
+    R_pnp = tmp_R_pnp.transpose();
+    MatrixXd T_pnp;
+    cv::cv2eigen(t, T_pnp);
+    T_pnp = R_pnp * (-T_pnp);
+
+    frame_it->second.R = R_pnp * (*r_ic_).transpose();
+    frame_it->second.T = T_pnp;
+  }
+
+  std::cout << "PnP solving completed for all frames" << std::endl;
+  return true;
 }
 
-
 bool Initializer::visualInitialAlign() {
-    VectorXd x;
+  VectorXd x;
 
-    // solve for gravity vector and scale, gyroscope bias
-    bool result = initial_alignment::VisualIMUAlignment(*all_image_frame_, *sliding_window_, *g_, x);
-    if (!result) {
-        std::cout << "solve gravity vector failed!" << std::endl;
-        return false;
+  // solve for gravity vector and scale, gyroscope bias
+  bool result = initial_alignment::VisualIMUAlignment(*all_image_frame_, *sliding_window_, *g_, x);
+  if (!result) {
+    std::cout << "solve gravity vector failed!" << std::endl;
+    return false;
+  }
+
+  // change state
+  for (int i = 0; i <= *frame_count_; i++) {
+    Matrix3d Ri = (*all_image_frame_)[(*sliding_window_)[i].timestamp].R;
+    Vector3d Pi = (*all_image_frame_)[(*sliding_window_)[i].timestamp].T;
+
+    (*sliding_window_)[i].P = Pi;
+    (*sliding_window_)[i].R = Ri;
+    (*all_image_frame_)[(*sliding_window_)[i].timestamp].is_key_frame = true;
+  }
+
+  VectorXd dep = feature_manager_->getDepthVector();
+  for (int i = 0; i < dep.size(); i++) dep[i] = -1;
+  feature_manager_->clearDepth(dep);
+
+  // triangulat on cam pose , no tic
+  Vector3d T_IC_TMP;
+  T_IC_TMP.setZero();
+  feature_manager_->triangulate(*sliding_window_, T_IC_TMP, *r_ic_);
+
+  double scale = (x.tail<1>())(0);
+
+  for (int i = 0; i <= WINDOW_SIZE; i++) {
+    (*sliding_window_)[i].pre_integration->repropagate(Vector3d::Zero(), (*sliding_window_)[i].Bg);
+  }
+
+  for (int i = *frame_count_; i >= 0; i--)
+    (*sliding_window_)[i].P =
+        scale * (*sliding_window_)[i].P - (*sliding_window_)[i].R * (*t_ic_) -
+        (scale * (*sliding_window_).front().P - (*sliding_window_).front().R * (*t_ic_));
+
+  int kv = -1;
+  map<double, ImageFrame>::iterator frame_i;
+  for (frame_i = all_image_frame_->begin(); frame_i != all_image_frame_->end(); frame_i++) {
+    if (frame_i->second.is_key_frame) {
+      kv++;
+      (*sliding_window_)[kv].V = frame_i->second.R * x.segment<3>(kv * 3);
     }
+  }
 
-    // change state
-    for (int i = 0; i <= *frame_count_; i++) {
-        Matrix3d Ri = (*all_image_frame_)[(*sliding_window_)[i].timestamp].R;
-        Vector3d Pi = (*all_image_frame_)[(*sliding_window_)[i].timestamp].T;
+  for (auto& it_per_id : feature_manager_->feature) {
+    it_per_id.used_num = it_per_id.feature_per_frame.size();
+    if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2)) continue;
+    it_per_id.estimated_depth *= scale;
+  }
 
-        (*sliding_window_)[i].P = Pi;
-        (*sliding_window_)[i].R = Ri;
-        (*all_image_frame_)[(*sliding_window_)[i].timestamp].is_key_frame = true;
-    }
+  Matrix3d R0 = Utility::g2R(*g_);
+  double yaw = Utility::R2ypr(R0 * (*sliding_window_).front().R).x();
+  R0 = Utility::ypr2R(Eigen::Vector3d{-yaw, 0, 0}) * R0;
+  *g_ = R0 * (*g_);
 
-    VectorXd dep = feature_manager_->getDepthVector();
-    for (int i = 0; i < dep.size(); i++)
-        dep[i] = -1;
-    feature_manager_->clearDepth(dep);
+  Matrix3d rot_diff = R0;
+  for (int i = 0; i <= *frame_count_; i++) {
+    (*sliding_window_)[i].P = rot_diff * (*sliding_window_)[i].P;
+    (*sliding_window_)[i].R = rot_diff * (*sliding_window_)[i].R;
+    (*sliding_window_)[i].V = rot_diff * (*sliding_window_)[i].V;
+  }
 
-    // triangulat on cam pose , no tic
-    Vector3d T_IC_TMP;
-    T_IC_TMP.setZero();
-    feature_manager_->triangulate(*sliding_window_, T_IC_TMP, *r_ic_);
-
-    double scale = (x.tail<1>())(0);
-
-    for (int i = 0; i <= WINDOW_SIZE; i++) {
-        (*sliding_window_)[i].pre_integration->repropagate(Vector3d::Zero(), (*sliding_window_)[i].Bg);
-    }
-
-    for (int i = *frame_count_; i >= 0; i--)
-        (*sliding_window_)[i].P = scale * (*sliding_window_)[i].P - (*sliding_window_)[i].R * (*t_ic_) - (scale * (*sliding_window_).front().P - (*sliding_window_).front().R * (*t_ic_));
-
-    int kv = -1;
-    map<double, ImageFrame>::iterator frame_i;
-    for (frame_i = all_image_frame_->begin(); frame_i != all_image_frame_->end(); frame_i++) {
-        if (frame_i->second.is_key_frame) {
-            kv++;
-            (*sliding_window_)[kv].V = frame_i->second.R * x.segment<3>(kv * 3);
-        }
-    }
-
-    for (auto &it_per_id : feature_manager_->feature) {
-        it_per_id.used_num = it_per_id.feature_per_frame.size();
-        if (!(it_per_id.used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2))
-            continue;
-        it_per_id.estimated_depth *= scale;
-    }
-
-    Matrix3d R0 = Utility::g2R(*g_);
-    double yaw = Utility::R2ypr(R0 * (*sliding_window_).front().R).x();
-    R0 = Utility::ypr2R(Eigen::Vector3d{-yaw, 0, 0}) * R0;
-    *g_ = R0 * (*g_);
-
-    Matrix3d rot_diff = R0;
-    for (int i = 0; i <= *frame_count_; i++) {
-        (*sliding_window_)[i].P = rot_diff * (*sliding_window_)[i].P;
-        (*sliding_window_)[i].R = rot_diff * (*sliding_window_)[i].R;
-        (*sliding_window_)[i].V = rot_diff * (*sliding_window_)[i].V;
-    }
-
-    return true;
-} 
+  return true;
+}

--- a/src/frontend/initialization/solve_5pts.cpp
+++ b/src/frontend/initialization/solve_5pts.cpp
@@ -2,215 +2,208 @@
 
 namespace cv {
 void decomposeEssentialMat(InputArray _E, OutputArray _R1, OutputArray _R2, OutputArray _t) {
-    Mat E = _E.getMat().reshape(1, 3);
-    CV_Assert(E.cols == 3 && E.rows == 3);
+  Mat E = _E.getMat().reshape(1, 3);
+  CV_Assert(E.cols == 3 && E.rows == 3);
 
-    Mat D, U, Vt;
-    SVD::compute(E, D, U, Vt);
+  Mat D, U, Vt;
+  SVD::compute(E, D, U, Vt);
 
-    if (determinant(U) < 0)
-        U *= -1.;
-    if (determinant(Vt) < 0)
-        Vt *= -1.;
+  if (determinant(U) < 0) U *= -1.;
+  if (determinant(Vt) < 0) Vt *= -1.;
 
-    Mat W = (Mat_<double>(3, 3) << 0, 1, 0, -1, 0, 0, 0, 0, 1);
-    W.convertTo(W, E.type());
+  Mat W = (Mat_<double>(3, 3) << 0, 1, 0, -1, 0, 0, 0, 0, 1);
+  W.convertTo(W, E.type());
 
-    Mat R1, R2, t;
-    R1 = U * W * Vt;
-    R2 = U * W.t() * Vt;
-    t = U.col(2) * 1.0;
+  Mat R1, R2, t;
+  R1 = U * W * Vt;
+  R2 = U * W.t() * Vt;
+  t = U.col(2) * 1.0;
 
-    R1.copyTo(_R1);
-    R2.copyTo(_R2);
+  R1.copyTo(_R1);
+  R2.copyTo(_R2);
+  t.copyTo(_t);
+}
+
+int recoverPose(InputArray E, InputArray _points1, InputArray _points2, InputArray _cameraMatrix,
+                OutputArray _R, OutputArray _t, InputOutputArray _mask) {
+  Mat points1, points2, cameraMatrix;
+  _points1.getMat().convertTo(points1, CV_64F);
+  _points2.getMat().convertTo(points2, CV_64F);
+  _cameraMatrix.getMat().convertTo(cameraMatrix, CV_64F);
+
+  int npoints = points1.checkVector(2);
+  CV_Assert(npoints >= 0 && points2.checkVector(2) == npoints && points1.type() == points2.type());
+
+  CV_Assert(cameraMatrix.rows == 3 && cameraMatrix.cols == 3 && cameraMatrix.channels() == 1);
+
+  if (points1.channels() > 1) {
+    points1 = points1.reshape(1, npoints);
+    points2 = points2.reshape(1, npoints);
+  }
+
+  double fx = cameraMatrix.at<double>(0, 0);
+  double fy = cameraMatrix.at<double>(1, 1);
+  double cx = cameraMatrix.at<double>(0, 2);
+  double cy = cameraMatrix.at<double>(1, 2);
+
+  points1.col(0) = (points1.col(0) - cx) / fx;
+  points2.col(0) = (points2.col(0) - cx) / fx;
+  points1.col(1) = (points1.col(1) - cy) / fy;
+  points2.col(1) = (points2.col(1) - cy) / fy;
+
+  points1 = points1.t();
+  points2 = points2.t();
+
+  Mat R1, R2, t;
+  decomposeEssentialMat(E, R1, R2, t);
+  Mat P0 = Mat::eye(3, 4, R1.type());
+  Mat P1(3, 4, R1.type()), P2(3, 4, R1.type()), P3(3, 4, R1.type()), P4(3, 4, R1.type());
+  P1(Range::all(), Range(0, 3)) = R1 * 1.0;
+  P1.col(3) = t * 1.0;
+  P2(Range::all(), Range(0, 3)) = R2 * 1.0;
+  P2.col(3) = t * 1.0;
+  P3(Range::all(), Range(0, 3)) = R1 * 1.0;
+  P3.col(3) = -t * 1.0;
+  P4(Range::all(), Range(0, 3)) = R2 * 1.0;
+  P4.col(3) = -t * 1.0;
+
+  // Do the cheirality check.
+  // Notice here a threshold dist is used to filter
+  // out far away points (i.e. infinite points) since
+  // there depth may vary between postive and negtive.
+  double dist = 50.0;
+  Mat Q;
+  triangulatePoints(P0, P1, points1, points2, Q);
+  Mat mask1 = Q.row(2).mul(Q.row(3)) > 0;
+  Q.row(0) /= Q.row(3);
+  Q.row(1) /= Q.row(3);
+  Q.row(2) /= Q.row(3);
+  Q.row(3) /= Q.row(3);
+  mask1 = (Q.row(2) < dist) & mask1;
+  Q = P1 * Q;
+  mask1 = (Q.row(2) > 0) & mask1;
+  mask1 = (Q.row(2) < dist) & mask1;
+
+  triangulatePoints(P0, P2, points1, points2, Q);
+  Mat mask2 = Q.row(2).mul(Q.row(3)) > 0;
+  Q.row(0) /= Q.row(3);
+  Q.row(1) /= Q.row(3);
+  Q.row(2) /= Q.row(3);
+  Q.row(3) /= Q.row(3);
+  mask2 = (Q.row(2) < dist) & mask2;
+  Q = P2 * Q;
+  mask2 = (Q.row(2) > 0) & mask2;
+  mask2 = (Q.row(2) < dist) & mask2;
+
+  triangulatePoints(P0, P3, points1, points2, Q);
+  Mat mask3 = Q.row(2).mul(Q.row(3)) > 0;
+  Q.row(0) /= Q.row(3);
+  Q.row(1) /= Q.row(3);
+  Q.row(2) /= Q.row(3);
+  Q.row(3) /= Q.row(3);
+  mask3 = (Q.row(2) < dist) & mask3;
+  Q = P3 * Q;
+  mask3 = (Q.row(2) > 0) & mask3;
+  mask3 = (Q.row(2) < dist) & mask3;
+
+  triangulatePoints(P0, P4, points1, points2, Q);
+  Mat mask4 = Q.row(2).mul(Q.row(3)) > 0;
+  Q.row(0) /= Q.row(3);
+  Q.row(1) /= Q.row(3);
+  Q.row(2) /= Q.row(3);
+  Q.row(3) /= Q.row(3);
+  mask4 = (Q.row(2) < dist) & mask4;
+  Q = P4 * Q;
+  mask4 = (Q.row(2) > 0) & mask4;
+  mask4 = (Q.row(2) < dist) & mask4;
+
+  mask1 = mask1.t();
+  mask2 = mask2.t();
+  mask3 = mask3.t();
+  mask4 = mask4.t();
+
+  // If _mask is given, then use it to filter outliers.
+  if (!_mask.empty()) {
+    Mat mask = _mask.getMat();
+    CV_Assert(mask.size() == mask1.size());
+    bitwise_and(mask, mask1, mask1);
+    bitwise_and(mask, mask2, mask2);
+    bitwise_and(mask, mask3, mask3);
+    bitwise_and(mask, mask4, mask4);
+  }
+  if (_mask.empty() && _mask.needed()) {
+    _mask.create(mask1.size(), CV_8U);
+  }
+
+  CV_Assert(_R.needed() && _t.needed());
+  _R.create(3, 3, R1.type());
+  _t.create(3, 1, t.type());
+
+  int good1 = countNonZero(mask1);
+  int good2 = countNonZero(mask2);
+  int good3 = countNonZero(mask3);
+  int good4 = countNonZero(mask4);
+
+  if (good1 >= good2 && good1 >= good3 && good1 >= good4) {
+    R1.copyTo(_R);
     t.copyTo(_t);
+    if (_mask.needed()) mask1.copyTo(_mask);
+    return good1;
+  } else if (good2 >= good1 && good2 >= good3 && good2 >= good4) {
+    R2.copyTo(_R);
+    t.copyTo(_t);
+    if (_mask.needed()) mask2.copyTo(_mask);
+    return good2;
+  } else if (good3 >= good1 && good3 >= good2 && good3 >= good4) {
+    t = -t;
+    R1.copyTo(_R);
+    t.copyTo(_t);
+    if (_mask.needed()) mask3.copyTo(_mask);
+    return good3;
+  } else {
+    t = -t;
+    R2.copyTo(_R);
+    t.copyTo(_t);
+    if (_mask.needed()) mask4.copyTo(_mask);
+    return good4;
+  }
 }
 
-int recoverPose(InputArray E, InputArray _points1, InputArray _points2, InputArray _cameraMatrix, OutputArray _R,
-                OutputArray _t, InputOutputArray _mask) {
-    Mat points1, points2, cameraMatrix;
-    _points1.getMat().convertTo(points1, CV_64F);
-    _points2.getMat().convertTo(points2, CV_64F);
-    _cameraMatrix.getMat().convertTo(cameraMatrix, CV_64F);
-
-    int npoints = points1.checkVector(2);
-    CV_Assert(npoints >= 0 && points2.checkVector(2) == npoints && points1.type() == points2.type());
-
-    CV_Assert(cameraMatrix.rows == 3 && cameraMatrix.cols == 3 && cameraMatrix.channels() == 1);
-
-    if (points1.channels() > 1) {
-        points1 = points1.reshape(1, npoints);
-        points2 = points2.reshape(1, npoints);
-    }
-
-    double fx = cameraMatrix.at<double>(0, 0);
-    double fy = cameraMatrix.at<double>(1, 1);
-    double cx = cameraMatrix.at<double>(0, 2);
-    double cy = cameraMatrix.at<double>(1, 2);
-
-    points1.col(0) = (points1.col(0) - cx) / fx;
-    points2.col(0) = (points2.col(0) - cx) / fx;
-    points1.col(1) = (points1.col(1) - cy) / fy;
-    points2.col(1) = (points2.col(1) - cy) / fy;
-
-    points1 = points1.t();
-    points2 = points2.t();
-
-    Mat R1, R2, t;
-    decomposeEssentialMat(E, R1, R2, t);
-    Mat P0 = Mat::eye(3, 4, R1.type());
-    Mat P1(3, 4, R1.type()), P2(3, 4, R1.type()), P3(3, 4, R1.type()), P4(3, 4, R1.type());
-    P1(Range::all(), Range(0, 3)) = R1 * 1.0;
-    P1.col(3) = t * 1.0;
-    P2(Range::all(), Range(0, 3)) = R2 * 1.0;
-    P2.col(3) = t * 1.0;
-    P3(Range::all(), Range(0, 3)) = R1 * 1.0;
-    P3.col(3) = -t * 1.0;
-    P4(Range::all(), Range(0, 3)) = R2 * 1.0;
-    P4.col(3) = -t * 1.0;
-
-    // Do the cheirality check.
-    // Notice here a threshold dist is used to filter
-    // out far away points (i.e. infinite points) since
-    // there depth may vary between postive and negtive.
-    double dist = 50.0;
-    Mat Q;
-    triangulatePoints(P0, P1, points1, points2, Q);
-    Mat mask1 = Q.row(2).mul(Q.row(3)) > 0;
-    Q.row(0) /= Q.row(3);
-    Q.row(1) /= Q.row(3);
-    Q.row(2) /= Q.row(3);
-    Q.row(3) /= Q.row(3);
-    mask1 = (Q.row(2) < dist) & mask1;
-    Q = P1 * Q;
-    mask1 = (Q.row(2) > 0) & mask1;
-    mask1 = (Q.row(2) < dist) & mask1;
-
-    triangulatePoints(P0, P2, points1, points2, Q);
-    Mat mask2 = Q.row(2).mul(Q.row(3)) > 0;
-    Q.row(0) /= Q.row(3);
-    Q.row(1) /= Q.row(3);
-    Q.row(2) /= Q.row(3);
-    Q.row(3) /= Q.row(3);
-    mask2 = (Q.row(2) < dist) & mask2;
-    Q = P2 * Q;
-    mask2 = (Q.row(2) > 0) & mask2;
-    mask2 = (Q.row(2) < dist) & mask2;
-
-    triangulatePoints(P0, P3, points1, points2, Q);
-    Mat mask3 = Q.row(2).mul(Q.row(3)) > 0;
-    Q.row(0) /= Q.row(3);
-    Q.row(1) /= Q.row(3);
-    Q.row(2) /= Q.row(3);
-    Q.row(3) /= Q.row(3);
-    mask3 = (Q.row(2) < dist) & mask3;
-    Q = P3 * Q;
-    mask3 = (Q.row(2) > 0) & mask3;
-    mask3 = (Q.row(2) < dist) & mask3;
-
-    triangulatePoints(P0, P4, points1, points2, Q);
-    Mat mask4 = Q.row(2).mul(Q.row(3)) > 0;
-    Q.row(0) /= Q.row(3);
-    Q.row(1) /= Q.row(3);
-    Q.row(2) /= Q.row(3);
-    Q.row(3) /= Q.row(3);
-    mask4 = (Q.row(2) < dist) & mask4;
-    Q = P4 * Q;
-    mask4 = (Q.row(2) > 0) & mask4;
-    mask4 = (Q.row(2) < dist) & mask4;
-
-    mask1 = mask1.t();
-    mask2 = mask2.t();
-    mask3 = mask3.t();
-    mask4 = mask4.t();
-
-    // If _mask is given, then use it to filter outliers.
-    if (!_mask.empty()) {
-        Mat mask = _mask.getMat();
-        CV_Assert(mask.size() == mask1.size());
-        bitwise_and(mask, mask1, mask1);
-        bitwise_and(mask, mask2, mask2);
-        bitwise_and(mask, mask3, mask3);
-        bitwise_and(mask, mask4, mask4);
-    }
-    if (_mask.empty() && _mask.needed()) {
-        _mask.create(mask1.size(), CV_8U);
-    }
-
-    CV_Assert(_R.needed() && _t.needed());
-    _R.create(3, 3, R1.type());
-    _t.create(3, 1, t.type());
-
-    int good1 = countNonZero(mask1);
-    int good2 = countNonZero(mask2);
-    int good3 = countNonZero(mask3);
-    int good4 = countNonZero(mask4);
-
-    if (good1 >= good2 && good1 >= good3 && good1 >= good4) {
-        R1.copyTo(_R);
-        t.copyTo(_t);
-        if (_mask.needed())
-            mask1.copyTo(_mask);
-        return good1;
-    } else if (good2 >= good1 && good2 >= good3 && good2 >= good4) {
-        R2.copyTo(_R);
-        t.copyTo(_t);
-        if (_mask.needed())
-            mask2.copyTo(_mask);
-        return good2;
-    } else if (good3 >= good1 && good3 >= good2 && good3 >= good4) {
-        t = -t;
-        R1.copyTo(_R);
-        t.copyTo(_t);
-        if (_mask.needed())
-            mask3.copyTo(_mask);
-        return good3;
-    } else {
-        t = -t;
-        R2.copyTo(_R);
-        t.copyTo(_t);
-        if (_mask.needed())
-            mask4.copyTo(_mask);
-        return good4;
-    }
+int recoverPose(InputArray E, InputArray _points1, InputArray _points2, OutputArray _R,
+                OutputArray _t, double focal, Point2d pp, InputOutputArray _mask) {
+  Mat cameraMatrix = (Mat_<double>(3, 3) << focal, 0, pp.x, 0, focal, pp.y, 0, 0, 1);
+  return cv::recoverPose(E, _points1, _points2, cameraMatrix, _R, _t, _mask);
 }
+}  // namespace cv
 
-int recoverPose(InputArray E, InputArray _points1, InputArray _points2, OutputArray _R, OutputArray _t, double focal,
-                Point2d pp, InputOutputArray _mask) {
-    Mat cameraMatrix = (Mat_<double>(3, 3) << focal, 0, pp.x, 0, focal, pp.y, 0, 0, 1);
-    return cv::recoverPose(E, _points1, _points2, cameraMatrix, _R, _t, _mask);
-}
-} // namespace cv
-
-bool MotionEstimator::solveRelativeRT(const vector<pair<Vector3d, Vector3d>> &corres, Matrix3d &Rotation,
-                                      Vector3d &Translation) {
-    if (corres.size() >= 15) {
-        vector<cv::Point2f> ll, rr;
-        for (int i = 0; i < int(corres.size()); i++) {
-            ll.push_back(cv::Point2f(corres[i].first(0), corres[i].first(1)));
-            rr.push_back(cv::Point2f(corres[i].second(0), corres[i].second(1)));
-        }
-        cv::Mat mask;
-        cv::Mat E = cv::findFundamentalMat(ll, rr, cv::FM_RANSAC, 0.3 / 460, 0.99, mask);
-        cv::Mat cameraMatrix = (cv::Mat_<double>(3, 3) << 1, 0, 0, 0, 1, 0, 0, 0, 1);
-        cv::Mat rot, trans;
-        int inlier_cnt = cv::recoverPose(E, ll, rr, cameraMatrix, rot, trans, mask);
-        // cout << "inlier_cnt " << inlier_cnt << endl;
-
-        Eigen::Matrix3d R;
-        Eigen::Vector3d T;
-        for (int i = 0; i < 3; i++) {
-            T(i) = trans.at<double>(i, 0);
-            for (int j = 0; j < 3; j++)
-                R(i, j) = rot.at<double>(i, j);
-        }
-
-        Rotation = R.transpose();
-        Translation = -R.transpose() * T;
-        if (inlier_cnt > 12)
-            return true;
-        else
-            return false;
+bool MotionEstimator::solveRelativeRT(const vector<pair<Vector3d, Vector3d>> &corres,
+                                      Matrix3d &Rotation, Vector3d &Translation) {
+  if (corres.size() >= 15) {
+    vector<cv::Point2f> ll, rr;
+    for (int i = 0; i < int(corres.size()); i++) {
+      ll.push_back(cv::Point2f(corres[i].first(0), corres[i].first(1)));
+      rr.push_back(cv::Point2f(corres[i].second(0), corres[i].second(1)));
     }
-    return false;
+    cv::Mat mask;
+    cv::Mat E = cv::findFundamentalMat(ll, rr, cv::FM_RANSAC, 0.3 / 460, 0.99, mask);
+    cv::Mat cameraMatrix = (cv::Mat_<double>(3, 3) << 1, 0, 0, 0, 1, 0, 0, 0, 1);
+    cv::Mat rot, trans;
+    int inlier_cnt = cv::recoverPose(E, ll, rr, cameraMatrix, rot, trans, mask);
+    // cout << "inlier_cnt " << inlier_cnt << endl;
+
+    Eigen::Matrix3d R;
+    Eigen::Vector3d T;
+    for (int i = 0; i < 3; i++) {
+      T(i) = trans.at<double>(i, 0);
+      for (int j = 0; j < 3; j++) R(i, j) = rot.at<double>(i, j);
+    }
+
+    Rotation = R.transpose();
+    Translation = -R.transpose() * T;
+    if (inlier_cnt > 12)
+      return true;
+    else
+      return false;
+  }
+  return false;
 }

--- a/src/tiny_vins_mono.cpp
+++ b/src/tiny_vins_mono.cpp
@@ -1,11 +1,11 @@
 #include <iostream>
 #include <thread>
 
-#include "utility/config.h"
 #include "backend/estimator.h"
+#include "utility/config.h"
 #include "utility/measurement_processor.h"
-#include "utility/visualizer.h"
 #include "utility/test_result_logger.h"
+#include "utility/visualizer.h"
 
 MeasurementProcessor measurement_processor;
 backend::Estimator vio_estimator;
@@ -13,189 +13,187 @@ Visualizer visualizer;
 utility::TestResultLogger result_logger;
 
 void vioInitialize(const Config& config) {
-    const std::string imu_filepath = config.dataset_path + "/mav0/imu0/data.csv";
-    const std::string image_csv_filepath = config.dataset_path + "/mav0/cam0/data.csv";
-    const std::string image_dirpath = config.dataset_path + "/mav0/cam0/data";
-    const std::string config_filepath = config.config_filepath;
+  const std::string imu_filepath = config.dataset_path + "/mav0/imu0/data.csv";
+  const std::string image_csv_filepath = config.dataset_path + "/mav0/cam0/data.csv";
+  const std::string image_dirpath = config.dataset_path + "/mav0/cam0/data";
+  const std::string config_filepath = config.config_filepath;
 
-    std::cout << "IMU file: " << imu_filepath << std::endl;
-    std::cout << "Image CSV file: " << image_csv_filepath << std::endl;
-    std::cout << "Image directory: " << image_dirpath << std::endl;
-    std::cout << "Config file: " << config_filepath << std::endl;
+  std::cout << "IMU file: " << imu_filepath << std::endl;
+  std::cout << "Image CSV file: " << image_csv_filepath << std::endl;
+  std::cout << "Image directory: " << image_dirpath << std::endl;
+  std::cout << "Config file: " << config_filepath << std::endl;
 
-    // g_config is extern variable in config.h, so we can use config globally
-    measurement_processor.initialize(imu_filepath, image_csv_filepath, image_dirpath, config_filepath);
-    vio_estimator.setParameter();
-    visualizer.initialize();
-    result_logger.initialize(config_filepath);
+  // g_config is extern variable in config.h, so we can use config globally
+  measurement_processor.initialize(imu_filepath, image_csv_filepath, image_dirpath,
+                                   config_filepath);
+  vio_estimator.setParameter();
+  visualizer.initialize();
+  result_logger.initialize(config_filepath);
 }
 
 void updateCameraPose(double timestamp) {
-    if (vio_estimator.solver_flag_ == SolverFlag::NON_LINEAR) {
-        int window_size = g_config.estimator.window_size;
-        Eigen::Vector3d body_position = vio_estimator.sliding_window_[window_size].P;
-        Eigen::Matrix3d body_rotation = vio_estimator.sliding_window_[window_size].R;
-        if (!body_position.allFinite() || !body_rotation.allFinite()) {
-            std::cerr << "Invalid pose data detected, skipping..." << std::endl;
-            return;
-        }
-        Eigen::Vector3d camera_position = body_position + body_rotation * vio_estimator.t_ic_;
-        Eigen::Matrix3d camera_rotation = body_rotation * vio_estimator.r_ic_;
-        
-        if (visualizer.isRunning()) {
-            visualizer.updateCameraPose(camera_position, camera_rotation, timestamp);
-        }
-        
-        result_logger.addPose(camera_position, camera_rotation, timestamp);
-        
-        static size_t last_printed_count = 0;
-        static std::vector<Eigen::Vector3d> temp_poses;
-        temp_poses.push_back(camera_position);
-        if (temp_poses.size() > last_printed_count && temp_poses.size() % 5 == 0) {
-            std::cout << "🎯 Frame " << temp_poses.size() 
-                        << " | Time: " << std::fixed << std::setprecision(3) << timestamp 
-                        << " | Cam Pos: [" << std::fixed << std::setprecision(2)
-                        << camera_position.x() << ", " << camera_position.y() << ", " << camera_position.z() << "]" << std::endl;
-            last_printed_count = temp_poses.size();
-        }
-        static size_t last_saved_count = 0;
-        if (temp_poses.size() > last_saved_count && temp_poses.size() % 50 == 0) {
-            result_logger.saveTrajectoryToFile();
-            last_saved_count = temp_poses.size();
-        }
+  if (vio_estimator.solver_flag_ == SolverFlag::NON_LINEAR) {
+    int window_size = g_config.estimator.window_size;
+    Eigen::Vector3d body_position = vio_estimator.sliding_window_[window_size].P;
+    Eigen::Matrix3d body_rotation = vio_estimator.sliding_window_[window_size].R;
+    if (!body_position.allFinite() || !body_rotation.allFinite()) {
+      std::cerr << "Invalid pose data detected, skipping..." << std::endl;
+      return;
     }
+    Eigen::Vector3d camera_position = body_position + body_rotation * vio_estimator.t_ic_;
+    Eigen::Matrix3d camera_rotation = body_rotation * vio_estimator.r_ic_;
+
+    if (visualizer.isRunning()) {
+      visualizer.updateCameraPose(camera_position, camera_rotation, timestamp);
+    }
+
+    result_logger.addPose(camera_position, camera_rotation, timestamp);
+
+    static size_t last_printed_count = 0;
+    static std::vector<Eigen::Vector3d> temp_poses;
+    temp_poses.push_back(camera_position);
+    if (temp_poses.size() > last_printed_count && temp_poses.size() % 5 == 0) {
+      std::cout << "🎯 Frame " << temp_poses.size() << " | Time: " << std::fixed
+                << std::setprecision(3) << timestamp << " | Cam Pos: [" << std::fixed
+                << std::setprecision(2) << camera_position.x() << ", " << camera_position.y()
+                << ", " << camera_position.z() << "]" << std::endl;
+      last_printed_count = temp_poses.size();
+    }
+    static size_t last_saved_count = 0;
+    if (temp_poses.size() > last_saved_count && temp_poses.size() % 50 == 0) {
+      result_logger.saveTrajectoryToFile();
+      last_saved_count = temp_poses.size();
+    }
+  }
 }
 
 void updateFeaturePoints3D() {
-    std::vector<Eigen::Vector3d> new_points;
-    if (vio_estimator.solver_flag_ == SolverFlag::NON_LINEAR) {
-        new_points = vio_estimator.getSlidingWindowMapPoints();
+  std::vector<Eigen::Vector3d> new_points;
+  if (vio_estimator.solver_flag_ == SolverFlag::NON_LINEAR) {
+    new_points = vio_estimator.getSlidingWindowMapPoints();
+  }
+  std::vector<Eigen::Vector3d> valid_points;
+  for (const auto& pt : new_points) {
+    if (pt.allFinite() && !std::isnan(pt.x()) && !std::isnan(pt.y()) && !std::isnan(pt.z())) {
+      valid_points.push_back(pt);
     }
-    std::vector<Eigen::Vector3d> valid_points;
-    for (const auto& pt : new_points) {
-        if (pt.allFinite() && !std::isnan(pt.x()) && !std::isnan(pt.y()) && !std::isnan(pt.z())) {
-            valid_points.push_back(pt);
-        }
-    }
-    if (visualizer.isRunning()) {
-        visualizer.updateFeaturePoints3D(valid_points);
-    }
+  }
+  if (visualizer.isRunning()) {
+    visualizer.updateFeaturePoints3D(valid_points);
+  }
 }
 
 void updateVisualization(double timestamp) {
-    updateCameraPose(timestamp);
-    updateFeaturePoints3D();
+  updateCameraPose(timestamp);
+  updateFeaturePoints3D();
 }
 
-void vioProcess()
-{
-    const auto& image_file_data = measurement_processor.getImageFileData();
-    double current_time = -1;
-    int32_t measurement_id = 0;
-    for (const auto& image_file_data_item : image_file_data) {
-        std::cout << "\nProcessing file: " << image_file_data_item.filename << std::endl;
-        if (measurement_id++ % (g_config.frame_skip + 1) != 0) 
-        {
-            std::cout << "skip frame " << (measurement_id-1) << std::endl;
-            continue;
-        }
-        
-        MeasurementMsg measurement = measurement_processor.createMeasurementMsg(measurement_id, image_file_data_item);
-        auto imu_msg = measurement.imu_msg;
-        auto image_msg = measurement.image_feature_msg;
-
-        // process IMU data
-        for (const auto& imu_data : imu_msg) {
-            double t = imu_data.timestamp;
-            double img_t = image_msg.timestamp;
-            double dx = 0, dy = 0, dz = 0, rx = 0, ry = 0, rz = 0;
-            if (t <= img_t) {
-                if (current_time < 0)
-                    current_time = t;
-                double dt = t - current_time;
-                current_time = t;
-                dx = imu_data.linear_acc_x;
-                dy = imu_data.linear_acc_y;
-                dz = imu_data.linear_acc_z;
-                rx = imu_data.angular_vel_x;
-                ry = imu_data.angular_vel_y;
-                rz = imu_data.angular_vel_z;
-                vio_estimator.processIMU(dt, Vector3d(dx, dy, dz), Vector3d(rx, ry, rz));
-            }
-            else {
-                double dt_1 = img_t - current_time;
-                double dt_2 = t - img_t;
-                current_time = img_t;
-                double w1 = dt_2 / (dt_1 + dt_2);
-                double w2 = dt_1 / (dt_1 + dt_2);
-                dx = w1 * dx + w2 * imu_data.linear_acc_x;
-                dy = w1 * dy + w2 * imu_data.linear_acc_y;
-                dz = w1 * dz + w2 * imu_data.linear_acc_z;
-                rx = w1 * rx + w2 * imu_data.angular_vel_x;
-                ry = w1 * ry + w2 * imu_data.angular_vel_y;
-                rz = w1 * rz + w2 * imu_data.angular_vel_z;
-                vio_estimator.processIMU(dt_1, Vector3d(dx, dy, dz), Vector3d(rx, ry, rz));
-            }
-        }
-
-        // process image data
-        ImageData image_data;
-        for (unsigned int i = 0; i < image_msg.points_count; i++) {                    
-            int v = image_msg.channel_data[0][i] + 0.5;
-            int feature_id = v;
-            double x = image_msg.feature_points[i].x;
-            double y = image_msg.feature_points[i].y;
-            double z = image_msg.feature_points[i].z;
-            double p_u = image_msg.channel_data[1][i];
-            double p_v = image_msg.channel_data[2][i];
-            double velocity_x = image_msg.channel_data[3][i];
-            double velocity_y = image_msg.channel_data[4][i];
-            Eigen::Matrix<double, 7, 1> xyz_uv_velocity;
-            xyz_uv_velocity << x, y, z, p_u, p_v, velocity_x, velocity_y;
-            image_data[feature_id].emplace_back(xyz_uv_velocity);
-        }
-        if (!image_data.empty()) {
-            vio_estimator.processImage(image_data, image_msg.timestamp);
-        } else {
-            std::cerr << "Warning: Empty image_data for measurement ID " << measurement_id << std::endl;
-        }
-
-        updateVisualization(image_msg.timestamp);
+void vioProcess() {
+  const auto& image_file_data = measurement_processor.getImageFileData();
+  double current_time = -1;
+  int32_t measurement_id = 0;
+  for (const auto& image_file_data_item : image_file_data) {
+    std::cout << "\nProcessing file: " << image_file_data_item.filename << std::endl;
+    if (measurement_id++ % (g_config.frame_skip + 1) != 0) {
+      std::cout << "skip frame " << (measurement_id - 1) << std::endl;
+      continue;
     }
 
-    std::cout << "\n🎯 Saving final complete trajectory..." << std::endl;
-    result_logger.saveTrajectoryToFile();
+    MeasurementMsg measurement =
+        measurement_processor.createMeasurementMsg(measurement_id, image_file_data_item);
+    auto imu_msg = measurement.imu_msg;
+    auto image_msg = measurement.image_feature_msg;
+
+    // process IMU data
+    for (const auto& imu_data : imu_msg) {
+      double t = imu_data.timestamp;
+      double img_t = image_msg.timestamp;
+      double dx = 0, dy = 0, dz = 0, rx = 0, ry = 0, rz = 0;
+      if (t <= img_t) {
+        if (current_time < 0) current_time = t;
+        double dt = t - current_time;
+        current_time = t;
+        dx = imu_data.linear_acc_x;
+        dy = imu_data.linear_acc_y;
+        dz = imu_data.linear_acc_z;
+        rx = imu_data.angular_vel_x;
+        ry = imu_data.angular_vel_y;
+        rz = imu_data.angular_vel_z;
+        vio_estimator.processIMU(dt, Vector3d(dx, dy, dz), Vector3d(rx, ry, rz));
+      } else {
+        double dt_1 = img_t - current_time;
+        double dt_2 = t - img_t;
+        current_time = img_t;
+        double w1 = dt_2 / (dt_1 + dt_2);
+        double w2 = dt_1 / (dt_1 + dt_2);
+        dx = w1 * dx + w2 * imu_data.linear_acc_x;
+        dy = w1 * dy + w2 * imu_data.linear_acc_y;
+        dz = w1 * dz + w2 * imu_data.linear_acc_z;
+        rx = w1 * rx + w2 * imu_data.angular_vel_x;
+        ry = w1 * ry + w2 * imu_data.angular_vel_y;
+        rz = w1 * rz + w2 * imu_data.angular_vel_z;
+        vio_estimator.processIMU(dt_1, Vector3d(dx, dy, dz), Vector3d(rx, ry, rz));
+      }
+    }
+
+    // process image data
+    ImageData image_data;
+    for (unsigned int i = 0; i < image_msg.points_count; i++) {
+      int v = image_msg.channel_data[0][i] + 0.5;
+      int feature_id = v;
+      double x = image_msg.feature_points[i].x;
+      double y = image_msg.feature_points[i].y;
+      double z = image_msg.feature_points[i].z;
+      double p_u = image_msg.channel_data[1][i];
+      double p_v = image_msg.channel_data[2][i];
+      double velocity_x = image_msg.channel_data[3][i];
+      double velocity_y = image_msg.channel_data[4][i];
+      Eigen::Matrix<double, 7, 1> xyz_uv_velocity;
+      xyz_uv_velocity << x, y, z, p_u, p_v, velocity_x, velocity_y;
+      image_data[feature_id].emplace_back(xyz_uv_velocity);
+    }
+    if (!image_data.empty()) {
+      vio_estimator.processImage(image_data, image_msg.timestamp);
+    } else {
+      std::cerr << "Warning: Empty image_data for measurement ID " << measurement_id << std::endl;
+    }
+
+    updateVisualization(image_msg.timestamp);
+  }
+
+  std::cout << "\n🎯 Saving final complete trajectory..." << std::endl;
+  result_logger.saveTrajectoryToFile();
 }
 
 int main(int argc, char* argv[]) {
-     if (argc < 2) {
-        std::cout << "Usage: " << argv[0] << " <config_file>" << std::endl;
-        std::cout << "Example: " << argv[0] << " ./config/config.yaml" << std::endl;
-        return 1;
-    }
+  if (argc < 2) {
+    std::cout << "Usage: " << argv[0] << " <config_file>" << std::endl;
+    std::cout << "Example: " << argv[0] << " ./config/config.yaml" << std::endl;
+    return 1;
+  }
 
-    std::string config_file = argv[1];
-    if (!utility::g_config.loadFromYaml(config_file)) {
-        std::cout << "Failed to load config from " << config_file << std::endl;
-        return 1;
-    }
-    utility::g_config.print();
+  std::string config_file = argv[1];
+  if (!utility::g_config.loadFromYaml(config_file)) {
+    std::cout << "Failed to load config from " << config_file << std::endl;
+    return 1;
+  }
+  utility::g_config.print();
 
-    vioInitialize(g_config);
+  vioInitialize(g_config);
 
-    std::thread vio_process_thread(vioProcess);
+  std::thread vio_process_thread(vioProcess);
 
-    // wait for visualizer to be initialized
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    
-    std::cout << "Starting Visualizer in main thread..." << std::endl;
-    visualizer.pangolinViewerThread();
-    
-    std::cout << "\n✅ All measurement files processed!" << std::endl;
-    if (vio_process_thread.joinable()) {
-        vio_process_thread.join();
-    }
-    
-    std::cout << "Process thread joined" << std::endl;
-    return 0;
+  // wait for visualizer to be initialized
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+  std::cout << "Starting Visualizer in main thread..." << std::endl;
+  visualizer.pangolinViewerThread();
+
+  std::cout << "\n✅ All measurement files processed!" << std::endl;
+  if (vio_process_thread.joinable()) {
+    vio_process_thread.join();
+  }
+
+  std::cout << "Process thread joined" << std::endl;
+  return 0;
 }

--- a/src/utility/config.cpp
+++ b/src/utility/config.cpp
@@ -1,137 +1,140 @@
-#include <iostream>
-#include <fstream>
-
 #include "utility/config.h"
+
 #include <yaml-cpp/yaml.h>
+
+#include <fstream>
+#include <iostream>
 
 namespace utility {
 // Global configuration instance
 Config g_config;
 
 bool Config::loadFromYaml(const std::string& yaml_path) {
-    try {
-        YAML::Node config = YAML::LoadFile(yaml_path);
-        
-        std::cout << "Loading configuration from: " << yaml_path << std::endl;
-        
-        // Load camera configuration
-        if (config["image_width"]) camera.col = config["image_width"].as<double>();
-        if (config["image_height"]) camera.row = config["image_height"].as<double>();
-        
-        // Load projection parameters
-        if (config["projection_parameters"]) {
-            auto proj = config["projection_parameters"];
-            if (proj["fx"]) camera.fx = proj["fx"].as<double>();
-            if (proj["fy"]) camera.fy = proj["fy"].as<double>();
-            if (proj["cx"]) camera.cx = proj["cx"].as<double>();
-            if (proj["cy"]) camera.cy = proj["cy"].as<double>();
-            
-            // Set focal_length as average of fx and fy
-            camera.focal_length = (camera.fx + camera.fy) / 2.0;
-        }
-        
-        // Load extrinsic parameters (OpenCV matrix format)
-        if (config["extrinsicRotation"]) {
-            auto ext_rot = config["extrinsicRotation"];
-            if (ext_rot["data"]) {
-                auto data = ext_rot["data"];
-                if (data.size() >= 9) {
-                    camera.r_ic << data[0].as<double>(), data[1].as<double>(), data[2].as<double>(),
-                                   data[3].as<double>(), data[4].as<double>(), data[5].as<double>(),
-                                   data[6].as<double>(), data[7].as<double>(), data[8].as<double>();
-                }
-            }
-        }
-        
-        if (config["extrinsicTranslation"]) {
-            auto ext_trans = config["extrinsicTranslation"];
-            if (ext_trans["data"]) {
-                auto data = ext_trans["data"];
-                if (data.size() >= 3) {
-                    camera.t_ic << data[0].as<double>(), data[1].as<double>(), data[2].as<double>();
-                }
-            }
-        }
+  try {
+    YAML::Node config = YAML::LoadFile(yaml_path);
 
-        // Load feature tracker configuration (top level parameters)
-        if (config["max_cnt"]) feature_tracker.max_cnt = config["max_cnt"].as<int>();
-        if (config["min_dist"]) feature_tracker.min_dist = config["min_dist"].as<int>();
-        if (config["F_threshold"]) feature_tracker.f_threshold = config["F_threshold"].as<double>();
-        if (config["show_track"]) feature_tracker.show_track = config["show_track"].as<int>();
-        if (config["equalize"]) feature_tracker.equalize = config["equalize"].as<int>();
-        if (config["fisheye"]) feature_tracker.fisheye = config["fisheye"].as<int>();
-        
-        // Load estimator configuration (top level parameters)
-        if (config["max_solver_time"]) estimator.solver_time = config["max_solver_time"].as<double>();
-        if (config["max_num_iterations"]) estimator.num_iterations = config["max_num_iterations"].as<int>();
-        if (config["keyframe_parallax"]) estimator.min_parallax = config["keyframe_parallax"].as<double>();
-        if (config["acc_n"]) estimator.acc_n = config["acc_n"].as<double>();
-        if (config["acc_w"]) estimator.acc_w = config["acc_w"].as<double>();
-        if (config["gyr_n"]) estimator.gyr_n = config["gyr_n"].as<double>();
-        if (config["gyr_w"]) estimator.gyr_w = config["gyr_w"].as<double>();
-        if (config["g_norm"]) estimator.g = Eigen::Vector3d(0.0, 0.0, config["g_norm"].as<double>());
-        
-        // Load processing parameters
-        if (config["frame_skip"]) frame_skip = config["frame_skip"].as<int>();
-        if (config["dataset_path"]) dataset_path = config["dataset_path"].as<std::string>();
-        config_filepath = yaml_path;
-        
-        // Set default values for missing parameters
-        if (estimator.init_depth == 0.0) estimator.init_depth = 5.0;
-        if (estimator.num_of_features == 0) estimator.num_of_features = 1000;
-        if (feature_tracker.window_size == 0) feature_tracker.window_size = 20;
-        
-        std::cout << "Configuration loaded successfully from: " << yaml_path << std::endl;
-        return true;
-        
-    } catch (const YAML::Exception& e) {
-        std::cerr << "Error loading configuration from " << yaml_path << ": " << e.what() << std::endl;
-        return false;
-    } catch (const std::exception& e) {
-        std::cerr << "Error loading configuration from " << yaml_path << ": " << e.what() << std::endl;
-        return false;
+    std::cout << "Loading configuration from: " << yaml_path << std::endl;
+
+    // Load camera configuration
+    if (config["image_width"]) camera.col = config["image_width"].as<double>();
+    if (config["image_height"]) camera.row = config["image_height"].as<double>();
+
+    // Load projection parameters
+    if (config["projection_parameters"]) {
+      auto proj = config["projection_parameters"];
+      if (proj["fx"]) camera.fx = proj["fx"].as<double>();
+      if (proj["fy"]) camera.fy = proj["fy"].as<double>();
+      if (proj["cx"]) camera.cx = proj["cx"].as<double>();
+      if (proj["cy"]) camera.cy = proj["cy"].as<double>();
+
+      // Set focal_length as average of fx and fy
+      camera.focal_length = (camera.fx + camera.fy) / 2.0;
     }
+
+    // Load extrinsic parameters (OpenCV matrix format)
+    if (config["extrinsicRotation"]) {
+      auto ext_rot = config["extrinsicRotation"];
+      if (ext_rot["data"]) {
+        auto data = ext_rot["data"];
+        if (data.size() >= 9) {
+          camera.r_ic << data[0].as<double>(), data[1].as<double>(), data[2].as<double>(),
+              data[3].as<double>(), data[4].as<double>(), data[5].as<double>(),
+              data[6].as<double>(), data[7].as<double>(), data[8].as<double>();
+        }
+      }
+    }
+
+    if (config["extrinsicTranslation"]) {
+      auto ext_trans = config["extrinsicTranslation"];
+      if (ext_trans["data"]) {
+        auto data = ext_trans["data"];
+        if (data.size() >= 3) {
+          camera.t_ic << data[0].as<double>(), data[1].as<double>(), data[2].as<double>();
+        }
+      }
+    }
+
+    // Load feature tracker configuration (top level parameters)
+    if (config["max_cnt"]) feature_tracker.max_cnt = config["max_cnt"].as<int>();
+    if (config["min_dist"]) feature_tracker.min_dist = config["min_dist"].as<int>();
+    if (config["F_threshold"]) feature_tracker.f_threshold = config["F_threshold"].as<double>();
+    if (config["show_track"]) feature_tracker.show_track = config["show_track"].as<int>();
+    if (config["equalize"]) feature_tracker.equalize = config["equalize"].as<int>();
+    if (config["fisheye"]) feature_tracker.fisheye = config["fisheye"].as<int>();
+
+    // Load estimator configuration (top level parameters)
+    if (config["max_solver_time"]) estimator.solver_time = config["max_solver_time"].as<double>();
+    if (config["max_num_iterations"])
+      estimator.num_iterations = config["max_num_iterations"].as<int>();
+    if (config["keyframe_parallax"])
+      estimator.min_parallax = config["keyframe_parallax"].as<double>();
+    if (config["acc_n"]) estimator.acc_n = config["acc_n"].as<double>();
+    if (config["acc_w"]) estimator.acc_w = config["acc_w"].as<double>();
+    if (config["gyr_n"]) estimator.gyr_n = config["gyr_n"].as<double>();
+    if (config["gyr_w"]) estimator.gyr_w = config["gyr_w"].as<double>();
+    if (config["g_norm"]) estimator.g = Eigen::Vector3d(0.0, 0.0, config["g_norm"].as<double>());
+
+    // Load processing parameters
+    if (config["frame_skip"]) frame_skip = config["frame_skip"].as<int>();
+    if (config["dataset_path"]) dataset_path = config["dataset_path"].as<std::string>();
+    config_filepath = yaml_path;
+
+    // Set default values for missing parameters
+    if (estimator.init_depth == 0.0) estimator.init_depth = 5.0;
+    if (estimator.num_of_features == 0) estimator.num_of_features = 1000;
+    if (feature_tracker.window_size == 0) feature_tracker.window_size = 20;
+
+    std::cout << "Configuration loaded successfully from: " << yaml_path << std::endl;
+    return true;
+
+  } catch (const YAML::Exception& e) {
+    std::cerr << "Error loading configuration from " << yaml_path << ": " << e.what() << std::endl;
+    return false;
+  } catch (const std::exception& e) {
+    std::cerr << "Error loading configuration from " << yaml_path << ": " << e.what() << std::endl;
+    return false;
+  }
 }
 
 void Config::print() const {
-    std::cout << "=== Configuration ===" << std::endl;
-    
-    std::cout << "Processing:" << std::endl;
-    std::cout << "  frame_skip: " << frame_skip << std::endl;
-    
-    std::cout << "Camera:" << std::endl;
-    std::cout << "  focal_length: " << camera.focal_length << std::endl;
-    std::cout << "  row: " << camera.row << std::endl;
-    std::cout << "  col: " << camera.col << std::endl;
-    std::cout << "  fx: " << camera.fx << std::endl;
-    std::cout << "  fy: " << camera.fy << std::endl;
-    std::cout << "  cx: " << camera.cx << std::endl;
-    std::cout << "  cy: " << camera.cy << std::endl;
-    std::cout << "  t_ic: " << camera.t_ic.transpose() << std::endl;
-    
-    std::cout << "Feature Tracker:" << std::endl;
-    std::cout << "  max_cnt: " << feature_tracker.max_cnt << std::endl;
-    std::cout << "  min_dist: " << feature_tracker.min_dist << std::endl;
-    std::cout << "  window_size: " << feature_tracker.window_size << std::endl;
-    std::cout << "  f_threshold: " << feature_tracker.f_threshold << std::endl;
-    std::cout << "  show_track: " << feature_tracker.show_track << std::endl;
-    std::cout << "  equalize: " << feature_tracker.equalize << std::endl;
-    std::cout << "  fisheye: " << feature_tracker.fisheye << std::endl;
-    
-    std::cout << "Estimator:" << std::endl;
-    std::cout << "  window_size: " << estimator.window_size << std::endl;
-    std::cout << "  num_iterations: " << estimator.num_iterations << std::endl;
-    std::cout << "  solver_time: " << estimator.solver_time << std::endl;
-    std::cout << "  min_parallax: " << estimator.min_parallax << std::endl;
-    std::cout << "  init_depth: " << estimator.init_depth << std::endl;
-    std::cout << "  acc_n: " << estimator.acc_n << std::endl;
-    std::cout << "  acc_w: " << estimator.acc_w << std::endl;
-    std::cout << "  gyr_n: " << estimator.gyr_n << std::endl;
-    std::cout << "  gyr_w: " << estimator.gyr_w << std::endl;
-    std::cout << "  gravity: " << estimator.g.transpose() << std::endl;
-    std::cout << "  num_of_features: " << estimator.num_of_features << std::endl;
-    
-    std::cout << "===================" << std::endl;
-} 
+  std::cout << "=== Configuration ===" << std::endl;
 
-} // namespace utility
+  std::cout << "Processing:" << std::endl;
+  std::cout << "  frame_skip: " << frame_skip << std::endl;
+
+  std::cout << "Camera:" << std::endl;
+  std::cout << "  focal_length: " << camera.focal_length << std::endl;
+  std::cout << "  row: " << camera.row << std::endl;
+  std::cout << "  col: " << camera.col << std::endl;
+  std::cout << "  fx: " << camera.fx << std::endl;
+  std::cout << "  fy: " << camera.fy << std::endl;
+  std::cout << "  cx: " << camera.cx << std::endl;
+  std::cout << "  cy: " << camera.cy << std::endl;
+  std::cout << "  t_ic: " << camera.t_ic.transpose() << std::endl;
+
+  std::cout << "Feature Tracker:" << std::endl;
+  std::cout << "  max_cnt: " << feature_tracker.max_cnt << std::endl;
+  std::cout << "  min_dist: " << feature_tracker.min_dist << std::endl;
+  std::cout << "  window_size: " << feature_tracker.window_size << std::endl;
+  std::cout << "  f_threshold: " << feature_tracker.f_threshold << std::endl;
+  std::cout << "  show_track: " << feature_tracker.show_track << std::endl;
+  std::cout << "  equalize: " << feature_tracker.equalize << std::endl;
+  std::cout << "  fisheye: " << feature_tracker.fisheye << std::endl;
+
+  std::cout << "Estimator:" << std::endl;
+  std::cout << "  window_size: " << estimator.window_size << std::endl;
+  std::cout << "  num_iterations: " << estimator.num_iterations << std::endl;
+  std::cout << "  solver_time: " << estimator.solver_time << std::endl;
+  std::cout << "  min_parallax: " << estimator.min_parallax << std::endl;
+  std::cout << "  init_depth: " << estimator.init_depth << std::endl;
+  std::cout << "  acc_n: " << estimator.acc_n << std::endl;
+  std::cout << "  acc_w: " << estimator.acc_w << std::endl;
+  std::cout << "  gyr_n: " << estimator.gyr_n << std::endl;
+  std::cout << "  gyr_w: " << estimator.gyr_w << std::endl;
+  std::cout << "  gravity: " << estimator.g.transpose() << std::endl;
+  std::cout << "  num_of_features: " << estimator.num_of_features << std::endl;
+
+  std::cout << "===================" << std::endl;
+}
+
+}  // namespace utility

--- a/src/utility/measurement_processor.cpp
+++ b/src/utility/measurement_processor.cpp
@@ -1,286 +1,287 @@
 #include "utility/measurement_processor.h"
-#include "utility/config.h"
-#include <fstream>
-#include <iostream>
-#include <sstream>
+
 #include <algorithm>
+#include <fstream>
 #include <iomanip>
-#include <set>
+#include <iostream>
 #include <opencv2/opencv.hpp>
+#include <set>
+#include <sstream>
 
-MeasurementProcessor::MeasurementProcessor() : prev_image_timestamp_(-1.0) 
-{
-}
+#include "utility/config.h"
 
-MeasurementProcessor::~MeasurementProcessor() {
-}
+MeasurementProcessor::MeasurementProcessor() : prev_image_timestamp_(-1.0) {}
 
-bool MeasurementProcessor::initialize(const std::string& imu_filepath, 
-                                     const std::string& image_csv_filepath,
-                                     const std::string& image_dir,
-                                     const std::string& config_filepath) {
-    std::cout << "=== MeasurementProcessor 초기화 ===" << std::endl;
-    
-    // Load configuration
-    if (!g_config.loadFromYaml(config_filepath)) {
-        std::cout << "Failed to load config from " << config_filepath << std::endl;
-        return false;
-    }
-    
-    // Print configuration for debugging
-    g_config.print();
-    
-    // Feature tracker 초기화
-    feature_tracker_.reset(new feature_tracker::FeatureTracker());
-    feature_tracker_->readIntrinsicParameter(config_filepath);
-    
-    // 데이터 로드
-    if (!loadImuData(imu_filepath)) {
-        std::cerr << "IMU 데이터 로드 실패" << std::endl;
-        return false;
-    }
-    
-    if (!loadImageFileData(image_csv_filepath, image_dir)) {
-        std::cerr << "이미지 데이터 로드 실패" << std::endl;
-        return false;
-    }
-    
-    // 데이터 범위 출력
-    printDataRange();
-    
-    return true;
+MeasurementProcessor::~MeasurementProcessor() {}
+
+bool MeasurementProcessor::initialize(const std::string& imu_filepath,
+                                      const std::string& image_csv_filepath,
+                                      const std::string& image_dir,
+                                      const std::string& config_filepath) {
+  std::cout << "=== MeasurementProcessor 초기화 ===" << std::endl;
+
+  // Load configuration
+  if (!g_config.loadFromYaml(config_filepath)) {
+    std::cout << "Failed to load config from " << config_filepath << std::endl;
+    return false;
+  }
+
+  // Print configuration for debugging
+  g_config.print();
+
+  // Feature tracker 초기화
+  feature_tracker_.reset(new feature_tracker::FeatureTracker());
+  feature_tracker_->readIntrinsicParameter(config_filepath);
+
+  // 데이터 로드
+  if (!loadImuData(imu_filepath)) {
+    std::cerr << "IMU 데이터 로드 실패" << std::endl;
+    return false;
+  }
+
+  if (!loadImageFileData(image_csv_filepath, image_dir)) {
+    std::cerr << "이미지 데이터 로드 실패" << std::endl;
+    return false;
+  }
+
+  // 데이터 범위 출력
+  printDataRange();
+
+  return true;
 }
 
 bool MeasurementProcessor::loadImuData(const std::string& filepath) {
-    std::cout << "\n1. IMU 데이터 로드 중..." << std::endl;
-    
-    std::ifstream file(filepath);
-    if (!file.is_open()) {
-        std::cerr << "IMU 파일을 열 수 없습니다: " << filepath << std::endl;
-        return false;
+  std::cout << "\n1. IMU 데이터 로드 중..." << std::endl;
+
+  std::ifstream file(filepath);
+  if (!file.is_open()) {
+    std::cerr << "IMU 파일을 열 수 없습니다: " << filepath << std::endl;
+    return false;
+  }
+
+  std::string line;
+  // 헤더 건너뛰기
+  std::getline(file, line);
+
+  while (std::getline(file, line)) {
+    if (line.empty()) continue;
+
+    std::istringstream iss(line);
+    std::string token;
+    IMUData data;
+
+    // timestamp [ns]를 초 단위로 변환
+    if (std::getline(iss, token, ',')) {
+      data.timestamp = std::stod(token) / 1e9;  // ns를 초로 변환
     }
-    
-    std::string line;
-    // 헤더 건너뛰기
-    std::getline(file, line);
-    
-    while (std::getline(file, line)) {
-        if (line.empty()) continue;
-        
-        std::istringstream iss(line);
-        std::string token;
-        IMUData data;
-        
-        // timestamp [ns]를 초 단위로 변환
-        if (std::getline(iss, token, ',')) {
-            data.timestamp = std::stod(token) / 1e9; // ns를 초로 변환
-        }
-        
-        // angular velocity (rad/s)
-        if (std::getline(iss, token, ',')) data.angular_vel_x = std::stod(token);
-        if (std::getline(iss, token, ',')) data.angular_vel_y = std::stod(token);
-        if (std::getline(iss, token, ',')) data.angular_vel_z = std::stod(token);
-        
-        // linear acceleration (m/s^2)
-        if (std::getline(iss, token, ',')) data.linear_acc_x = std::stod(token);
-        if (std::getline(iss, token, ',')) data.linear_acc_y = std::stod(token);
-        if (std::getline(iss, token)) data.linear_acc_z = std::stod(token);
-        
-        imu_data_.push_back(data);
-    }
-    
-    file.close();
-    std::cout << "IMU 데이터 " << imu_data_.size() << "개 로드 완료" << std::endl;
-    return true;
+
+    // angular velocity (rad/s)
+    if (std::getline(iss, token, ',')) data.angular_vel_x = std::stod(token);
+    if (std::getline(iss, token, ',')) data.angular_vel_y = std::stod(token);
+    if (std::getline(iss, token, ',')) data.angular_vel_z = std::stod(token);
+
+    // linear acceleration (m/s^2)
+    if (std::getline(iss, token, ',')) data.linear_acc_x = std::stod(token);
+    if (std::getline(iss, token, ',')) data.linear_acc_y = std::stod(token);
+    if (std::getline(iss, token)) data.linear_acc_z = std::stod(token);
+
+    imu_data_.push_back(data);
+  }
+
+  file.close();
+  std::cout << "IMU 데이터 " << imu_data_.size() << "개 로드 완료" << std::endl;
+  return true;
 }
 
-bool MeasurementProcessor::loadImageFileData(const std::string& csv_filepath, const std::string& image_dir) {
-    std::cout << "\n2. 이미지 데이터 로드 중..." << std::endl;
-    
-    std::ifstream file(csv_filepath);
-    if (!file.is_open()) {
-        std::cerr << "이미지 CSV 파일을 열 수 없습니다: " << csv_filepath << std::endl;
-        return false;
+bool MeasurementProcessor::loadImageFileData(const std::string& csv_filepath,
+                                             const std::string& image_dir) {
+  std::cout << "\n2. 이미지 데이터 로드 중..." << std::endl;
+
+  std::ifstream file(csv_filepath);
+  if (!file.is_open()) {
+    std::cerr << "이미지 CSV 파일을 열 수 없습니다: " << csv_filepath << std::endl;
+    return false;
+  }
+
+  std::string line;
+  // 헤더 건너뛰기
+  std::getline(file, line);
+
+  while (std::getline(file, line)) {
+    if (line.empty()) continue;
+
+    std::istringstream iss(line);
+    std::string token;
+    ImageFileData data;
+
+    // timestamp [ns]를 초 단위로 변환
+    if (std::getline(iss, token, ',')) {
+      data.timestamp = std::stod(token) / 1e9;  // ns를 초로 변환
     }
-    
-    std::string line;
-    // 헤더 건너뛰기
-    std::getline(file, line);
-    
-    while (std::getline(file, line)) {
-        if (line.empty()) continue;
-        
-        std::istringstream iss(line);
-        std::string token;
-        ImageFileData data;
-        
-        // timestamp [ns]를 초 단위로 변환
-        if (std::getline(iss, token, ',')) {
-            data.timestamp = std::stod(token) / 1e9; // ns를 초로 변환
-        }
-        
-        // filename
-        if (std::getline(iss, token)) {
-            data.filename = cleanFilename(token);
-            data.full_path = image_dir + "/" + data.filename;
-        }
-        
-        image_file_data_.push_back(data);
+
+    // filename
+    if (std::getline(iss, token)) {
+      data.filename = cleanFilename(token);
+      data.full_path = image_dir + "/" + data.filename;
     }
-    
-    file.close();
-    std::cout << "이미지 데이터 " << image_file_data_.size() << "개 로드 완료" << std::endl;
-    return true;
+
+    image_file_data_.push_back(data);
+  }
+
+  file.close();
+  std::cout << "이미지 데이터 " << image_file_data_.size() << "개 로드 완료" << std::endl;
+  return true;
 }
 
 std::string MeasurementProcessor::cleanFilename(const std::string& filename) {
-    std::string cleaned = filename;
-    // 앞뒤 공백 및 개행 제거
-    cleaned.erase(cleaned.find_last_not_of(" \n\r\t") + 1);
-    cleaned.erase(0, cleaned.find_first_not_of(" \n\r\t"));
-    return cleaned;
+  std::string cleaned = filename;
+  // 앞뒤 공백 및 개행 제거
+  cleaned.erase(cleaned.find_last_not_of(" \n\r\t") + 1);
+  cleaned.erase(0, cleaned.find_first_not_of(" \n\r\t"));
+  return cleaned;
 }
 
 ImageFeatureMsg MeasurementProcessor::extractImageFeatures(const ImageFileData& image_data) {
-    ImageFeatureMsg image_feature_msg;
-    
-    // 항상 timestamp와 frame_id를 설정 (PUB_THIS_FRAME과 관계없이)
-    image_feature_msg.timestamp = image_data.timestamp;
-    image_feature_msg.frame_id = image_data.filename;
-    
-    cv::Mat show_img = cv::imread(image_data.full_path, cv::IMREAD_GRAYSCALE);
-    if (show_img.empty()) {
-        std::cerr << "이미지를 로드할 수 없습니다: " << image_data.full_path << std::endl;
-        return image_feature_msg;
-    }
-    
-    feature_tracker_->readImage(show_img.rowRange(0, g_config.camera.row), image_data.timestamp);
+  ImageFeatureMsg image_feature_msg;
 
-    for (unsigned int i = 0;; i++) {
-        bool completed = false;
-        completed |= feature_tracker_->updateID(i);
-        if (!completed)
-            break;
-    }
+  // 항상 timestamp와 frame_id를 설정 (PUB_THIS_FRAME과 관계없이)
+  image_feature_msg.timestamp = image_data.timestamp;
+  image_feature_msg.frame_id = image_data.filename;
 
-    std::vector<int32_t> id_of_point;
-    std::vector<float> u_of_point;
-    std::vector<float> v_of_point;
-    std::vector<float> velocity_x_of_point;
-    std::vector<float> velocity_y_of_point;
-
-    std::set<int> hash_ids;
-    auto &un_pts = feature_tracker_->cur_un_pts;
-    auto &cur_pts = feature_tracker_->cur_pts;
-    auto &ids = feature_tracker_->ids;
-    auto &pts_velocity = feature_tracker_->pts_velocity;
-    
-    for (unsigned int j = 0; j < ids.size(); j++) {
-        if (feature_tracker_->track_cnt[j] > 1) {
-            int p_id = ids[j];
-            hash_ids.insert(p_id);
-            image_feature_msg.feature_points.push_back(Point3D{p_id, un_pts[j].x, un_pts[j].y, 1.0});
-            id_of_point.push_back(p_id);
-            u_of_point.push_back(cur_pts[j].x);
-            v_of_point.push_back(cur_pts[j].y);
-            velocity_x_of_point.push_back(pts_velocity[j].x);
-            velocity_y_of_point.push_back(pts_velocity[j].y);
-        }
-    }
-    
-    image_feature_msg.points_count = image_feature_msg.feature_points.size();
-    image_feature_msg.channels_count = 5;
-    image_feature_msg.channel_data[0] = ChannelData(id_of_point.begin(), id_of_point.end());
-    image_feature_msg.channel_data[1] = ChannelData(u_of_point.begin(), u_of_point.end());
-    image_feature_msg.channel_data[2] = ChannelData(v_of_point.begin(), v_of_point.end());
-    image_feature_msg.channel_data[3] = ChannelData(velocity_x_of_point.begin(), velocity_x_of_point.end());
-    image_feature_msg.channel_data[4] = ChannelData(velocity_y_of_point.begin(), velocity_y_of_point.end());
-
-    if (g_config.feature_tracker.show_track) {
-        cv::Mat tmp_img = show_img.rowRange(0, g_config.camera.row);
-        cv::cvtColor(show_img, tmp_img, CV_GRAY2RGB);
-
-        for (unsigned int j = 0; j < feature_tracker_->cur_pts.size(); j++) {
-            double len = std::min(1.0, 1.0 * feature_tracker_->track_cnt[j] / g_config.feature_tracker.window_size);
-            cv::circle(tmp_img, feature_tracker_->cur_pts[j], 2, cv::Scalar(255 * (1 - len), 0, 255 * len), 2);
-        }
-
-        cv::imshow("show_img", tmp_img);
-        cv::waitKey(1);
-    }
-    
-    
+  cv::Mat show_img = cv::imread(image_data.full_path, cv::IMREAD_GRAYSCALE);
+  if (show_img.empty()) {
+    std::cerr << "이미지를 로드할 수 없습니다: " << image_data.full_path << std::endl;
     return image_feature_msg;
+  }
+
+  feature_tracker_->readImage(show_img.rowRange(0, g_config.camera.row), image_data.timestamp);
+
+  for (unsigned int i = 0;; i++) {
+    bool completed = false;
+    completed |= feature_tracker_->updateID(i);
+    if (!completed) break;
+  }
+
+  std::vector<int32_t> id_of_point;
+  std::vector<float> u_of_point;
+  std::vector<float> v_of_point;
+  std::vector<float> velocity_x_of_point;
+  std::vector<float> velocity_y_of_point;
+
+  std::set<int> hash_ids;
+  auto& un_pts = feature_tracker_->cur_un_pts;
+  auto& cur_pts = feature_tracker_->cur_pts;
+  auto& ids = feature_tracker_->ids;
+  auto& pts_velocity = feature_tracker_->pts_velocity;
+
+  for (unsigned int j = 0; j < ids.size(); j++) {
+    if (feature_tracker_->track_cnt[j] > 1) {
+      int p_id = ids[j];
+      hash_ids.insert(p_id);
+      image_feature_msg.feature_points.push_back(Point3D{p_id, un_pts[j].x, un_pts[j].y, 1.0});
+      id_of_point.push_back(p_id);
+      u_of_point.push_back(cur_pts[j].x);
+      v_of_point.push_back(cur_pts[j].y);
+      velocity_x_of_point.push_back(pts_velocity[j].x);
+      velocity_y_of_point.push_back(pts_velocity[j].y);
+    }
+  }
+
+  image_feature_msg.points_count = image_feature_msg.feature_points.size();
+  image_feature_msg.channels_count = 5;
+  image_feature_msg.channel_data[0] = ChannelData(id_of_point.begin(), id_of_point.end());
+  image_feature_msg.channel_data[1] = ChannelData(u_of_point.begin(), u_of_point.end());
+  image_feature_msg.channel_data[2] = ChannelData(v_of_point.begin(), v_of_point.end());
+  image_feature_msg.channel_data[3] =
+      ChannelData(velocity_x_of_point.begin(), velocity_x_of_point.end());
+  image_feature_msg.channel_data[4] =
+      ChannelData(velocity_y_of_point.begin(), velocity_y_of_point.end());
+
+  if (g_config.feature_tracker.show_track) {
+    cv::Mat tmp_img = show_img.rowRange(0, g_config.camera.row);
+    cv::cvtColor(show_img, tmp_img, CV_GRAY2RGB);
+
+    for (unsigned int j = 0; j < feature_tracker_->cur_pts.size(); j++) {
+      double len = std::min(
+          1.0, 1.0 * feature_tracker_->track_cnt[j] / g_config.feature_tracker.window_size);
+      cv::circle(tmp_img, feature_tracker_->cur_pts[j], 2,
+                 cv::Scalar(255 * (1 - len), 0, 255 * len), 2);
+    }
+
+    cv::imshow("show_img", tmp_img);
+    cv::waitKey(1);
+  }
+
+  return image_feature_msg;
 }
 
-MeasurementMsg MeasurementProcessor::createMeasurementMsg(int measurement_id, 
-                                                         const ImageFileData& image_data) {
-    MeasurementMsg msg;
-    msg.measurement_id = measurement_id;
-    
-    // 이미지 특징점 추출
-    msg.image_feature_msg = extractImageFeatures(image_data);
-    
-    // 현재 이미지 타임스탬프
-    double current_image_timestamp = image_data.timestamp;
-    
-    // IMU 데이터 수집 범위 결정
-    double start_time, end_time;
-    
-    if (prev_image_timestamp_ < 0) {
-        start_time = 0;
-        end_time = current_image_timestamp;
-    } else {
-        start_time = prev_image_timestamp_;
-        end_time = current_image_timestamp;
+MeasurementMsg MeasurementProcessor::createMeasurementMsg(int measurement_id,
+                                                          const ImageFileData& image_data) {
+  MeasurementMsg msg;
+  msg.measurement_id = measurement_id;
+
+  // 이미지 특징점 추출
+  msg.image_feature_msg = extractImageFeatures(image_data);
+
+  // 현재 이미지 타임스탬프
+  double current_image_timestamp = image_data.timestamp;
+
+  // IMU 데이터 수집 범위 결정
+  double start_time, end_time;
+
+  if (prev_image_timestamp_ < 0) {
+    start_time = 0;
+    end_time = current_image_timestamp;
+  } else {
+    start_time = prev_image_timestamp_;
+    end_time = current_image_timestamp;
+  }
+
+  // 시간 범위 내의 IMU 데이터 수집
+  for (const auto& imu : imu_data_) {
+    if (imu.timestamp >= start_time && imu.timestamp <= end_time) {
+      IMUMsg imu_msg;
+      imu_msg.timestamp = imu.timestamp;
+      imu_msg.linear_acc_x = imu.linear_acc_x;
+      imu_msg.linear_acc_y = imu.linear_acc_y;
+      imu_msg.linear_acc_z = imu.linear_acc_z;
+      imu_msg.angular_vel_x = imu.angular_vel_x;
+      imu_msg.angular_vel_y = imu.angular_vel_y;
+      imu_msg.angular_vel_z = imu.angular_vel_z;
+
+      msg.imu_msg.push_back(imu_msg);
     }
-    
-    // 시간 범위 내의 IMU 데이터 수집
-    for (const auto& imu : imu_data_) {
-        if (imu.timestamp >= start_time && imu.timestamp <= end_time) {
-            IMUMsg imu_msg;
-            imu_msg.timestamp = imu.timestamp;
-            imu_msg.linear_acc_x = imu.linear_acc_x;
-            imu_msg.linear_acc_y = imu.linear_acc_y;
-            imu_msg.linear_acc_z = imu.linear_acc_z;
-            imu_msg.angular_vel_x = imu.angular_vel_x;
-            imu_msg.angular_vel_y = imu.angular_vel_y;
-            imu_msg.angular_vel_z = imu.angular_vel_z;
-            
-            msg.imu_msg.push_back(imu_msg);
-        }
-    }
-    
-    // 현재 이미지 타임스탬프를 이전 타임스탬프로 저장
-    prev_image_timestamp_ = current_image_timestamp;
-    
-    return msg;
+  }
+
+  // 현재 이미지 타임스탬프를 이전 타임스탬프로 저장
+  prev_image_timestamp_ = current_image_timestamp;
+
+  return msg;
 }
 
 void MeasurementProcessor::printDataRange() const {
-    std::cout << "\n3. 데이터 범위 정보:" << std::endl;
-    if (!imu_data_.empty()) {
-        std::cout << "IMU 데이터 범위: ";
-        printTimeInfo(imu_data_.front().timestamp);
-        std::cout << " ~ ";
-        printTimeInfo(imu_data_.back().timestamp);
-        std::cout << std::endl;
-    }
-    
-    if (!image_file_data_.empty()) {
-        std::cout << "이미지 데이터 범위: ";
-        printTimeInfo(image_file_data_.front().timestamp);
-        std::cout << " ~ ";
-        printTimeInfo(image_file_data_.back().timestamp);
-        std::cout << std::endl;
-    }
+  std::cout << "\n3. 데이터 범위 정보:" << std::endl;
+  if (!imu_data_.empty()) {
+    std::cout << "IMU 데이터 범위: ";
+    printTimeInfo(imu_data_.front().timestamp);
+    std::cout << " ~ ";
+    printTimeInfo(imu_data_.back().timestamp);
+    std::cout << std::endl;
+  }
+
+  if (!image_file_data_.empty()) {
+    std::cout << "이미지 데이터 범위: ";
+    printTimeInfo(image_file_data_.front().timestamp);
+    std::cout << " ~ ";
+    printTimeInfo(image_file_data_.back().timestamp);
+    std::cout << std::endl;
+  }
 }
 
 void MeasurementProcessor::printTimeInfo(double timestamp) const {
-    std::time_t time_t = static_cast<std::time_t>(timestamp);
-    std::tm* tm = std::gmtime(&time_t);
-    
-    std::cout << std::fixed << std::setprecision(6) 
-              << timestamp << " (" 
-              << std::put_time(tm, "%Y-%m-%d %H:%M:%S") << " UTC)";
-} 
+  std::time_t time_t = static_cast<std::time_t>(timestamp);
+  std::tm* tm = std::gmtime(&time_t);
+
+  std::cout << std::fixed << std::setprecision(6) << timestamp << " ("
+            << std::put_time(tm, "%Y-%m-%d %H:%M:%S") << " UTC)";
+}

--- a/src/utility/measurement_reader.cpp
+++ b/src/utility/measurement_reader.cpp
@@ -1,182 +1,187 @@
 #include "utility/measurement_reader.h"
+
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
 
 bool readMeasurementFile(const std::string& filepath, MeasurementMsg& measurement) {
-    std::ifstream file(filepath);
-    if (!file.is_open()) {
-        std::cerr << "파일을 열 수 없습니다: " << filepath << std::endl;
-        return false;
+  std::ifstream file(filepath);
+  if (!file.is_open()) {
+    std::cerr << "파일을 열 수 없습니다: " << filepath << std::endl;
+    return false;
+  }
+
+  std::string line;
+  bool reading_imu = false;
+  bool reading_features = false;
+  bool reading_channels = false;
+
+  // 데이터 초기화
+  measurement.imu_msg.clear();
+  measurement.image_feature_msg.feature_points.clear();
+
+  while (std::getline(file, line)) {
+    // 빈 줄이나 주석 건너뛰기
+    if (line.empty() || line[0] == '#') {
+      // 측정 ID 파싱
+      if (line.find("# Measurement ") != std::string::npos) {
+        std::istringstream iss(line);
+        std::string hash, measurement_str;
+        int id;
+        iss >> hash >> measurement_str >> id;
+        measurement.measurement_id = id;
+      }
+      // IMU 데이터 섹션 시작
+      else if (line.find("## IMU DATA") != std::string::npos) {
+        reading_imu = true;
+        reading_features = false;
+        reading_channels = false;
+      }
+      // 이미지 특징점 데이터 섹션 시작
+      else if (line.find("## IMAGE FEATURE DATA") != std::string::npos) {
+        reading_imu = false;
+        reading_features = false;
+        reading_channels = false;
+      }
+      // 타임스탬프 파싱
+      else if (line.find("# timestamp: ") != std::string::npos) {
+        std::string temp = line.substr(line.find(": ") + 2);
+        measurement.image_feature_msg.timestamp = std::stod(temp);
+      }
+      // 프레임 ID 파싱
+      else if (line.find("# frame_id: ") != std::string::npos) {
+        measurement.image_feature_msg.frame_id = line.substr(line.find(": ") + 2);
+      }
+      // 포인트 개수 파싱
+      else if (line.find("# points_count: ") != std::string::npos) {
+        std::string temp = line.substr(line.find(": ") + 2);
+        measurement.image_feature_msg.points_count = std::stoi(temp);
+      }
+      // 채널 개수 파싱
+      else if (line.find("# channels_count: ") != std::string::npos) {
+        std::string temp = line.substr(line.find(": ") + 2);
+        measurement.image_feature_msg.channels_count = std::stoi(temp);
+      }
+      // 특징점 섹션 시작
+      else if (line.find("### FEATURE POINTS") != std::string::npos) {
+        reading_features = true;
+        reading_imu = false;
+        reading_channels = false;
+      }
+      // 채널 섹션 시작
+      else if (line.find("### CHANNEL") != std::string::npos) {
+        reading_channels = true;
+        reading_features = false;
+        reading_imu = false;
+      }
+      continue;
     }
 
-    std::string line;
-    bool reading_imu = false;
-    bool reading_features = false;
-    bool reading_channels = false;
-    
-    // 데이터 초기화
-    measurement.imu_msg.clear();
-    measurement.image_feature_msg.feature_points.clear();
+    // IMU 데이터 파싱
+    if (reading_imu) {
+      std::istringstream iss(line);
+      std::string token;
+      IMUMsg imu_msg;
 
-    while (std::getline(file, line)) {
-        // 빈 줄이나 주석 건너뛰기
-        if (line.empty() || line[0] == '#') {
-            // 측정 ID 파싱
-            if (line.find("# Measurement ") != std::string::npos) {
-                std::istringstream iss(line);
-                std::string hash, measurement_str;
-                int id;
-                iss >> hash >> measurement_str >> id;
-                measurement.measurement_id = id;
-            }
-            // IMU 데이터 섹션 시작
-            else if (line.find("## IMU DATA") != std::string::npos) {
-                reading_imu = true;
-                reading_features = false;
-                reading_channels = false;
-            }
-            // 이미지 특징점 데이터 섹션 시작
-            else if (line.find("## IMAGE FEATURE DATA") != std::string::npos) {
-                reading_imu = false;
-                reading_features = false;
-                reading_channels = false;
-            }
-            // 타임스탬프 파싱
-            else if (line.find("# timestamp: ") != std::string::npos) {
-                std::string temp = line.substr(line.find(": ") + 2);
-                measurement.image_feature_msg.timestamp = std::stod(temp);
-            }
-            // 프레임 ID 파싱
-            else if (line.find("# frame_id: ") != std::string::npos) {
-                measurement.image_feature_msg.frame_id = line.substr(line.find(": ") + 2);
-            }
-            // 포인트 개수 파싱
-            else if (line.find("# points_count: ") != std::string::npos) {
-                std::string temp = line.substr(line.find(": ") + 2);
-                measurement.image_feature_msg.points_count = std::stoi(temp);
-            }
-            // 채널 개수 파싱
-            else if (line.find("# channels_count: ") != std::string::npos) {
-                std::string temp = line.substr(line.find(": ") + 2);
-                measurement.image_feature_msg.channels_count = std::stoi(temp);
-            }
-            // 특징점 섹션 시작
-            else if (line.find("### FEATURE POINTS") != std::string::npos) {
-                reading_features = true;
-                reading_imu = false;
-                reading_channels = false;
-            }
-            // 채널 섹션 시작
-            else if (line.find("### CHANNEL") != std::string::npos) {
-                reading_channels = true;
-                reading_features = false;
-                reading_imu = false;
-            }
-            continue;
-        }
+      // 쉼표로 구분된 데이터 파싱
+      if (std::getline(iss, token, ',')) {
+        imu_msg.timestamp = std::stod(token);
+        if (std::getline(iss, token, ',')) imu_msg.linear_acc_x = std::stod(token);
+        if (std::getline(iss, token, ',')) imu_msg.linear_acc_y = std::stod(token);
+        if (std::getline(iss, token, ',')) imu_msg.linear_acc_z = std::stod(token);
+        if (std::getline(iss, token, ',')) imu_msg.angular_vel_x = std::stod(token);
+        if (std::getline(iss, token, ',')) imu_msg.angular_vel_y = std::stod(token);
+        if (std::getline(iss, token)) imu_msg.angular_vel_z = std::stod(token);
 
-        // IMU 데이터 파싱
-        if (reading_imu) {
-            std::istringstream iss(line);
-            std::string token;
-            IMUMsg imu_msg;
-            
-            // 쉼표로 구분된 데이터 파싱
-            if (std::getline(iss, token, ',')) {
-                imu_msg.timestamp = std::stod(token);
-                if (std::getline(iss, token, ',')) imu_msg.linear_acc_x = std::stod(token);
-                if (std::getline(iss, token, ',')) imu_msg.linear_acc_y = std::stod(token);
-                if (std::getline(iss, token, ',')) imu_msg.linear_acc_z = std::stod(token);
-                if (std::getline(iss, token, ',')) imu_msg.angular_vel_x = std::stod(token);
-                if (std::getline(iss, token, ',')) imu_msg.angular_vel_y = std::stod(token);
-                if (std::getline(iss, token)) imu_msg.angular_vel_z = std::stod(token);
-                
-                measurement.imu_msg.push_back(imu_msg);
-            }
-        }
-        // 특징점 데이터 파싱
-        else if (reading_features) {
-            std::istringstream iss(line);
-            std::string token;
-            Point3D point;
-            
-            // 쉼표로 구분된 데이터 파싱
-            if (std::getline(iss, token, ',')) {
-                point.index = std::stoi(token);
-                if (std::getline(iss, token, ',')) point.x = std::stod(token);
-                if (std::getline(iss, token, ',')) point.y = std::stod(token);
-                if (std::getline(iss, token)) point.z = std::stod(token);
-                
-                measurement.image_feature_msg.feature_points.push_back(point);
-            }
-        }
-        // 채널 데이터 파싱
-        else if (reading_channels) {
-            std::istringstream iss(line);
-            std::string token;
-            
-            // 쉼표로 구분된 데이터 파싱
-            if (std::getline(iss, token, ',')) {
-                int32_t index = std::stoi(token);
-                if (std::getline(iss, token, ',')) {
-                    double value = std::stod(token);
-                    measurement.image_feature_msg.channel_data[0].push_back(value);
-                }
-                if (std::getline(iss, token, ',')) {
-                    double value = std::stod(token);
-                    measurement.image_feature_msg.channel_data[1].push_back(value);
-                }
-                if (std::getline(iss, token, ',')) {
-                    double value = std::stod(token);
-                    measurement.image_feature_msg.channel_data[2].push_back(value);
-                }
-                if (std::getline(iss, token, ',')) {
-                    double value = std::stod(token);
-                    measurement.image_feature_msg.channel_data[3].push_back(value);
-                }
-                if (std::getline(iss, token, ',')) {
-                    double value = std::stod(token);
-                    measurement.image_feature_msg.channel_data[4].push_back(value);
-                }
-            }
-        }
+        measurement.imu_msg.push_back(imu_msg);
+      }
     }
+    // 특징점 데이터 파싱
+    else if (reading_features) {
+      std::istringstream iss(line);
+      std::string token;
+      Point3D point;
 
-    file.close();
-    return true;
+      // 쉼표로 구분된 데이터 파싱
+      if (std::getline(iss, token, ',')) {
+        point.index = std::stoi(token);
+        if (std::getline(iss, token, ',')) point.x = std::stod(token);
+        if (std::getline(iss, token, ',')) point.y = std::stod(token);
+        if (std::getline(iss, token)) point.z = std::stod(token);
+
+        measurement.image_feature_msg.feature_points.push_back(point);
+      }
+    }
+    // 채널 데이터 파싱
+    else if (reading_channels) {
+      std::istringstream iss(line);
+      std::string token;
+
+      // 쉼표로 구분된 데이터 파싱
+      if (std::getline(iss, token, ',')) {
+        int32_t index = std::stoi(token);
+        if (std::getline(iss, token, ',')) {
+          double value = std::stod(token);
+          measurement.image_feature_msg.channel_data[0].push_back(value);
+        }
+        if (std::getline(iss, token, ',')) {
+          double value = std::stod(token);
+          measurement.image_feature_msg.channel_data[1].push_back(value);
+        }
+        if (std::getline(iss, token, ',')) {
+          double value = std::stod(token);
+          measurement.image_feature_msg.channel_data[2].push_back(value);
+        }
+        if (std::getline(iss, token, ',')) {
+          double value = std::stod(token);
+          measurement.image_feature_msg.channel_data[3].push_back(value);
+        }
+        if (std::getline(iss, token, ',')) {
+          double value = std::stod(token);
+          measurement.image_feature_msg.channel_data[4].push_back(value);
+        }
+      }
+    }
+  }
+
+  file.close();
+  return true;
 }
 
 void printMeasurementMsg(const MeasurementMsg& measurement) {
-    std::cout << "=== Measurement " << measurement.measurement_id << " ===" << std::endl;
-    
-    // IMU 데이터 출력
-    std::cout << "IMU Msg (" << measurement.imu_msg.size() << " samples):" << std::endl;
-    for (size_t i = 0; i < std::min(measurement.imu_msg.size(), size_t(5)); ++i) {
-        const auto& imu = measurement.imu_msg[i];
-        std::cout << "  [" << i << "] Time: " << imu.timestamp 
-                  << ", Acc: (" << imu.linear_acc_x << ", " << imu.linear_acc_y << ", " << imu.linear_acc_z << ")"
-                  << ", Gyro: (" << imu.angular_vel_x << ", " << imu.angular_vel_y << ", " << imu.angular_vel_z << ")" << std::endl;
-    }
-    if (measurement.imu_msg.size() > 5) {
-        std::cout << "  ... and " << (measurement.imu_msg.size() - 5) << " more samples" << std::endl;
-    }
-    
-    // 이미지 특징점 데이터 출력
-    std::cout << "Image Feature Msg:" << std::endl;
-    std::cout << "  Timestamp: " << measurement.image_feature_msg.timestamp << std::endl;
-    std::cout << "  Frame ID: " << measurement.image_feature_msg.frame_id << std::endl;
-    std::cout << "  Points Count: " << measurement.image_feature_msg.points_count << std::endl;
-    std::cout << "  Channels Count: " << measurement.image_feature_msg.channels_count << std::endl;
-    
-    std::cout << "  Feature Points (" << measurement.image_feature_msg.feature_points.size() << " points):" << std::endl;
-    for (size_t i = 0; i < std::min(measurement.image_feature_msg.feature_points.size(), size_t(5)); ++i) {
-        const auto& point = measurement.image_feature_msg.feature_points[i];
-        std::cout << "    [" << point.index << "] (" << point.x << ", " << point.y << ", " << point.z << ")" << std::endl;
-    }
-    if (measurement.image_feature_msg.feature_points.size() > 5) {
-        std::cout << "    ... and " << (measurement.image_feature_msg.feature_points.size() - 5) << " more points" << std::endl;
-    }
-    
-} 
+  std::cout << "=== Measurement " << measurement.measurement_id << " ===" << std::endl;
+
+  // IMU 데이터 출력
+  std::cout << "IMU Msg (" << measurement.imu_msg.size() << " samples):" << std::endl;
+  for (size_t i = 0; i < std::min(measurement.imu_msg.size(), size_t(5)); ++i) {
+    const auto& imu = measurement.imu_msg[i];
+    std::cout << "  [" << i << "] Time: " << imu.timestamp << ", Acc: (" << imu.linear_acc_x << ", "
+              << imu.linear_acc_y << ", " << imu.linear_acc_z << ")"
+              << ", Gyro: (" << imu.angular_vel_x << ", " << imu.angular_vel_y << ", "
+              << imu.angular_vel_z << ")" << std::endl;
+  }
+  if (measurement.imu_msg.size() > 5) {
+    std::cout << "  ... and " << (measurement.imu_msg.size() - 5) << " more samples" << std::endl;
+  }
+
+  // 이미지 특징점 데이터 출력
+  std::cout << "Image Feature Msg:" << std::endl;
+  std::cout << "  Timestamp: " << measurement.image_feature_msg.timestamp << std::endl;
+  std::cout << "  Frame ID: " << measurement.image_feature_msg.frame_id << std::endl;
+  std::cout << "  Points Count: " << measurement.image_feature_msg.points_count << std::endl;
+  std::cout << "  Channels Count: " << measurement.image_feature_msg.channels_count << std::endl;
+
+  std::cout << "  Feature Points (" << measurement.image_feature_msg.feature_points.size()
+            << " points):" << std::endl;
+  for (size_t i = 0; i < std::min(measurement.image_feature_msg.feature_points.size(), size_t(5));
+       ++i) {
+    const auto& point = measurement.image_feature_msg.feature_points[i];
+    std::cout << "    [" << point.index << "] (" << point.x << ", " << point.y << ", " << point.z
+              << ")" << std::endl;
+  }
+  if (measurement.image_feature_msg.feature_points.size() > 5) {
+    std::cout << "    ... and " << (measurement.image_feature_msg.feature_points.size() - 5)
+              << " more points" << std::endl;
+  }
+}

--- a/src/utility/test_result_logger.cpp
+++ b/src/utility/test_result_logger.cpp
@@ -1,138 +1,139 @@
 #include "utility/test_result_logger.h"
-#include <iostream>
+
+#include <experimental/filesystem>
 #include <fstream>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
-#include <experimental/filesystem>
 
 using namespace utility;
 namespace fs = std::experimental::filesystem;
 
-TestResultLogger::TestResultLogger() : log_dir_("") {
-}
+TestResultLogger::TestResultLogger() : log_dir_("") {}
 
-TestResultLogger::~TestResultLogger() {
-}
+TestResultLogger::~TestResultLogger() {}
 
 bool TestResultLogger::initialize(const std::string& config_path) {
-    try {
-        std::cout << "=== TestResultLogger Initialization Start ===" << std::endl;
-        
-        // Create log directory with timestamp
-        log_dir_ = "logs/" + getTimestampString();
-        if (fs::create_directories(log_dir_)) {
-            std::cout << "Log directory created: " << log_dir_ << std::endl;
-        } else {
-            std::cout << "Log directory already exists or failed to create: " << log_dir_ << std::endl;
-        }
+  try {
+    std::cout << "=== TestResultLogger Initialization Start ===" << std::endl;
 
-        // Copy config file to log directory
-        copyConfigFile(config_path);
-        
-        std::cout << "=== TestResultLogger Initialization Complete ===" << std::endl;
-        return true;
-        
-    } catch (const std::exception& e) {
-        std::cerr << "TestResultLogger init failed: " << e.what() << std::endl;
-        return false;
+    // Create log directory with timestamp
+    log_dir_ = "logs/" + getTimestampString();
+    if (fs::create_directories(log_dir_)) {
+      std::cout << "Log directory created: " << log_dir_ << std::endl;
+    } else {
+      std::cout << "Log directory already exists or failed to create: " << log_dir_ << std::endl;
     }
+
+    // Copy config file to log directory
+    copyConfigFile(config_path);
+
+    std::cout << "=== TestResultLogger Initialization Complete ===" << std::endl;
+    return true;
+
+  } catch (const std::exception& e) {
+    std::cerr << "TestResultLogger init failed: " << e.what() << std::endl;
+    return false;
+  }
 }
 
-void TestResultLogger::addPose(const Eigen::Vector3d& position, const Eigen::Matrix3d& rotation, double timestamp) {
-    std::lock_guard<std::mutex> lock(pose_mutex_);
-    
-    // Validate input data
-    if (!position.allFinite() || !rotation.allFinite()) {
-        std::cerr << "TestResultLogger: Invalid pose data received!" << std::endl;
-        return;
-    }
-    
-    camera_poses_.push_back(position);
-    camera_rotations_.push_back(rotation);
-    trajectory_timestamps_.push_back(timestamp);
-    
-    // Log progress occasionally
-    static int log_counter = 0;
-    if (++log_counter % 10 == 0) {
-        std::cout << "TestResultLogger received pose " << camera_poses_.size() 
-                  << ": [" << position.x() << ", " << position.y() << ", " << position.z() 
-                  << "] timestamp: " << timestamp << std::endl;
-    }
+void TestResultLogger::addPose(const Eigen::Vector3d& position, const Eigen::Matrix3d& rotation,
+                               double timestamp) {
+  std::lock_guard<std::mutex> lock(pose_mutex_);
+
+  // Validate input data
+  if (!position.allFinite() || !rotation.allFinite()) {
+    std::cerr << "TestResultLogger: Invalid pose data received!" << std::endl;
+    return;
+  }
+
+  camera_poses_.push_back(position);
+  camera_rotations_.push_back(rotation);
+  trajectory_timestamps_.push_back(timestamp);
+
+  // Log progress occasionally
+  static int log_counter = 0;
+  if (++log_counter % 10 == 0) {
+    std::cout << "TestResultLogger received pose " << camera_poses_.size() << ": [" << position.x()
+              << ", " << position.y() << ", " << position.z() << "] timestamp: " << timestamp
+              << std::endl;
+  }
 }
 
 void TestResultLogger::saveTrajectoryToFile() {
-    std::lock_guard<std::mutex> lock(pose_mutex_);
-    
-    if (camera_poses_.empty() || trajectory_timestamps_.empty() || camera_rotations_.empty()) {
-        std::cout << "No trajectory data to save." << std::endl;
-        return;
-    }
-    
-    try {
-        if (log_dir_.empty()) {
-            std::cerr << "Log directory not initialized. Cannot save trajectory." << std::endl;
-            return;
-        }
+  std::lock_guard<std::mutex> lock(pose_mutex_);
 
-        std::string file_path = log_dir_ + "/trajectory_pose.txt";
-        std::ofstream pose_file(file_path);
+  if (camera_poses_.empty() || trajectory_timestamps_.empty() || camera_rotations_.empty()) {
+    std::cout << "No trajectory data to save." << std::endl;
+    return;
+  }
 
-        if (!pose_file.is_open()) {
-            std::cerr << "Failed to open " << file_path << " for writing" << std::endl;
-            return;
-        }
-        
-        pose_file << "# timestamp tx ty tz qx qy qz qw" << std::endl;
-        
-        // Ensure we don't exceed the bounds
-        size_t num_poses = std::min({camera_poses_.size(), camera_rotations_.size(), trajectory_timestamps_.size()});
-        
-        for (size_t i = 0; i < num_poses; i++) {
-            const auto& pos = camera_poses_[i];
-            const auto& rot = camera_rotations_[i];
-            double timestamp = trajectory_timestamps_[i];
-            
-            if (pos.allFinite() && rot.allFinite()) {
-                Eigen::Quaterniond q(rot);
-                pose_file << std::fixed << std::setprecision(9) << timestamp << " "
-                          << std::fixed << std::setprecision(6) 
-                          << pos.x() << " " << pos.y() << " " << pos.z() << " "
-                          << q.x() << " " << q.y() << " " << q.z() << " " << q.w() << std::endl;
-            }
-        }
-        
-        pose_file.close();
-        std::cout << "✅ Trajectory saved to " << file_path << " (" << num_poses << " poses)" << std::endl;
-        
-    } catch (const std::exception& e) {
-        std::cerr << "Error saving trajectory to file: " << e.what() << std::endl;
+  try {
+    if (log_dir_.empty()) {
+      std::cerr << "Log directory not initialized. Cannot save trajectory." << std::endl;
+      return;
     }
+
+    std::string file_path = log_dir_ + "/trajectory_pose.txt";
+    std::ofstream pose_file(file_path);
+
+    if (!pose_file.is_open()) {
+      std::cerr << "Failed to open " << file_path << " for writing" << std::endl;
+      return;
+    }
+
+    pose_file << "# timestamp tx ty tz qx qy qz qw" << std::endl;
+
+    // Ensure we don't exceed the bounds
+    size_t num_poses =
+        std::min({camera_poses_.size(), camera_rotations_.size(), trajectory_timestamps_.size()});
+
+    for (size_t i = 0; i < num_poses; i++) {
+      const auto& pos = camera_poses_[i];
+      const auto& rot = camera_rotations_[i];
+      double timestamp = trajectory_timestamps_[i];
+
+      if (pos.allFinite() && rot.allFinite()) {
+        Eigen::Quaterniond q(rot);
+        pose_file << std::fixed << std::setprecision(9) << timestamp << " " << std::fixed
+                  << std::setprecision(6) << pos.x() << " " << pos.y() << " " << pos.z() << " "
+                  << q.x() << " " << q.y() << " " << q.z() << " " << q.w() << std::endl;
+      }
+    }
+
+    pose_file.close();
+    std::cout << "✅ Trajectory saved to " << file_path << " (" << num_poses << " poses)"
+              << std::endl;
+
+  } catch (const std::exception& e) {
+    std::cerr << "Error saving trajectory to file: " << e.what() << std::endl;
+  }
 }
 
 size_t TestResultLogger::getPoseCount() const {
-    std::lock_guard<std::mutex> lock(pose_mutex_);
-    return camera_poses_.size();
+  std::lock_guard<std::mutex> lock(pose_mutex_);
+  return camera_poses_.size();
 }
 
 std::string TestResultLogger::getTimestampString() const {
-    auto now = std::chrono::system_clock::now();
-    auto in_time_t = std::chrono::system_clock::to_time_t(now);
-    std::stringstream ss;
-    ss << std::put_time(std::localtime(&in_time_t), "%Y%m%d_%H%M%S");
-    return ss.str();
+  auto now = std::chrono::system_clock::now();
+  auto in_time_t = std::chrono::system_clock::to_time_t(now);
+  std::stringstream ss;
+  ss << std::put_time(std::localtime(&in_time_t), "%Y%m%d_%H%M%S");
+  return ss.str();
 }
 
 void TestResultLogger::copyConfigFile(const std::string& config_path) {
-    try {
-        fs::path src_path(config_path);
-        if (fs::exists(src_path)) {
-            fs::path dst_path = fs::path(log_dir_) / src_path.filename();
-            fs::copy_file(src_path, dst_path, fs::copy_options::overwrite_existing);
-            std::cout << "✅ Copied config file to " << dst_path << std::endl;
-        } else {
-            std::cerr << "⚠️ Config file not found at " << config_path << ", skipping copy." << std::endl;
-        }
-    } catch (const fs::filesystem_error& e) {
-        std::cerr << "❌ Failed to copy config file: " << e.what() << std::endl;
+  try {
+    fs::path src_path(config_path);
+    if (fs::exists(src_path)) {
+      fs::path dst_path = fs::path(log_dir_) / src_path.filename();
+      fs::copy_file(src_path, dst_path, fs::copy_options::overwrite_existing);
+      std::cout << "✅ Copied config file to " << dst_path << std::endl;
+    } else {
+      std::cerr << "⚠️ Config file not found at " << config_path << ", skipping copy." << std::endl;
     }
-} 
+  } catch (const fs::filesystem_error& e) {
+    std::cerr << "❌ Failed to copy config file: " << e.what() << std::endl;
+  }
+}

--- a/src/utility/utility.cpp
+++ b/src/utility/utility.cpp
@@ -1,55 +1,59 @@
 #include "utility/utility.h"
+
 #include <dirent.h>
+
 #include <algorithm>
 #include <cstring>
 
-Eigen::Matrix3d Utility::g2R(const Eigen::Vector3d &g) {
-    Eigen::Matrix3d R0;
-    Eigen::Vector3d ng1 = g.normalized();
-    Eigen::Vector3d ng2{0, 0, 1.0};
-    R0 = Eigen::Quaterniond::FromTwoVectors(ng1, ng2).toRotationMatrix();
-    double yaw = Utility::R2ypr(R0).x();
-    R0 = Utility::ypr2R(Eigen::Vector3d{-yaw, 0, 0}) * R0;
-    // R0 = Utility::ypr2R(Eigen::Vector3d{-90, 0, 0}) * R0;
-    return R0;
+Eigen::Matrix3d Utility::g2R(const Eigen::Vector3d& g) {
+  Eigen::Matrix3d R0;
+  Eigen::Vector3d ng1 = g.normalized();
+  Eigen::Vector3d ng2{0, 0, 1.0};
+  R0 = Eigen::Quaterniond::FromTwoVectors(ng1, ng2).toRotationMatrix();
+  double yaw = Utility::R2ypr(R0).x();
+  R0 = Utility::ypr2R(Eigen::Vector3d{-yaw, 0, 0}) * R0;
+  // R0 = Utility::ypr2R(Eigen::Vector3d{-90, 0, 0}) * R0;
+  return R0;
 }
 
 std::vector<std::string> utility::getImageFilesFromDirectory(const std::string& directory_path) {
-    std::vector<std::string> image_files;
-    
-    DIR* dir = opendir(directory_path.c_str());
-    if (dir == nullptr) {
-        std::cerr << "Error opening directory " << directory_path << ": " << strerror(errno) << std::endl;
-        return image_files;
-    }
-    
-    struct dirent* entry;
-    while ((entry = readdir(dir)) != nullptr) {
-        if (entry->d_type == DT_REG) { // Regular file
-            std::string filename = entry->d_name;
-            std::string file_path = directory_path + "/" + filename;
-            
-            // Check file extension
-            std::string extension;
-            size_t dot_pos = filename.find_last_of('.');
-            if (dot_pos != std::string::npos) {
-                extension = filename.substr(dot_pos);
-                std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
-                
-                if (extension == ".png" || extension == ".jpg" || extension == ".jpeg" || 
-                    extension == ".bmp" || extension == ".tiff" || extension == ".tif") {
-                    image_files.push_back(file_path);
-                }
-            }
-        }
-    }
-    
-    closedir(dir);
-    
-    // Sort files by name to ensure chronological order
-    std::sort(image_files.begin(), image_files.end());
-    
-    std::cout << "Found " << image_files.size() << " image files in directory: " << directory_path << std::endl;
-    
+  std::vector<std::string> image_files;
+
+  DIR* dir = opendir(directory_path.c_str());
+  if (dir == nullptr) {
+    std::cerr << "Error opening directory " << directory_path << ": " << strerror(errno)
+              << std::endl;
     return image_files;
+  }
+
+  struct dirent* entry;
+  while ((entry = readdir(dir)) != nullptr) {
+    if (entry->d_type == DT_REG) {  // Regular file
+      std::string filename = entry->d_name;
+      std::string file_path = directory_path + "/" + filename;
+
+      // Check file extension
+      std::string extension;
+      size_t dot_pos = filename.find_last_of('.');
+      if (dot_pos != std::string::npos) {
+        extension = filename.substr(dot_pos);
+        std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
+
+        if (extension == ".png" || extension == ".jpg" || extension == ".jpeg" ||
+            extension == ".bmp" || extension == ".tiff" || extension == ".tif") {
+          image_files.push_back(file_path);
+        }
+      }
+    }
+  }
+
+  closedir(dir);
+
+  // Sort files by name to ensure chronological order
+  std::sort(image_files.begin(), image_files.end());
+
+  std::cout << "Found " << image_files.size() << " image files in directory: " << directory_path
+            << std::endl;
+
+  return image_files;
 }

--- a/src/utility/visualizer.cpp
+++ b/src/utility/visualizer.cpp
@@ -1,499 +1,507 @@
 #include "utility/visualizer.h"
-#include "utility/config.h"
-#include <iostream>
+
+#include <algorithm>
+#include <chrono>
+#include <experimental/filesystem>
 #include <fstream>
 #include <iomanip>
-#include <chrono>
-#include <algorithm>
-#include <experimental/filesystem>
+#include <iostream>
 #include <sstream>
+
+#include "utility/config.h"
 
 using namespace utility;
 namespace fs = std::experimental::filesystem;
 
-Visualizer::Visualizer() 
-    : running_(false), g_s_cam_(nullptr), g_d_cam_(nullptr) {
-}
+Visualizer::Visualizer() : running_(false), g_s_cam_(nullptr), g_d_cam_(nullptr) {}
 
-Visualizer::~Visualizer() {
-    stop();
-}
+Visualizer::~Visualizer() { stop(); }
 
 bool Visualizer::initialize() {
-    try {
-        std::cout << "=== Visualizer Initialization Start ===" << std::endl;
-        
-        // DISPLAY environment variable check
-        const char* display = getenv("DISPLAY");
-        std::cout << "DISPLAY: " << (display ? display : "NOT SET") << std::endl;
-        
-        // Create Pangolin window
-        std::cout << "Creating Pangolin window..." << std::endl;
-        pangolin::CreateWindowAndBind("Visualizer Test", 1024, 768);
-        std::cout << "Window created successfully" << std::endl;
-        
-        // OpenGL settings
-        glEnable(GL_DEPTH_TEST);
-        glEnable(GL_BLEND);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        std::cout << "OpenGL depth test and blend enabled" << std::endl;
-        
-        // Render state setup
-        g_s_cam_ = new pangolin::OpenGlRenderState(
-            pangolin::ProjectionMatrix(1024, 768, 500, 500, 512, 389, 0.1, 1000),
-            pangolin::ModelViewLookAt(-3, 0, 0, 2, 0, 0, pangolin::AxisZ)
-        );
-        std::cout << "Render state created" << std::endl;
-        
-        // View setup
-        g_d_cam_ = &pangolin::CreateDisplay()
-            .SetBounds(0.0, 1.0, 0.0, 0.7, -1024.0f/768.0f)
-            .SetHandler(new pangolin::Handler3D(*g_s_cam_));
-        std::cout << "Display created" << std::endl;
-        
-        std::cout << "=== Visualizer Initialization Complete ===" << std::endl;
-        return true;
-        
-    } catch (const std::exception& e) {
-        std::cerr << "Visualizer init failed: " << e.what() << std::endl;
-        return false;
-    }
+  try {
+    std::cout << "=== Visualizer Initialization Start ===" << std::endl;
+
+    // DISPLAY environment variable check
+    const char* display = getenv("DISPLAY");
+    std::cout << "DISPLAY: " << (display ? display : "NOT SET") << std::endl;
+
+    // Create Pangolin window
+    std::cout << "Creating Pangolin window..." << std::endl;
+    pangolin::CreateWindowAndBind("Visualizer Test", 1024, 768);
+    std::cout << "Window created successfully" << std::endl;
+
+    // OpenGL settings
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    std::cout << "OpenGL depth test and blend enabled" << std::endl;
+
+    // Render state setup
+    g_s_cam_ = new pangolin::OpenGlRenderState(
+        pangolin::ProjectionMatrix(1024, 768, 500, 500, 512, 389, 0.1, 1000),
+        pangolin::ModelViewLookAt(-3, 0, 0, 2, 0, 0, pangolin::AxisZ));
+    std::cout << "Render state created" << std::endl;
+
+    // View setup
+    g_d_cam_ = &pangolin::CreateDisplay()
+                    .SetBounds(0.0, 1.0, 0.0, 0.7, -1024.0f / 768.0f)
+                    .SetHandler(new pangolin::Handler3D(*g_s_cam_));
+    std::cout << "Display created" << std::endl;
+
+    std::cout << "=== Visualizer Initialization Complete ===" << std::endl;
+    return true;
+
+  } catch (const std::exception& e) {
+    std::cerr << "Visualizer init failed: " << e.what() << std::endl;
+    return false;
+  }
 }
 
 bool Visualizer::start() {
-    if (!running_) {
-        try {
-            running_ = true;
-            viewer_thread_ = std::thread(&Visualizer::pangolinViewerThread, this);
-            std::cout << "Visualizer started successfully" << std::endl;
-            return true;
-        } catch (const std::exception& e) {
-            std::cerr << "Failed to start Visualizer: " << e.what() << std::endl;
-            running_ = false;
-            return false;
-        }
+  if (!running_) {
+    try {
+      running_ = true;
+      viewer_thread_ = std::thread(&Visualizer::pangolinViewerThread, this);
+      std::cout << "Visualizer started successfully" << std::endl;
+      return true;
+    } catch (const std::exception& e) {
+      std::cerr << "Failed to start Visualizer: " << e.what() << std::endl;
+      running_ = false;
+      return false;
     }
-    return true; // 이미 실행 중이면 성공으로 간주
+  }
+  return true;  // 이미 실행 중이면 성공으로 간주
 }
 
 void Visualizer::stop() {
-    running_ = false;
-    if (viewer_thread_.joinable()) {
-        viewer_thread_.join();
-    }
+  running_ = false;
+  if (viewer_thread_.joinable()) {
+    viewer_thread_.join();
+  }
 }
 
 void Visualizer::setupPangolinViewer() {
-    // This function is called from pangolinViewerThread
-    // Initialization is already done in initialize()
+  // This function is called from pangolinViewerThread
+  // Initialization is already done in initialize()
 }
 
 void Visualizer::pangolinViewerThread() {
-    running_ = true;
-    try {
-        {
-            std::lock_guard<std::mutex> lk(render_ready_mutex_);
-            render_ready_ = true;
-        }
-        render_ready_cv_.notify_all();
-        std::cout << "=== Starting Visualizer render loop ===" << std::endl;
-        
-        // 루프 시작 전 상태 확인
-        std::cout << "Before loop - running_: " << (running_ ? "true" : "false") << std::endl;
-        std::cout << "Before loop - ShouldQuit(): " << (pangolin::ShouldQuit() ? "true" : "false") << std::endl;
-        
-        int frame_count = 0;
-        while (!pangolin::ShouldQuit() && running_) {
-            frame_count++;
-            
-            // 매 프레임마다 로그 출력 (처음 10프레임)
-            if (frame_count <= 10) {
-                std::cout << "Render frame " << frame_count << " - poses: " << camera_poses_.size() 
-                          << ", running: " << (running_ ? "true" : "false")
-                          << ", should_quit: " << (pangolin::ShouldQuit() ? "true" : "false") << std::endl;
-            }
-            // 이후 10프레임마다 출력
-            else if (frame_count % 10 == 0) {
-                std::cout << "Render frame " << frame_count << " - poses: " << camera_poses_.size() << std::endl;
-            }
-            
-            // 화면 클리어
-            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-            
-            // 카메라 뷰 활성화
-            if (g_d_cam_ && g_s_cam_) {
-                g_d_cam_->Activate(*g_s_cam_);
-            } else {
-                std::cerr << "Warning: Camera view not available at frame " << frame_count << std::endl;
-            }
-            
-            // 좌표축 그리기
-            drawCoordinateFrame();
-            
-            // 그리드 그리기
-            drawGrid();
-            
-            // 궤적 그리기
-            drawCameraTrajectory();
-            
-            // 3D 맵포인트 그리기
-            drawFeaturePoints3D();
-            
-            // 프레임 완료
-            pangolin::FinishFrame();
-            
-            // 프레임 레이트 제어
-            std::this_thread::sleep_for(std::chrono::milliseconds(33));
-        }
-        
-        std::cout << "=== Visualizer render loop ended ===" << std::endl;
-        std::cout << "Final frame count: " << frame_count << std::endl;
-        std::cout << "Final pose count: " << camera_poses_.size() << std::endl;
-        std::cout << "Exit reason - running_: " << (running_ ? "true" : "false") << std::endl;
-        std::cout << "Exit reason - ShouldQuit(): " << (pangolin::ShouldQuit() ? "true" : "false") << std::endl;
-        
-    } catch (const std::exception& e) {
-        std::cerr << "Visualizer render error: " << e.what() << std::endl;
+  running_ = true;
+  try {
+    {
+      std::lock_guard<std::mutex> lk(render_ready_mutex_);
+      render_ready_ = true;
     }
+    render_ready_cv_.notify_all();
+    std::cout << "=== Starting Visualizer render loop ===" << std::endl;
+
+    // 루프 시작 전 상태 확인
+    std::cout << "Before loop - running_: " << (running_ ? "true" : "false") << std::endl;
+    std::cout << "Before loop - ShouldQuit(): " << (pangolin::ShouldQuit() ? "true" : "false")
+              << std::endl;
+
+    int frame_count = 0;
+    while (!pangolin::ShouldQuit() && running_) {
+      frame_count++;
+
+      // 매 프레임마다 로그 출력 (처음 10프레임)
+      if (frame_count <= 10) {
+        std::cout << "Render frame " << frame_count << " - poses: " << camera_poses_.size()
+                  << ", running: " << (running_ ? "true" : "false")
+                  << ", should_quit: " << (pangolin::ShouldQuit() ? "true" : "false") << std::endl;
+      }
+      // 이후 10프레임마다 출력
+      else if (frame_count % 10 == 0) {
+        std::cout << "Render frame " << frame_count << " - poses: " << camera_poses_.size()
+                  << std::endl;
+      }
+
+      // 화면 클리어
+      glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+      // 카메라 뷰 활성화
+      if (g_d_cam_ && g_s_cam_) {
+        g_d_cam_->Activate(*g_s_cam_);
+      } else {
+        std::cerr << "Warning: Camera view not available at frame " << frame_count << std::endl;
+      }
+
+      // 좌표축 그리기
+      drawCoordinateFrame();
+
+      // 그리드 그리기
+      drawGrid();
+
+      // 궤적 그리기
+      drawCameraTrajectory();
+
+      // 3D 맵포인트 그리기
+      drawFeaturePoints3D();
+
+      // 프레임 완료
+      pangolin::FinishFrame();
+
+      // 프레임 레이트 제어
+      std::this_thread::sleep_for(std::chrono::milliseconds(33));
+    }
+
+    std::cout << "=== Visualizer render loop ended ===" << std::endl;
+    std::cout << "Final frame count: " << frame_count << std::endl;
+    std::cout << "Final pose count: " << camera_poses_.size() << std::endl;
+    std::cout << "Exit reason - running_: " << (running_ ? "true" : "false") << std::endl;
+    std::cout << "Exit reason - ShouldQuit(): " << (pangolin::ShouldQuit() ? "true" : "false")
+              << std::endl;
+
+  } catch (const std::exception& e) {
+    std::cerr << "Visualizer render error: " << e.what() << std::endl;
+  }
 }
 
 void Visualizer::drawCoordinateFrame() {
-    static int frame_count = 0;
-    frame_count++;
-    
-    // 처음 5프레임만 로그 출력
-    if (frame_count <= 5) {
-        std::cout << "Drawing coordinate frame - frame " << frame_count << std::endl;
-    }
-    
-    // Draw coordinate frame at origin
-    glLineWidth(3.0f);
-    
-    // X axis - red
-    glColor3f(1.0f, 0.0f, 0.0f);
-    glBegin(GL_LINES);
-    glVertex3f(0.0f, 0.0f, 0.0f);
-    glVertex3f(0.3f, 0.0f, 0.0f);
-    glEnd();
-    
-    // Y axis - green
-    glColor3f(0.0f, 1.0f, 0.0f);
-    glBegin(GL_LINES);
-    glVertex3f(0.0f, 0.0f, 0.0f);
-    glVertex3f(0.0f, 0.3f, 0.0f);
-    glEnd();
-    
-    // Z axis - blue
-    glColor3f(0.0f, 0.0f, 1.0f);
-    glBegin(GL_LINES);
-    glVertex3f(0.0f, 0.0f, 0.0f);
-    glVertex3f(0.0f, 0.0f, 0.3f);
-    glEnd();
-    
-    if (frame_count <= 5) {
-        std::cout << "Coordinate frame drawn successfully" << std::endl;
-    }
+  static int frame_count = 0;
+  frame_count++;
+
+  // 처음 5프레임만 로그 출력
+  if (frame_count <= 5) {
+    std::cout << "Drawing coordinate frame - frame " << frame_count << std::endl;
+  }
+
+  // Draw coordinate frame at origin
+  glLineWidth(3.0f);
+
+  // X axis - red
+  glColor3f(1.0f, 0.0f, 0.0f);
+  glBegin(GL_LINES);
+  glVertex3f(0.0f, 0.0f, 0.0f);
+  glVertex3f(0.3f, 0.0f, 0.0f);
+  glEnd();
+
+  // Y axis - green
+  glColor3f(0.0f, 1.0f, 0.0f);
+  glBegin(GL_LINES);
+  glVertex3f(0.0f, 0.0f, 0.0f);
+  glVertex3f(0.0f, 0.3f, 0.0f);
+  glEnd();
+
+  // Z axis - blue
+  glColor3f(0.0f, 0.0f, 1.0f);
+  glBegin(GL_LINES);
+  glVertex3f(0.0f, 0.0f, 0.0f);
+  glVertex3f(0.0f, 0.0f, 0.3f);
+  glEnd();
+
+  if (frame_count <= 5) {
+    std::cout << "Coordinate frame drawn successfully" << std::endl;
+  }
 }
 
 void Visualizer::drawGrid() {
-    // Draw XY plane grid
-    glColor3f(0.3f, 0.3f, 0.3f); // Light gray color for grid
-    glLineWidth(1.0f);
-    
-    const float grid_size = 10.0f;  // Grid extends from -5 to +5 in both X and Y
-    const float grid_step = 0.5f;   // Grid spacing
-    const int num_lines = (int)(grid_size / grid_step) + 1;
-    
-    glBegin(GL_LINES);
-    // Draw vertical lines (parallel to Y axis)
-    for (int i = 0; i < num_lines; i++) {
-        float x = -grid_size/2 + i * grid_step;
-        glVertex3f(x, -grid_size/2, 0.0f);
-        glVertex3f(x, grid_size/2, 0.0f);
-    }
-    // Draw horizontal lines (parallel to X axis) 
-    for (int i = 0; i < num_lines; i++) {
-        float y = -grid_size/2 + i * grid_step;
-        glVertex3f(-grid_size/2, y, 0.0f);
-        glVertex3f(grid_size/2, y, 0.0f);
-    }
-    glEnd();
+  // Draw XY plane grid
+  glColor3f(0.3f, 0.3f, 0.3f);  // Light gray color for grid
+  glLineWidth(1.0f);
+
+  const float grid_size = 10.0f;  // Grid extends from -5 to +5 in both X and Y
+  const float grid_step = 0.5f;   // Grid spacing
+  const int num_lines = (int)(grid_size / grid_step) + 1;
+
+  glBegin(GL_LINES);
+  // Draw vertical lines (parallel to Y axis)
+  for (int i = 0; i < num_lines; i++) {
+    float x = -grid_size / 2 + i * grid_step;
+    glVertex3f(x, -grid_size / 2, 0.0f);
+    glVertex3f(x, grid_size / 2, 0.0f);
+  }
+  // Draw horizontal lines (parallel to X axis)
+  for (int i = 0; i < num_lines; i++) {
+    float y = -grid_size / 2 + i * grid_step;
+    glVertex3f(-grid_size / 2, y, 0.0f);
+    glVertex3f(grid_size / 2, y, 0.0f);
+  }
+  glEnd();
 }
 
 void Visualizer::drawCameraTrajectory() {
-    std::lock_guard<std::mutex> lock(pose_mutex_);
-    
+  std::lock_guard<std::mutex> lock(pose_mutex_);
+
+  static int draw_count = 0;
+  draw_count++;
+
+  if (camera_poses_.empty()) {
+    static int empty_count = 0;
+    if (++empty_count % 10 == 0) {
+      std::cout << "[drawCameraTrajectory] No poses available (count: " << empty_count << ")"
+                << std::endl;
+    }
+    return;
+  }
+
+  // 처음 5번만 자세한 로그 출력
+  if (draw_count <= 5) {
+    std::cout << "[drawCameraTrajectory] Drawing " << camera_poses_.size()
+              << " poses (count: " << draw_count << ")" << std::endl;
+    std::cout << "First pose: [" << camera_poses_[0].x() << ", " << camera_poses_[0].y() << ", "
+              << camera_poses_[0].z() << "]" << std::endl;
+    std::cout << "Last pose: [" << camera_poses_.back().x() << ", " << camera_poses_.back().y()
+              << ", " << camera_poses_.back().z() << "]" << std::endl;
+  }
+
+  // Draw camera trajectory
+  glColor3f(0.0f, 1.0f, 0.0f);  // Green color for trajectory
+  glLineWidth(2.0f);
+  glBegin(GL_LINE_STRIP);
+  for (const auto& pose : camera_poses_) {
+    if (pose.allFinite()) {
+      glVertex3f(pose.x(), pose.y(), pose.z());
+    }
+  }
+  glEnd();
+
+  // Draw camera positions
+  glPointSize(3.0f);
+  glColor3f(1.0f, 0.0f, 0.0f);  // Red color for camera positions
+  glBegin(GL_POINTS);
+  for (const auto& pose : camera_poses_) {
+    if (pose.allFinite()) {
+      glVertex3f(pose.x(), pose.y(), pose.z());
+    }
+  }
+  glEnd();
+
+  glFlush();
+  glFinish();
+
+  if (draw_count <= 5) {
+    std::cout << "Trajectory drawn successfully" << std::endl;
+  }
+
+  try {
+    // 디버깅: 궤적 그리기 시작
     static int draw_count = 0;
-    draw_count++;
-    
-    if (camera_poses_.empty()) {
-        static int empty_count = 0;
-        if (++empty_count % 10 == 0) {
-            std::cout << "[drawCameraTrajectory] No poses available (count: " << empty_count << ")" << std::endl;
-        }
-        return;
+    if (++draw_count % 100 == 0) {
+      std::cout << "drawCameraTrajectory: Drawing " << camera_poses_.size()
+                << " poses (count: " << draw_count << ")" << std::endl;
     }
-    
-    // 처음 5번만 자세한 로그 출력
-    if (draw_count <= 5) {
-        std::cout << "[drawCameraTrajectory] Drawing " << camera_poses_.size() << " poses (count: " << draw_count << ")" << std::endl;
-        std::cout << "First pose: [" << camera_poses_[0].x() << ", " << camera_poses_[0].y() << ", " << camera_poses_[0].z() << "]" << std::endl;
-        std::cout << "Last pose: [" << camera_poses_.back().x() << ", " << camera_poses_.back().y() << ", " << camera_poses_.back().z() << "]" << std::endl;
-    }
-    
+
     // Draw camera trajectory
     glColor3f(0.0f, 1.0f, 0.0f);  // Green color for trajectory
     glLineWidth(2.0f);
     glBegin(GL_LINE_STRIP);
     for (const auto& pose : camera_poses_) {
-        if (pose.allFinite()) {
-            glVertex3f(pose.x(), pose.y(), pose.z());
-        }
+      if (pose.allFinite()) {
+        glVertex3f(pose.x(), pose.y(), pose.z());
+      }
     }
     glEnd();
-    
+
     // Draw camera positions
     glPointSize(3.0f);
     glColor3f(1.0f, 0.0f, 0.0f);  // Red color for camera positions
     glBegin(GL_POINTS);
     for (const auto& pose : camera_poses_) {
-        if (pose.allFinite()) {
-            glVertex3f(pose.x(), pose.y(), pose.z());
-        }
+      if (pose.allFinite()) {
+        glVertex3f(pose.x(), pose.y(), pose.z());
+      }
     }
     glEnd();
-    
-    glFlush();
-    glFinish();
-    
-    if (draw_count <= 5) {
-        std::cout << "Trajectory drawn successfully" << std::endl;
-    }
-    
-    try {
-        // 디버깅: 궤적 그리기 시작
-        static int draw_count = 0;
-        if (++draw_count % 100 == 0) {
-            std::cout << "drawCameraTrajectory: Drawing " << camera_poses_.size() << " poses (count: " << draw_count << ")" << std::endl;
+
+    // Draw camera frustums (every 10th camera to avoid clutter)
+    if (camera_poses_.size() == camera_rotations_.size()) {
+      for (size_t i = 0; i < camera_poses_.size(); i += 10) {
+        if (camera_poses_[i].allFinite() && camera_rotations_[i].allFinite()) {
+          drawCameraFrustum(camera_poses_[i], camera_rotations_[i], 0.1);
         }
-        
-        // Draw camera trajectory
-        glColor3f(0.0f, 1.0f, 0.0f);  // Green color for trajectory
-        glLineWidth(2.0f);
-        glBegin(GL_LINE_STRIP);
-        for (const auto& pose : camera_poses_) {
-            if (pose.allFinite()) {
-                glVertex3f(pose.x(), pose.y(), pose.z());
-            }
+      }
+    }
+
+    // Draw current camera frame and frustum
+    if (!camera_poses_.empty() && !camera_rotations_.empty()) {
+      Eigen::Vector3d current_pos = camera_poses_.back();
+      Eigen::Matrix3d current_rot = camera_rotations_.back();
+
+      if (current_pos.allFinite() && current_rot.allFinite()) {
+        // Draw current camera frustum (larger and more visible)
+        glColor3f(1.0f, 1.0f, 0.0f);  // Bright yellow for current camera
+        glLineWidth(2.5f);
+        drawCameraFrustum(current_pos, current_rot, 0.15);
+
+        // Camera frame axes
+        double frame_size = 0.08;
+
+        // X axis - red
+        glColor3f(1.0f, 0.0f, 0.0f);
+        glLineWidth(3.0f);
+        glBegin(GL_LINES);
+        glVertex3f(current_pos.x(), current_pos.y(), current_pos.z());
+        Eigen::Vector3d x_end = current_pos + current_rot.col(0) * frame_size;
+        if (x_end.allFinite()) {
+          glVertex3f(x_end.x(), x_end.y(), x_end.z());
         }
         glEnd();
-        
-        // Draw camera positions
-        glPointSize(3.0f);
-        glColor3f(1.0f, 0.0f, 0.0f);  // Red color for camera positions
-        glBegin(GL_POINTS);
-        for (const auto& pose : camera_poses_) {
-            if (pose.allFinite()) {
-                glVertex3f(pose.x(), pose.y(), pose.z());
-            }
+
+        // Y axis - green
+        glColor3f(0.0f, 1.0f, 0.0f);
+        glBegin(GL_LINES);
+        glVertex3f(current_pos.x(), current_pos.y(), current_pos.z());
+        Eigen::Vector3d y_end = current_pos + current_rot.col(1) * frame_size;
+        if (y_end.allFinite()) {
+          glVertex3f(y_end.x(), y_end.y(), y_end.z());
         }
         glEnd();
-        
-        // Draw camera frustums (every 10th camera to avoid clutter)
-        if (camera_poses_.size() == camera_rotations_.size()) {
-            for (size_t i = 0; i < camera_poses_.size(); i += 10) {
-                if (camera_poses_[i].allFinite() && camera_rotations_[i].allFinite()) {
-                    drawCameraFrustum(camera_poses_[i], camera_rotations_[i], 0.1);
-                }
-            }
+
+        // Z axis - blue (camera forward direction)
+        glColor3f(0.0f, 0.0f, 1.0f);
+        glLineWidth(4.0f);
+        glBegin(GL_LINES);
+        glVertex3f(current_pos.x(), current_pos.y(), current_pos.z());
+        Eigen::Vector3d z_end = current_pos + current_rot.col(2) * frame_size;
+        if (z_end.allFinite()) {
+          glVertex3f(z_end.x(), z_end.y(), z_end.z());
         }
-        
-        // Draw current camera frame and frustum
-        if (!camera_poses_.empty() && !camera_rotations_.empty()) {
-            Eigen::Vector3d current_pos = camera_poses_.back();
-            Eigen::Matrix3d current_rot = camera_rotations_.back();
-            
-            if (current_pos.allFinite() && current_rot.allFinite()) {
-                // Draw current camera frustum (larger and more visible)
-                glColor3f(1.0f, 1.0f, 0.0f);  // Bright yellow for current camera
-                glLineWidth(2.5f);
-                drawCameraFrustum(current_pos, current_rot, 0.15);
-                
-                // Camera frame axes
-                double frame_size = 0.08;
-                
-                // X axis - red
-                glColor3f(1.0f, 0.0f, 0.0f);
-                glLineWidth(3.0f);
-                glBegin(GL_LINES);
-                glVertex3f(current_pos.x(), current_pos.y(), current_pos.z());
-                Eigen::Vector3d x_end = current_pos + current_rot.col(0) * frame_size;
-                if (x_end.allFinite()) {
-                    glVertex3f(x_end.x(), x_end.y(), x_end.z());
-                }
-                glEnd();
-                
-                // Y axis - green
-                glColor3f(0.0f, 1.0f, 0.0f);
-                glBegin(GL_LINES);
-                glVertex3f(current_pos.x(), current_pos.y(), current_pos.z());
-                Eigen::Vector3d y_end = current_pos + current_rot.col(1) * frame_size;
-                if (y_end.allFinite()) {
-                    glVertex3f(y_end.x(), y_end.y(), y_end.z());
-                }
-                glEnd();
-                
-                // Z axis - blue (camera forward direction)
-                glColor3f(0.0f, 0.0f, 1.0f);
-                glLineWidth(4.0f);
-                glBegin(GL_LINES);
-                glVertex3f(current_pos.x(), current_pos.y(), current_pos.z());
-                Eigen::Vector3d z_end = current_pos + current_rot.col(2) * frame_size;
-                if (z_end.allFinite()) {
-                    glVertex3f(z_end.x(), z_end.y(), z_end.z());
-                }
-                glEnd();
-            }
-        }
-    } catch (const std::exception& e) {
-        std::cerr << "Error drawing trajectory: " << e.what() << std::endl;
+        glEnd();
+      }
     }
+  } catch (const std::exception& e) {
+    std::cerr << "Error drawing trajectory: " << e.what() << std::endl;
+  }
 }
 
 void Visualizer::drawFeaturePoints3D() {
-    std::lock_guard<std::mutex> lock(points_mutex_);
-    
-    if (feature_points_3d_.empty()) return;
-    
-    glPointSize(2.0f);
-    glColor3f(0.0f, 0.8f, 1.0f);  // Cyan
-    glBegin(GL_POINTS);
-    for (const auto& pt : feature_points_3d_) {
-        if (pt.allFinite())
-            glVertex3f(pt.x(), pt.y(), pt.z());
-    }
-    glEnd();
+  std::lock_guard<std::mutex> lock(points_mutex_);
+
+  if (feature_points_3d_.empty()) return;
+
+  glPointSize(2.0f);
+  glColor3f(0.0f, 0.8f, 1.0f);  // Cyan
+  glBegin(GL_POINTS);
+  for (const auto& pt : feature_points_3d_) {
+    if (pt.allFinite()) glVertex3f(pt.x(), pt.y(), pt.z());
+  }
+  glEnd();
 }
 
-void Visualizer::updateCameraPose(const Eigen::Vector3d& position, const Eigen::Matrix3d& rotation, double timestamp) {
-    std::lock_guard<std::mutex> lock(pose_mutex_);
-    
-    // Validate input data
-    if (!position.allFinite() || !rotation.allFinite()) {
-        std::cerr << "Visualizer: Invalid pose data received!" << std::endl;
-        return;
-    }
-    
-    camera_poses_.push_back(position);
-    camera_rotations_.push_back(rotation);
-    trajectory_timestamps_.push_back(timestamp);
-    
-    // Log progress occasionally
-    static int log_counter = 0;
-    if (++log_counter % 10 == 0) {
-        std::cout << "Visualizer received pose " << camera_poses_.size() 
-                  << ": [" << position.x() << ", " << position.y() << ", " << position.z() 
-                  << "] timestamp: " << timestamp << std::endl;
-    }
+void Visualizer::updateCameraPose(const Eigen::Vector3d& position, const Eigen::Matrix3d& rotation,
+                                  double timestamp) {
+  std::lock_guard<std::mutex> lock(pose_mutex_);
+
+  // Validate input data
+  if (!position.allFinite() || !rotation.allFinite()) {
+    std::cerr << "Visualizer: Invalid pose data received!" << std::endl;
+    return;
+  }
+
+  camera_poses_.push_back(position);
+  camera_rotations_.push_back(rotation);
+  trajectory_timestamps_.push_back(timestamp);
+
+  // Log progress occasionally
+  static int log_counter = 0;
+  if (++log_counter % 10 == 0) {
+    std::cout << "Visualizer received pose " << camera_poses_.size() << ": [" << position.x()
+              << ", " << position.y() << ", " << position.z() << "] timestamp: " << timestamp
+              << std::endl;
+  }
 }
 
 void Visualizer::updateFeaturePoints3D(const std::vector<Eigen::Vector3d>& points) {
-    std::lock_guard<std::mutex> lock(points_mutex_);
-    
-    // Filter valid points
-    std::vector<Eigen::Vector3d> valid_points;
-    for (const auto& pt : points) {
-        if (pt.allFinite() && !std::isnan(pt.x()) && !std::isnan(pt.y()) && !std::isnan(pt.z())) {
-            valid_points.push_back(pt);
-        }
+  std::lock_guard<std::mutex> lock(points_mutex_);
+
+  // Filter valid points
+  std::vector<Eigen::Vector3d> valid_points;
+  for (const auto& pt : points) {
+    if (pt.allFinite() && !std::isnan(pt.x()) && !std::isnan(pt.y()) && !std::isnan(pt.z())) {
+      valid_points.push_back(pt);
     }
-    
-    feature_points_3d_ = valid_points;
-    
-    // Debug info (occasionally)
-    static int debug_counter = 0;
-    if (++debug_counter % 100 == 0) {
-        std::cout << "Updated 3D points: " << valid_points.size() << " valid out of " << points.size() << std::endl;
-    }
+  }
+
+  feature_points_3d_ = valid_points;
+
+  // Debug info (occasionally)
+  static int debug_counter = 0;
+  if (++debug_counter % 100 == 0) {
+    std::cout << "Updated 3D points: " << valid_points.size() << " valid out of " << points.size()
+              << std::endl;
+  }
 }
 
 void Visualizer::testWithSimpleData() {
-    std::cout << "=== Testing with simple trajectory ===" << std::endl;
-    
-    // Generate simple circular trajectory
-    for (int i = 0; i < 50; i++) {
-        double angle = i * 0.1;
-        Eigen::Vector3d pos(cos(angle), sin(angle), 0.1 * i);
-        Eigen::Matrix3d rot = Eigen::Matrix3d::Identity();
-        double timestamp = i * 0.1;
-        
-        updateCameraPose(pos, rot, timestamp);
-        
-        // Simple rendering test
-        if (i % 10 == 0) {
-            std::cout << "Test pose " << i << ": [" << pos.x() << ", " << pos.y() << ", " << pos.z() << "]" << std::endl;
-        }
+  std::cout << "=== Testing with simple trajectory ===" << std::endl;
+
+  // Generate simple circular trajectory
+  for (int i = 0; i < 50; i++) {
+    double angle = i * 0.1;
+    Eigen::Vector3d pos(cos(angle), sin(angle), 0.1 * i);
+    Eigen::Matrix3d rot = Eigen::Matrix3d::Identity();
+    double timestamp = i * 0.1;
+
+    updateCameraPose(pos, rot, timestamp);
+
+    // Simple rendering test
+    if (i % 10 == 0) {
+      std::cout << "Test pose " << i << ": [" << pos.x() << ", " << pos.y() << ", " << pos.z()
+                << "]" << std::endl;
     }
+  }
 }
 
 void Visualizer::waitUntilRenderReady() {
-    std::unique_lock<std::mutex> lk(render_ready_mutex_);
-    render_ready_cv_.wait(lk, [this]{ return render_ready_; });
+  std::unique_lock<std::mutex> lk(render_ready_mutex_);
+  render_ready_cv_.wait(lk, [this] { return render_ready_; });
 }
 
-void Visualizer::drawCameraFrustum(const Eigen::Vector3d& pos, const Eigen::Matrix3d& rot, double size) {
-    if (!pos.allFinite() || !rot.allFinite()) return;
-    
-    // Camera intrinsic parameters from config
-    double fx = g_config.camera.fx;
-    double fy = g_config.camera.fy;
-    double cx = g_config.camera.cx;
-    double cy = g_config.camera.cy;
-    double width = g_config.camera.col;
-    double height = g_config.camera.row;
-    
-    // Frustum depth
-    double near_plane = size * 0.1;
-    double far_plane = size;
-    
-    // Calculate corner rays in camera frame
-    Eigen::Vector3d corners[4];
-    corners[0] = Eigen::Vector3d((0 - cx) / fx, (0 - cy) / fy, 1.0);           // top-left
-    corners[1] = Eigen::Vector3d((width - cx) / fx, (0 - cy) / fy, 1.0);       // top-right
-    corners[2] = Eigen::Vector3d((width - cx) / fx, (height - cy) / fy, 1.0);  // bottom-right
-    corners[3] = Eigen::Vector3d((0 - cx) / fx, (height - cy) / fy, 1.0);      // bottom-left
-    
-    // Transform to world coordinates and scale
-    Eigen::Vector3d near_corners[4], far_corners[4];
-    for (int i = 0; i < 4; i++) {
-        corners[i].normalize();
-        near_corners[i] = pos + rot * (corners[i] * near_plane);
-        far_corners[i] = pos + rot * (corners[i] * far_plane);
-    }
-    
-    // Draw frustum lines
-    glColor3f(0.8f, 0.8f, 0.0f);  // Yellow color for frustum
-    glLineWidth(1.5f);
-    
-    // Draw lines from camera center to far corners
-    glBegin(GL_LINES);
-    for (int i = 0; i < 4; i++) {
-        glVertex3f(pos.x(), pos.y(), pos.z());
-        glVertex3f(far_corners[i].x(), far_corners[i].y(), far_corners[i].z());
-    }
-    glEnd();
-    
-    // Draw near plane rectangle
-    glBegin(GL_LINE_LOOP);
-    for (int i = 0; i < 4; i++) {
-        glVertex3f(near_corners[i].x(), near_corners[i].y(), near_corners[i].z());
-    }
-    glEnd();
-    
-    // Draw far plane rectangle
-    glBegin(GL_LINE_LOOP);
-    for (int i = 0; i < 4; i++) {
-        glVertex3f(far_corners[i].x(), far_corners[i].y(), far_corners[i].z());
-    }
-    glEnd();
-} 
+void Visualizer::drawCameraFrustum(const Eigen::Vector3d& pos, const Eigen::Matrix3d& rot,
+                                   double size) {
+  if (!pos.allFinite() || !rot.allFinite()) return;
+
+  // Camera intrinsic parameters from config
+  double fx = g_config.camera.fx;
+  double fy = g_config.camera.fy;
+  double cx = g_config.camera.cx;
+  double cy = g_config.camera.cy;
+  double width = g_config.camera.col;
+  double height = g_config.camera.row;
+
+  // Frustum depth
+  double near_plane = size * 0.1;
+  double far_plane = size;
+
+  // Calculate corner rays in camera frame
+  Eigen::Vector3d corners[4];
+  corners[0] = Eigen::Vector3d((0 - cx) / fx, (0 - cy) / fy, 1.0);           // top-left
+  corners[1] = Eigen::Vector3d((width - cx) / fx, (0 - cy) / fy, 1.0);       // top-right
+  corners[2] = Eigen::Vector3d((width - cx) / fx, (height - cy) / fy, 1.0);  // bottom-right
+  corners[3] = Eigen::Vector3d((0 - cx) / fx, (height - cy) / fy, 1.0);      // bottom-left
+
+  // Transform to world coordinates and scale
+  Eigen::Vector3d near_corners[4], far_corners[4];
+  for (int i = 0; i < 4; i++) {
+    corners[i].normalize();
+    near_corners[i] = pos + rot * (corners[i] * near_plane);
+    far_corners[i] = pos + rot * (corners[i] * far_plane);
+  }
+
+  // Draw frustum lines
+  glColor3f(0.8f, 0.8f, 0.0f);  // Yellow color for frustum
+  glLineWidth(1.5f);
+
+  // Draw lines from camera center to far corners
+  glBegin(GL_LINES);
+  for (int i = 0; i < 4; i++) {
+    glVertex3f(pos.x(), pos.y(), pos.z());
+    glVertex3f(far_corners[i].x(), far_corners[i].y(), far_corners[i].z());
+  }
+  glEnd();
+
+  // Draw near plane rectangle
+  glBegin(GL_LINE_LOOP);
+  for (int i = 0; i < 4; i++) {
+    glVertex3f(near_corners[i].x(), near_corners[i].y(), near_corners[i].z());
+  }
+  glEnd();
+
+  // Draw far plane rectangle
+  glBegin(GL_LINE_LOOP);
+  for (int i = 0; i < 4; i++) {
+    glVertex3f(far_corners[i].x(), far_corners[i].y(), far_corners[i].z());
+  }
+  glEnd();
+}


### PR DESCRIPTION
`clang-format` was installed and configured to enforce a consistent coding style across the C   codebase.

Key changes include:
*   A `.clang-format` configuration file was created, adopting Google style with 2-space indentation and a 100-character line limit.
*   `clang-format` was applied to all `.cpp` and `.h` files in the workspace.
*   The formatting process successfully handled filenames containing spaces.
*   Changes observed in files like `include/backend/estimator.h`, `include/backend/factor/imu_factor.h`, and `include/common/image_frame.h` include:
    *   Reordering of include directives for consistency.
    *   Standardization of indentation and spacing.
    *   Alignment of code elements for improved readability.

In total, 66 files were modified, resulting in significant line changes (9,958 additions, 11,317 deletions), indicating a comprehensive reformatting of the code to a consistent style.