### PR TITLE
Add namespace gpl to common/gpl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,11 @@ add_library(initializer
 )
 target_link_libraries(initializer ceres utility ${OpenCV_LIBS})
 
-add_library(gpl src/common/gpl/gpl.cc)
-target_link_libraries(gpl)
+add_library(gpl 
+    src/common/gpl/gpl.cc
+    src/common/gpl/EigenQuaternionParameterization.cc
+)
+target_link_libraries(gpl ceres)
 
 add_library(camera_models
     src/common/camera_models/CameraFactory.cc

--- a/include/backend/factor/pose_local_parameterization.h
+++ b/include/backend/factor/pose_local_parameterization.h
@@ -10,11 +10,13 @@
 namespace backend {
 namespace factor {
 
-class PoseLocalParameterization : public ceres::LocalParameterization {
-  virtual bool Plus(const double *x, const double *delta, double *x_plus_delta) const;
-  virtual bool ComputeJacobian(const double *x, double *jacobian) const;
-  virtual int GlobalSize() const { return 7; };
-  virtual int LocalSize() const { return 6; };
+class PoseLocalParameterization : public ceres::Manifold {
+  virtual bool Plus(const double *x, const double *delta, double *x_plus_delta) const override;
+  virtual bool PlusJacobian(const double *x, double *jacobian) const override;
+  virtual bool Minus(const double *y, const double *x, double *y_minus_x) const override;
+  virtual bool MinusJacobian(const double *x, double *jacobian) const override;
+  virtual int AmbientSize() const override { return 7; };
+  virtual int TangentSize() const override { return 6; };
 };
 
 }  // namespace factor

--- a/include/common/gpl/EigenQuaternionParameterization.h
+++ b/include/common/gpl/EigenQuaternionParameterization.h
@@ -1,19 +1,20 @@
 #ifndef EIGENQUATERNIONPARAMETERIZATION_H
 #define EIGENQUATERNIONPARAMETERIZATION_H
 
-#include "ceres/local_parameterization.h"
+#include "ceres/manifold.h"
 
 namespace common {
+namespace gpl {
 
-class EigenQuaternionParameterization : public ceres::LocalParameterization {
+class EigenQuaternionParameterization : public ceres::Manifold {
 public:
     virtual ~EigenQuaternionParameterization() {}
-    virtual bool Plus(const double* x, const double* delta, double* x_plus_delta) const;
-    virtual bool ComputeJacobian(const double* x, double* jacobian) const;
-    virtual int GlobalSize() const {
+    virtual bool Plus(const double* x, const double* delta, double* x_plus_delta) const override;
+    virtual bool PlusJacobian(const double* x, double* jacobian) const override;
+    virtual int AmbientSize() const override {
         return 4;
     }
-    virtual int LocalSize() const {
+    virtual int TangentSize() const override {
         return 3;
     }
 
@@ -30,6 +31,7 @@ void EigenQuaternionParameterization::EigenQuaternionProduct(const T z[4], const
     zw[3] = z[3] * w[3] - z[0] * w[0] - z[1] * w[1] - z[2] * w[2];
 }
 
+}  // namespace gpl
 }  // namespace common
 
 #endif

--- a/include/common/gpl/EigenUtils.h
+++ b/include/common/gpl/EigenUtils.h
@@ -3,10 +3,11 @@
 
 #include <eigen3/Eigen/Dense>
 
-#include "camodocal/gpl/gpl.h"
+#include "common/gpl/gpl.h"
 #include "ceres/rotation.h"
 
 namespace common {
+namespace gpl {
 
 // Returns the 3D cross product skew symmetric matrix of a given 3D vector
 template <typename T>
@@ -362,6 +363,7 @@ Eigen::Matrix<T, 4, 4> estimate3DRigidSimilarityTransform(
     return homogeneousTransform(sR, t);
 }
 
+}  // namespace gpl
 }  // namespace common
 
 #endif

--- a/include/common/gpl/gpl.h
+++ b/include/common/gpl/gpl.h
@@ -6,6 +6,7 @@
 #include <opencv2/core/core.hpp>
 
 namespace common {
+namespace gpl {
 
 template <class T>
 const T clamp(const T& v, const T& a, const T& b) {
@@ -86,6 +87,7 @@ void UTMtoLL(double utmNorthing, double utmEasting, const std::string& utmZone, 
 
 long int timestampDiff(uint64_t t1, uint64_t t2);
 
+}  // namespace gpl
 }  // namespace common
 
 #endif

--- a/src/backend/factor/pose_local_parameterization.cpp
+++ b/src/backend/factor/pose_local_parameterization.cpp
@@ -20,10 +20,42 @@ bool PoseLocalParameterization::Plus(const double *x, const double *delta,
 
   return true;
 }
-bool PoseLocalParameterization::ComputeJacobian(const double *x, double *jacobian) const {
+bool PoseLocalParameterization::PlusJacobian(const double *x, double *jacobian) const {
   Eigen::Map<Eigen::Matrix<double, 7, 6, Eigen::RowMajor>> j(jacobian);
   j.topRows<6>().setIdentity();
   j.bottomRows<1>().setZero();
+
+  return true;
+}
+
+bool PoseLocalParameterization::Minus(const double *y, const double *x, double *y_minus_x) const {
+  Eigen::Map<const Eigen::Vector3d> p_x(x);
+  Eigen::Map<const Eigen::Quaterniond> q_x(x + 3);
+  
+  Eigen::Map<const Eigen::Vector3d> p_y(y);
+  Eigen::Map<const Eigen::Quaterniond> q_y(y + 3);
+
+  Eigen::Map<Eigen::Vector3d> dp(y_minus_x);
+  Eigen::Map<Eigen::Vector3d> dq(y_minus_x + 3);
+
+  dp = p_y - p_x;
+  
+  Eigen::Quaterniond delta_q = q_x.inverse() * q_y;
+  dq = 2.0 * delta_q.vec();
+  if (delta_q.w() < 0) {
+    dq = -dq;
+  }
+
+  return true;
+}
+
+bool PoseLocalParameterization::MinusJacobian(const double *x, double *jacobian) const {
+  Eigen::Map<Eigen::Matrix<double, 6, 7, Eigen::RowMajor>> j(jacobian);
+  j.topLeftCorner<3, 3>().setIdentity();
+  j.topRightCorner<3, 4>().setZero();
+  j.bottomLeftCorner<3, 3>().setZero();
+  j.bottomRightCorner<3, 4>().setZero();
+  j.block<3, 3>(3, 3).setIdentity();
 
   return true;
 }

--- a/src/backend/optimizer.cpp
+++ b/src/backend/optimizer.cpp
@@ -41,13 +41,13 @@ void Optimizer::optimize(common::MarginalizationFlag marginalization_flag) {
 void Optimizer::setupOptimizationProblem(ceres::Problem& problem) {
     // Add pose and speed-bias parameter blocks for sliding window
     for (int i = 0; i < WINDOW_SIZE + 1; i++) {
-        ceres::LocalParameterization* local_parameterization = new backend::factor::PoseLocalParameterization();
+        ceres::Manifold* local_parameterization = new backend::factor::PoseLocalParameterization();
         problem.AddParameterBlock(para_Pose[i], SIZE_POSE, local_parameterization);  // R, P
         problem.AddParameterBlock(para_SpeedAndBiases[i], SIZE_SPEEDANDBIAS);        // V, Ba, Bg
     }
 
     // Add extrinsic parameter block
-    ceres::LocalParameterization* local_parameterization = new backend::factor::PoseLocalParameterization();
+    ceres::Manifold* local_parameterization = new backend::factor::PoseLocalParameterization();
     problem.AddParameterBlock(para_Ex_Pose, SIZE_POSE, local_parameterization);
     problem.SetParameterBlockConstant(para_Ex_Pose);
 

--- a/src/common/camera_models/CataCamera.cc
+++ b/src/common/camera_models/CataCamera.cc
@@ -1,4 +1,5 @@
 #include "common/camera_models/CataCamera.h"
+#include "common/gpl/gpl.h"
 
 #include <cmath>
 #include <cstdio>
@@ -314,13 +315,13 @@ void CataCamera::estimateIntrinsics(const cv::Size& boardSize,
                 P.at<double>(c, 0) = u;
                 P.at<double>(c, 1) = v;
                 P.at<double>(c, 2) = 0.5;
-                P.at<double>(c, 3) = -0.5 * (square(u) + square(v));
+                P.at<double>(c, 3) = -0.5 * (common::gpl::square(u) + common::gpl::square(v));
             }
 
             cv::Mat C;
             cv::SVD::solveZ(P, C);
 
-            double t = square(C.at<double>(0)) + square(C.at<double>(1)) + C.at<double>(2) * C.at<double>(3);
+            double t = common::gpl::square(C.at<double>(0)) + common::gpl::square(C.at<double>(1)) + C.at<double>(2) * C.at<double>(3);
             if (t < 0.0) {
                 continue;
             }

--- a/src/common/camera_models/EquidistantCamera.cc
+++ b/src/common/camera_models/EquidistantCamera.cc
@@ -1,4 +1,5 @@
 #include "common/camera_models/EquidistantCamera.h"
+#include "common/gpl/gpl.h"
 
 #include <cmath>
 #include <cstdio>
@@ -267,7 +268,7 @@ void EquidistantCamera::estimateIntrinsics(const cv::Size& boardSize,
                 circle.push_back(imagePoints.at(i).at(r * boardSize.width + c));
             }
 
-            fitCircle(circle, center[r](0), center[r](1), radius[r]);
+            common::gpl::fitCircle(circle, center[r](0), center[r](1), radius[r]);
         }
 
         for (int j = 0; j < boardSize.height; ++j) {
@@ -275,7 +276,7 @@ void EquidistantCamera::estimateIntrinsics(const cv::Size& boardSize,
                 // find distance between pair of vanishing points which
                 // correspond to intersection points of 2 circles
                 std::vector<cv::Point2d> ipts;
-                ipts = intersectCircles(center[j](0), center[j](1), radius[j], center[k](0), center[k](1), radius[k]);
+                ipts = common::gpl::intersectCircles(center[j](0), center[j](1), radius[j], center[k](0), center[k](1), radius[k]);
 
                 if (ipts.size() < 2) {
                     continue;

--- a/src/common/camera_models/ScaramuzzaCamera.cc
+++ b/src/common/camera_models/ScaramuzzaCamera.cc
@@ -1,4 +1,5 @@
 #include "common/camera_models/ScaramuzzaCamera.h"
+#include "common/gpl/gpl.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
@@ -242,12 +243,12 @@ void OCAMCamera::estimateIntrinsics(const cv::Size& boardSize,
         const double st1 = h(4);
         const double st2 = h(5);
 
-        const double AA = square(sr11 * sr12 + sr21 * sr22);
-        const double BB = square(sr11) + square(sr21);
-        const double CC = square(sr12) + square(sr22);
+        const double AA = common::gpl::square(sr11 * sr12 + sr21 * sr22);
+        const double BB = common::gpl::square(sr11) + common::gpl::square(sr21);
+        const double CC = common::gpl::square(sr12) + common::gpl::square(sr22);
 
-        const double sr32_squared_1 = (-(CC - BB) + sqrt(square(CC - BB) + 4.0 * AA)) / 2.0;
-        const double sr32_squared_2 = (-(CC - BB) - sqrt(square(CC - BB) + 4.0 * AA)) / 2.0;
+        const double sr32_squared_1 = (-(CC - BB) + sqrt(common::gpl::square(CC - BB) + 4.0 * AA)) / 2.0;
+        const double sr32_squared_2 = (-(CC - BB) - sqrt(common::gpl::square(CC - BB) + 4.0 * AA)) / 2.0;
 
         // printf("rst = %.12f\n", sr32_squared_1*sr32_squared_1 + (CC-BB)*sr32_squared_1 - AA);
 

--- a/src/common/gpl/EigenQuaternionParameterization.cc
+++ b/src/common/gpl/EigenQuaternionParameterization.cc
@@ -1,8 +1,9 @@
-#include "camodocal/gpl/EigenQuaternionParameterization.h"
+#include "common/gpl/EigenQuaternionParameterization.h"
 
 #include <cmath>
 
 namespace common {
+namespace gpl {
 
 bool EigenQuaternionParameterization::Plus(const double* x, const double* delta, double* x_plus_delta) const {
     const double norm_delta = sqrt(delta[0] * delta[0] + delta[1] * delta[1] + delta[2] * delta[2]);
@@ -22,7 +23,7 @@ bool EigenQuaternionParameterization::Plus(const double* x, const double* delta,
     return true;
 }
 
-bool EigenQuaternionParameterization::ComputeJacobian(const double* x, double* jacobian) const {
+bool EigenQuaternionParameterization::PlusJacobian(const double* x, double* jacobian) const {
     jacobian[0] = x[3];
     jacobian[1] = x[2];
     jacobian[2] = -x[1];  // NOLINT
@@ -38,4 +39,5 @@ bool EigenQuaternionParameterization::ComputeJacobian(const double* x, double* j
     return true;
 }
 
+}  // namespace gpl
 }  // namespace common

--- a/src/common/gpl/gpl.cc
+++ b/src/common/gpl/gpl.cc
@@ -42,6 +42,7 @@ const double WGS84_ECCSQ = 0.00669437999013;
 #endif
 
 namespace common {
+namespace gpl {
 
 double hypot3(double x, double y, double z) {
     return sqrt(square(x) + square(y) + square(z));
@@ -668,4 +669,5 @@ long int timestampDiff(uint64_t t1, uint64_t t2) {
     }
 }
 
+}  // namespace gpl
 }  // namespace common

--- a/src/frontend/initialization/initial_sfm.cpp
+++ b/src/frontend/initialization/initial_sfm.cpp
@@ -197,7 +197,7 @@ bool GlobalSFM::construct(int frame_num, Quaterniond* q, Vector3d* T, int l, con
 
     // full BA
     ceres::Problem problem;
-    ceres::LocalParameterization* local_parameterization = new ceres::QuaternionParameterization();
+    ceres::Manifold* local_parameterization = new ceres::QuaternionManifold();
     // cout << " begin full BA " << endl;
     for (int i = 0; i < frame_num; i++) {
         // double array for ceres

--- a/src/utility/measurement_processor.cpp
+++ b/src/utility/measurement_processor.cpp
@@ -204,7 +204,7 @@ ImageFeatureMsg MeasurementProcessor::extractImageFeatures(const ImageFileData& 
 
     if (g_config.feature_tracker.show_track) {
         cv::Mat tmp_img = show_img.rowRange(0, g_config.camera.row);
-        cv::cvtColor(show_img, tmp_img, CV_GRAY2RGB);
+        cv::cvtColor(show_img, tmp_img, cv::COLOR_GRAY2RGB);
 
         for (unsigned int j = 0; j < feature_tracker_->cur_pts.size(); j++) {
             double len = std::min(1.0, 1.0 * feature_tracker_->track_cnt[j] / g_config.feature_tracker.window_size);


### PR DESCRIPTION
Introduce `gpl` namespace for `common/gpl` code and update Ceres API usage.

The primary goal is to encapsulate `common/gpl` code within `namespace common { namespace gpl { ... } }`. This required updating include paths and function calls. Additionally, the project's dependency on Ceres was updated to version 2.2.0, necessitating changes from `ceres::LocalParameterization` to `ceres::Manifold` and `ceres::QuaternionParameterization` to `ceres::QuaternionManifold`, along with implementing new required methods.