### PR TITLE
Update header guards to match folder structure

### DIFF
--- a/include/backend/estimator.h
+++ b/include/backend/estimator.h
@@ -1,5 +1,5 @@
-#ifndef ESTIMATOR_H
-#define ESTIMATOR_H
+#ifndef BACKEND__ESTIMATOR_H
+#define BACKEND__ESTIMATOR_H
 
 #include <Eigen/Dense>
 #include <iostream>
@@ -78,4 +78,4 @@ private:
 
 }  // namespace backend
 
-#endif  // ESTIMATOR_H
+#endif  // BACKEND__ESTIMATOR_H

--- a/include/backend/factor/imu_factor.h
+++ b/include/backend/factor/imu_factor.h
@@ -1,5 +1,5 @@
-#ifndef IMU_FACTOR_H
-#define IMU_FACTOR_H
+#ifndef BACKEND__FACTOR__IMU_FACTOR_H
+#define BACKEND__FACTOR__IMU_FACTOR_H
 
 #include <ceres/ceres.h>
 #include <eigen3/Eigen/Dense>
@@ -131,4 +131,4 @@ public:
 }  // namespace factor
 }  // namespace backend
 
-#endif  // IMU_FACTOR_H
+#endif  // BACKEND__FACTOR__IMU_FACTOR_H

--- a/include/backend/factor/integration_base.h
+++ b/include/backend/factor/integration_base.h
@@ -1,5 +1,5 @@
-#ifndef INTEGRATION_BASE_H
-#define INTEGRATION_BASE_H
+#ifndef BACKEND__FACTOR__INTEGRATION_BASE_H
+#define BACKEND__FACTOR__INTEGRATION_BASE_H
 
 #include <eigen3/Eigen/Dense>
 #include <iostream>
@@ -215,4 +215,4 @@ public:
 }  // namespace factor
 }  // namespace backend
 
-#endif  // INTEGRATION_BASE_H
+#endif  // BACKEND__FACTOR__INTEGRATION_BASE_H

--- a/include/backend/factor/marginalization_factor.h
+++ b/include/backend/factor/marginalization_factor.h
@@ -1,5 +1,5 @@
-#ifndef MARGINALIZATION_FACTOR_H
-#define MARGINALIZATION_FACTOR_H
+#ifndef BACKEND__FACTOR__MARGINALIZATION_FACTOR_H
+#define BACKEND__FACTOR__MARGINALIZATION_FACTOR_H
 
 #include <ceres/ceres.h>
 #include <pthread.h>
@@ -82,4 +82,4 @@ public:
 }  // namespace factor
 }  // namespace backend
 
-#endif
+#endif  // BACKEND__FACTOR__MARGINALIZATION_FACTOR_H

--- a/include/backend/factor/pose_local_parameterization.h
+++ b/include/backend/factor/pose_local_parameterization.h
@@ -1,5 +1,5 @@
-#ifndef POSE_LOCAL_PARAMETERIZATION_H
-#define POSE_LOCAL_PARAMETERIZATION_H
+#ifndef BACKEND__FACTOR__POSE_LOCAL_PARAMETERIZATION_H
+#define BACKEND__FACTOR__POSE_LOCAL_PARAMETERIZATION_H
 
 #include <ceres/ceres.h>
 #include <eigen3/Eigen/Dense>
@@ -23,4 +23,4 @@ class PoseLocalParameterization : public ceres::LocalParameterization {
 }  // namespace factor
 }  // namespace backend
 
-#endif
+#endif  // BACKEND__FACTOR__POSE_LOCAL_PARAMETERIZATION_H

--- a/include/backend/factor/projection_factor.h
+++ b/include/backend/factor/projection_factor.h
@@ -1,5 +1,5 @@
-#ifndef PROJECTION_FACTOR_H
-#define PROJECTION_FACTOR_H
+#ifndef BACKEND__FACTOR__PROJECTION_FACTOR_H
+#define BACKEND__FACTOR__PROJECTION_FACTOR_H
 
 #include <ceres/ceres.h>
 #include <Eigen/Dense>
@@ -24,4 +24,4 @@ public:
 }  // namespace factor
 }  // namespace backend
 
-#endif  // PROJECTION_FACTOR_H
+#endif  // BACKEND__FACTOR__PROJECTION_FACTOR_H

--- a/include/backend/optimizer.h
+++ b/include/backend/optimizer.h
@@ -1,5 +1,5 @@
-#ifndef OPTIMIZER_H
-#define OPTIMIZER_H
+#ifndef BACKEND__OPTIMIZER_H
+#define BACKEND__OPTIMIZER_H
 
 #include <ceres/ceres.h>
 #include <Eigen/Dense>
@@ -78,4 +78,4 @@ private:
 
 }  // namespace backend
 
-#endif  // OPTIMIZER_H
+#endif  // BACKEND__OPTIMIZER_H

--- a/include/backend/sliding_window.h
+++ b/include/backend/sliding_window.h
@@ -1,5 +1,5 @@
-#ifndef SLIDING_WINDOW_H
-#define SLIDING_WINDOW_H
+#ifndef BACKEND__SLIDING_WINDOW_H
+#define BACKEND__SLIDING_WINDOW_H
 
 #include <Eigen/Dense>
 
@@ -46,4 +46,4 @@ private:
 
 }  // namespace backend
 
-#endif
+#endif  // BACKEND__SLIDING_WINDOW_H

--- a/include/common/camera_models/Camera.h
+++ b/include/common/camera_models/Camera.h
@@ -1,5 +1,5 @@
-#ifndef CAMERA_H
-#define CAMERA_H
+#ifndef COMMON__CAMERA_MODELS__CAMERA_H
+#define COMMON__CAMERA_MODELS__CAMERA_H
 
 #include <boost/shared_ptr.hpp>
 #include <eigen3/Eigen/Dense>
@@ -124,4 +124,4 @@ typedef boost::shared_ptr<const Camera> CameraConstPtr;
 }  // namespace camera_models
 }  // namespace common
 
-#endif
+#endif  // COMMON__CAMERA_MODELS__CAMERA_H

--- a/include/common/camera_models/CameraFactory.h
+++ b/include/common/camera_models/CameraFactory.h
@@ -1,5 +1,5 @@
-#ifndef CAMERAFACTORY_H
-#define CAMERAFACTORY_H
+#ifndef COMMON__CAMERA_MODELS__CAMERA_FACTORY_H
+#define COMMON__CAMERA_MODELS__CAMERA_FACTORY_H
 
 #include <boost/shared_ptr.hpp>
 #include <opencv2/core/core.hpp>
@@ -27,4 +27,4 @@ private:
 }  // namespace camera_models
 }  // namespace common
 
-#endif
+#endif  // COMMON__CAMERA_MODELS__CAMERA_FACTORY_H

--- a/include/common/camera_models/CataCamera.h
+++ b/include/common/camera_models/CataCamera.h
@@ -1,5 +1,5 @@
-#ifndef CATACAMERA_H
-#define CATACAMERA_H
+#ifndef COMMON__CAMERA_MODELS__CATA_CAMERA_H
+#define COMMON__CAMERA_MODELS__CATA_CAMERA_H
 
 #include <opencv2/core/core.hpp>
 #include <string>
@@ -190,4 +190,4 @@ void CataCamera::spaceToPlane(const T* const params, const T* const q, const T* 
 }  // namespace camera_models
 }  // namespace common
 
-#endif
+#endif  // COMMON__CAMERA_MODELS__CATA_CAMERA_H

--- a/include/common/camera_models/CostFunctionFactory.h
+++ b/include/common/camera_models/CostFunctionFactory.h
@@ -1,5 +1,5 @@
-#ifndef COSTFUNCTIONFACTORY_H
-#define COSTFUNCTIONFACTORY_H
+#ifndef COMMON__CAMERA_MODELS__COST_FUNCTION_FACTORY_H
+#define COMMON__CAMERA_MODELS__COST_FUNCTION_FACTORY_H
 
 #include <boost/shared_ptr.hpp>
 #include <opencv2/core/core.hpp>
@@ -64,4 +64,4 @@ private:
 }  // namespace camera_models
 }  // namespace common
 
-#endif
+#endif  // COMMON__CAMERA_MODELS__COST_FUNCTION_FACTORY_H

--- a/include/common/camera_models/EquidistantCamera.h
+++ b/include/common/camera_models/EquidistantCamera.h
@@ -1,5 +1,5 @@
-#ifndef EQUIDISTANTCAMERA_H
-#define EQUIDISTANTCAMERA_H
+#ifndef COMMON__CAMERA_MODELS__EQUIDISTANT_CAMERA_H
+#define COMMON__CAMERA_MODELS__EQUIDISTANT_CAMERA_H
 
 #include <opencv2/core/core.hpp>
 #include <string>
@@ -188,4 +188,4 @@ void EquidistantCamera::spaceToPlane(const T* const params, const T* const q, co
 }  // namespace camera_models
 }  // namespace common
 
-#endif
+#endif  // COMMON__CAMERA_MODELS__EQUIDISTANT_CAMERA_H

--- a/include/common/camera_models/PinholeCamera.h
+++ b/include/common/camera_models/PinholeCamera.h
@@ -1,5 +1,5 @@
-#ifndef PINHOLECAMERA_H
-#define PINHOLECAMERA_H
+#ifndef COMMON__CAMERA_MODELS__PINHOLE_CAMERA_H
+#define COMMON__CAMERA_MODELS__PINHOLE_CAMERA_H
 
 #include <opencv2/core/core.hpp>
 #include <string>
@@ -177,4 +177,4 @@ void PinholeCamera::spaceToPlane(const T* const params, const T* const q, const 
 }  // namespace camera_models
 }  // namespace common
 
-#endif
+#endif  // COMMON__CAMERA_MODELS__PINHOLE_CAMERA_H

--- a/include/common/camera_models/ScaramuzzaCamera.h
+++ b/include/common/camera_models/ScaramuzzaCamera.h
@@ -1,5 +1,5 @@
-#ifndef SCARAMUZZACAMERA_H
-#define SCARAMUZZACAMERA_H
+#ifndef COMMON__CAMERA_MODELS__SCARAMUZZA_CAMERA_H
+#define COMMON__CAMERA_MODELS__SCARAMUZZA_CAMERA_H
 
 #include <opencv2/core/core.hpp>
 #include <string>
@@ -344,4 +344,4 @@ void OCAMCamera::SphereToPlane(const T* const params, const Eigen::Matrix<T, 3, 
 }  // namespace camera_models
 }  // namespace common
 
-#endif
+#endif  // COMMON__CAMERA_MODELS__SCARAMUZZA_CAMERA_H

--- a/include/common/common_types.h
+++ b/include/common/common_types.h
@@ -1,5 +1,5 @@
-#ifndef COMMON_TYPES_H
-#define COMMON_TYPES_H
+#ifndef COMMON__COMMON_TYPES_H
+#define COMMON__COMMON_TYPES_H
 
 namespace common {
 
@@ -8,4 +8,4 @@ enum MarginalizationFlag { MARGIN_OLD_KEYFRAME = 0, MARGIN_NEW_GENERAL_FRAME = 1
 
 } // namespace common
 
-#endif  // COMMON_TYPES_H
+#endif  // COMMON__COMMON_TYPES_H

--- a/include/common/frame.h
+++ b/include/common/frame.h
@@ -1,5 +1,5 @@
-#ifndef FRAME_H
-#define FRAME_H
+#ifndef COMMON__FRAME_H
+#define COMMON__FRAME_H
 
 #include <Eigen/Dense>
 
@@ -29,4 +29,4 @@ public:
 
 } // namespace common
 
-#endif
+#endif  // COMMON__FRAME_H

--- a/include/common/gpl/EigenQuaternionParameterization.h
+++ b/include/common/gpl/EigenQuaternionParameterization.h
@@ -1,5 +1,5 @@
-#ifndef EIGENQUATERNIONPARAMETERIZATION_H
-#define EIGENQUATERNIONPARAMETERIZATION_H
+#ifndef COMMON__GPL__EIGEN_QUATERNION_PARAMETERIZATION_H
+#define COMMON__GPL__EIGEN_QUATERNION_PARAMETERIZATION_H
 
 #include "ceres/local_parameterization.h"
 
@@ -34,4 +34,4 @@ void EigenQuaternionParameterization::EigenQuaternionProduct(const T z[4], const
 }  // namespace gpl
 }  // namespace common
 
-#endif
+#endif  // COMMON__GPL__EIGEN_QUATERNION_PARAMETERIZATION_H

--- a/include/common/gpl/EigenUtils.h
+++ b/include/common/gpl/EigenUtils.h
@@ -1,5 +1,5 @@
-#ifndef EIGENUTILS_H
-#define EIGENUTILS_H
+#ifndef COMMON__GPL__EIGEN_UTILS_H
+#define COMMON__GPL__EIGEN_UTILS_H
 
 #include <eigen3/Eigen/Dense>
 
@@ -366,4 +366,4 @@ Eigen::Matrix<T, 4, 4> estimate3DRigidSimilarityTransform(
 }  // namespace gpl
 }  // namespace common
 
-#endif
+#endif  // COMMON__GPL__EIGEN_UTILS_H

--- a/include/common/gpl/gpl.h
+++ b/include/common/gpl/gpl.h
@@ -1,5 +1,5 @@
-#ifndef GPL_H
-#define GPL_H
+#ifndef COMMON__GPL__GPL_H
+#define COMMON__GPL__GPL_H
 
 #include <algorithm>
 #include <cmath>
@@ -90,4 +90,4 @@ long int timestampDiff(uint64_t t1, uint64_t t2);
 }  // namespace gpl
 }  // namespace common
 
-#endif
+#endif  // COMMON__GPL__GPL_H

--- a/include/common/image_frame.h
+++ b/include/common/image_frame.h
@@ -1,5 +1,5 @@
-#ifndef IMAGE_FRAME_H
-#define IMAGE_FRAME_H
+#ifndef COMMON__IMAGE_FRAME_H
+#define COMMON__IMAGE_FRAME_H
 
 #include <eigen3/Eigen/Dense>
 #include <map>
@@ -137,4 +137,4 @@ public:
 
 } // namespace common
 
-#endif
+#endif  // COMMON__IMAGE_FRAME_H

--- a/include/frontend/failure_detector.h
+++ b/include/frontend/failure_detector.h
@@ -1,5 +1,5 @@
-#ifndef FAILURE_DETECTOR_H
-#define FAILURE_DETECTOR_H
+#ifndef FRONTEND__FAILURE_DETECTOR_H
+#define FRONTEND__FAILURE_DETECTOR_H
 
 #include <Eigen/Dense>
 #include <iostream>
@@ -60,4 +60,4 @@ private:
 
 }  // namespace frontend
 
-#endif  // FAILURE_DETECTOR_H
+#endif  // FRONTEND__FAILURE_DETECTOR_H

--- a/include/frontend/feature_manager.h
+++ b/include/frontend/feature_manager.h
@@ -1,5 +1,5 @@
-#ifndef FEATURE_MANAGER_H
-#define FEATURE_MANAGER_H
+#ifndef FRONTEND__FEATURE_MANAGER_H
+#define FRONTEND__FEATURE_MANAGER_H
 
 #include <algorithm>
 #include <eigen3/Eigen/Dense>
@@ -92,4 +92,4 @@ private:
 
 }  // namespace frontend
 
-#endif
+#endif  // FRONTEND__FEATURE_MANAGER_H

--- a/include/frontend/feature_tracker.h
+++ b/include/frontend/feature_tracker.h
@@ -1,5 +1,5 @@
-#ifndef FEATURE_TRACKER_H
-#define FEATURE_TRACKER_H
+#ifndef FRONTEND__FEATURE_TRACKER_H
+#define FRONTEND__FEATURE_TRACKER_H
 
 #include <execinfo.h>
 #include <csignal>
@@ -61,4 +61,4 @@ public:
 };
 
 }  // namespace frontend
-#endif  // FEATURE_TRACKER_H
+#endif  // FRONTEND__FEATURE_TRACKER_H

--- a/include/frontend/initialization/initial_alignment.h
+++ b/include/frontend/initialization/initial_alignment.h
@@ -1,5 +1,5 @@
-#ifndef INITIAL_ALIGNMENT_H
-#define INITIAL_ALIGNMENT_H
+#ifndef FRONTEND__INITIALIZATION__INITIAL_ALIGNMENT_H
+#define FRONTEND__INITIALIZATION__INITIAL_ALIGNMENT_H
 
 #include <eigen3/Eigen/Dense>
 #include <iostream>
@@ -23,4 +23,4 @@ bool VisualIMUAlignment(map<double, common::ImageFrame> const& all_image_frame, 
 }  // namespace initialization
 }  // namespace frontend
 
-#endif  // INITIAL_ALIGNMENT_H
+#endif  // FRONTEND__INITIALIZATION__INITIAL_ALIGNMENT_H

--- a/include/frontend/initialization/initial_sfm.h
+++ b/include/frontend/initialization/initial_sfm.h
@@ -1,5 +1,5 @@
-#ifndef INITIAL_SFM_H
-#define INITIAL_SFM_H
+#ifndef FRONTEND__INITIALIZATION__INITIAL_SFM_H
+#define FRONTEND__INITIALIZATION__INITIAL_SFM_H
 
 #include <ceres/ceres.h>
 #include <ceres/rotation.h>
@@ -71,4 +71,4 @@ private:
 }  // namespace initialization
 }  // namespace frontend
 
-#endif  // INITIAL_SFM_H
+#endif  // FRONTEND__INITIALIZATION__INITIAL_SFM_H

--- a/include/frontend/initialization/initializer.h
+++ b/include/frontend/initialization/initializer.h
@@ -1,5 +1,5 @@
-#ifndef INITIALIZER_H
-#define INITIALIZER_H
+#ifndef FRONTEND__INITIALIZATION__INITIALIZER_H
+#define FRONTEND__INITIALIZATION__INITIALIZER_H
 
 #include <Eigen/Dense>
 #include <map>
@@ -48,4 +48,4 @@ private:
 }  // namespace initialization
 }  // namespace frontend
 
-#endif  // INITIALIZER_H
+#endif  // FRONTEND__INITIALIZATION__INITIALIZER_H

--- a/include/frontend/initialization/solve_5pts.h
+++ b/include/frontend/initialization/solve_5pts.h
@@ -1,5 +1,5 @@
-#ifndef SOLVE_5PTS_H
-#define SOLVE_5PTS_H
+#ifndef FRONTEND__INITIALIZATION__SOLVE_5PTS_H
+#define FRONTEND__INITIALIZATION__SOLVE_5PTS_H
 
 #include <eigen3/Eigen/Dense>
 #include <opencv2/opencv.hpp>
@@ -26,4 +26,4 @@ private:
 }  // namespace initialization
 }  // namespace frontend
 
-#endif  // SOLVE_5PTS_H
+#endif  // FRONTEND__INITIALIZATION__SOLVE_5PTS_H

--- a/include/utility/config.h
+++ b/include/utility/config.h
@@ -1,5 +1,5 @@
-#ifndef CONFIG_H
-#define CONFIG_H
+#ifndef UTILITY__CONFIG_H
+#define UTILITY__CONFIG_H
 
 #include <Eigen/Dense>
 #include <opencv2/opencv.hpp>
@@ -87,4 +87,4 @@ extern Config g_config;
 
 }  // namespace utility
 
-#endif  // CONFIG_H
+#endif  // UTILITY__CONFIG_H

--- a/include/utility/measurement_processor.h
+++ b/include/utility/measurement_processor.h
@@ -1,5 +1,5 @@
-#ifndef MEASUREMENT_PROCESSOR_H
-#define MEASUREMENT_PROCESSOR_H
+#ifndef UTILITY__MEASUREMENT_PROCESSOR_H
+#define UTILITY__MEASUREMENT_PROCESSOR_H
 
 #include <array>
 #include <string>
@@ -94,4 +94,4 @@ private:
 
 }  // namespace utility
 
-#endif  // MEASUREMENT_PROCESSOR_H
+#endif  // UTILITY__MEASUREMENT_PROCESSOR_H

--- a/include/utility/test_result_logger.h
+++ b/include/utility/test_result_logger.h
@@ -1,5 +1,5 @@
-#ifndef TEST_RESULT_LOGGER_H
-#define TEST_RESULT_LOGGER_H
+#ifndef UTILITY__TEST_RESULT_LOGGER_H
+#define UTILITY__TEST_RESULT_LOGGER_H
 
 #include <Eigen/Dense>
 #include <chrono>
@@ -56,4 +56,4 @@ private:
 
 }  // namespace utility
 
-#endif  // TEST_RESULT_LOGGER_H
+#endif  // UTILITY__TEST_RESULT_LOGGER_H

--- a/include/utility/utility.h
+++ b/include/utility/utility.h
@@ -1,5 +1,5 @@
-#ifndef UTILITY_H
-#define UTILITY_H
+#ifndef UTILITY__UTILITY_H
+#define UTILITY__UTILITY_H
 
 #include <libgen.h>
 #include <stdio.h>
@@ -176,4 +176,4 @@ std::vector<std::string> getImageFilesFromDirectory(const std::string& directory
 // Backward compatibility: allow existing code to use Utility class directly
 using Utility = utility::Utility;
 
-#endif  // UTILITY_H
+#endif  // UTILITY__UTILITY_H

--- a/include/utility/visualizer.h
+++ b/include/utility/visualizer.h
@@ -1,5 +1,5 @@
-#ifndef VISUALIZER_H
-#define VISUALIZER_H
+#ifndef UTILITY__VISUALIZER_H
+#define UTILITY__VISUALIZER_H
 
 #include <pangolin/pangolin.h>
 
@@ -79,4 +79,4 @@ private:
 
 }  // namespace utility
 
-#endif  // VISUALIZER_H
+#endif  // UTILITY__VISUALIZER_H


### PR DESCRIPTION
Update header guards in all `include` folder header files to match their directory structure.